### PR TITLE
Fix LNURL access for inactive addresses

### DIFF
--- a/src/domains/lnurl/lnurl_service.rs
+++ b/src/domains/lnurl/lnurl_service.rs
@@ -69,6 +69,10 @@ impl LnUrlUseCases for LnUrlService {
             .await?
             .ok_or_else(|| DataError::NotFound("Lightning address not found.".to_string()))?;
 
+        if !ln_address.active {
+            return Err(DataError::NotFound("Lightning address not found.".to_string()).into());
+        }
+
         let lnurlp = LnURLPayRequest {
             callback: format!("{}/lnurlp/{}/callback", self.host, username),
             max_sendable: MAX_SENDABLE,
@@ -98,6 +102,10 @@ impl LnUrlUseCases for LnUrlService {
             .find_by_username(&username)
             .await?
             .ok_or_else(|| DataError::NotFound("Lightning address not found.".to_string()))?;
+
+        if !ln_address.active {
+            return Err(DataError::NotFound("Lightning address not found.".to_string()).into());
+        }
 
         let mut invoice = self
             .ln_client

--- a/src/domains/payment/payments_service.rs
+++ b/src/domains/payment/payments_service.rs
@@ -77,6 +77,10 @@ impl PaymentService {
         let address_opt = self.store.ln_address.find_by_username(username).await?;
         match address_opt {
             Some(retrieved_address) => {
+                if !retrieved_address.active {
+                    return Err(DataError::NotFound("Recipient not found.".to_string()).into());
+                }
+
                 if retrieved_address.wallet_id == wallet_id {
                     return Err(DataError::Validation("Cannot pay to yourself.".to_string()).into());
                 }


### PR DESCRIPTION
## Summary
- enforce that LNURL payment requests require an active Lightning Address
- disallow sending internal payments to inactive Lightning Addresses

## Testing
- `cargo check --quiet` *(fails: could not fetch `breez-sdk-core`)*