### PR TITLE
chore: remove unused Breez SDK dead code

### DIFF
--- a/src/application/errors/lightning_error.rs
+++ b/src/application/errors/lightning_error.rs
@@ -53,5 +53,4 @@ pub enum LightningError {
 
     #[error("Failed to retrieve healthcheck: {0}")]
     HealthCheck(String),
-
 }

--- a/src/infra/axum/axum_response.rs
+++ b/src/infra/axum/axum_response.rs
@@ -119,12 +119,7 @@ impl IntoResponse for DataError {
 impl IntoResponse for LightningError {
     fn into_response(self) -> Response {
         let (error_message, status) = match self {
-            LightningError::Pay(_)
-            | LightningError::Invoice(_)
-            | LightningError::ConnectLSP(_)
-            | LightningError::SignMessage(_)
-            | LightningError::CheckMessage(_)
-            | LightningError::RedeemOnChain(_) => {
+            LightningError::Pay(_) | LightningError::Invoice(_) => {
                 warn!("{}", self);
                 (self.to_string(), StatusCode::UNPROCESSABLE_ENTITY)
             }

--- a/src/infra/lightning/breez/breez_client.rs
+++ b/src/infra/lightning/breez/breez_client.rs
@@ -96,7 +96,6 @@ impl BreezClient {
 
         Ok((client_key, client_crt))
     }
-
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- Remove 10 unused methods from `BreezClient` (`node_info`, `lsp_info`, `list_lsps`, `close_lsp_channels`, `redeem_onchain`, `connect_lsp`, `sign_message`, `check_message`, `sync`, `backup`)
- Remove unused `working_dir` field from `BreezClient` struct
- Remove 10 corresponding unused `LightningError` variants (`LSPInfo`, `ListLSPs`, `CloseLSPChannels`, `RedeemOnChain`, `Unsupported`, `ConnectLSP`, `Sync`, `Backup`, `SignMessage`, `CheckMessage`)
- Clean up now-unused imports (`ToHex`, `tracing::info`, and several `breez_sdk_core` types)

This resolves all 3 compiler warnings in the project.

## Test plan
- [x] `cargo check` compiles with zero warnings