### PR TITLE
Breez Liquid: implement BitcoinWallet support and document provider limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ SwissKnife allows direct Lightning integration, supporting the most used node im
 - [`Core Lightning`](https://corelightning.org/):
   - Run your own node
   - Manage your own liquidity.
+- [`Breez SDK (Liquid)`](https://breez.technology):
+  - Nodeless integration via Breez Liquid SDK
+  - Lightning send/receive and Bitcoin swaps supported
+  - Note: direct Bitcoin address generation and raw PSBT flows are not exposed by this provider
 
 ## Installation
 
@@ -99,7 +103,7 @@ Extended documentation is available [here](https://docs.numeraire.tech/swissknif
 
 #### Lightning providers
 
-- [ ] [`Breez SDK (Liquid)`](https://phoenix.acinq.co/server)
+- [x] [`Breez SDK (Liquid)`](https://breez.technology)
   - Nodeless
 - [ ] [`Breez SDK (Spark)`](https://www.lightspark.com/)
   - Nodeless


### PR DESCRIPTION
### Motivation
- Provide a usable `BitcoinWallet` implementation for the Breez Liquid provider so SwissKnife can perform on-chain flows through Breez SDK where possible.
- Surface Breez-specific limitations (nodeless swap-based on-chain flows, no direct BTC address/PSBT APIs) so callers and operators know what to expect.
- Persist configured network information from Breez config so the client reports the correct `BtcNetwork`.

### Description
- Implemented `BitcoinWallet` for `BreezClient` using Breez Liquid swap APIs by calling `prepare_pay_onchain` in `prepare_transaction` and `pay_onchain` in `sign_send_transaction` and serializing a small prepared payload in `psbt` for the prepared object.
- Added best-effort mapping from Breez Bitcoin payment entries into internal types in `get_transaction`, `synchronize`, and `get_output` to emit deposit/withdrawal events and resolve outputs where possible.
- Marked `new_address` as unsupported for Breez with a clear `BitcoinError::Unsupported` message and made `release_prepared_transaction` a no-op due to lack of UTXO locking in the provider API.
- Persist the configured Bitcoin network on `BreezClient` and return it from `network()`, and updated `README.md` to list Breez Liquid as supported while documenting current limitations (no direct BTC address generation and no raw PSBT flows).

### Testing
- Ran `make fmt-fix` and formatting was applied successfully.
- Ran `make lint` and linter completed successfully (project compiled as part of linting).
- Attempted `cargo test` in the environment but the test run did not complete before the session was terminated, so full test suite results are currently unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f43a08edc832facb204fa30e1a43b)