### PR TITLE
fix: clean backend warning sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ deps-outdated:
 	@cargo outdated
 
 lint:
-	@cargo clippy --workspace --all-targets -- --no-deps
+	@cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
 fmt:
 	@cargo fmt --all -- --check

--- a/src/application/errors/bitcoin_error.rs
+++ b/src/application/errors/bitcoin_error.rs
@@ -32,7 +32,4 @@ pub enum BitcoinError {
 
     #[error("Failed to synchronize bitcoin transactions: {0}")]
     Synchronize(String),
-
-    #[error("Unsupported bitcoin operation: {0}")]
-    Unsupported(String),
 }

--- a/src/application/errors/lightning_error.rs
+++ b/src/application/errors/lightning_error.rs
@@ -18,9 +18,6 @@ pub enum LightningError {
     #[error("Failed to connect to Lightning node websocket server: {0}")]
     ConnectWebsocket(String),
 
-    #[error("Failed to disconnect from Lightning node: {0}")]
-    Disconnect(String),
-
     #[error("Lightning event listener failure: {0}")]
     Listener(String),
 

--- a/src/domains/lnurl/entities/lnurl.rs
+++ b/src/domains/lnurl/entities/lnurl.rs
@@ -46,21 +46,10 @@ pub struct LnUrlPayRequestData {
     pub min_sendable: u64,
     pub max_sendable: u64,
     pub metadata: String,
-    pub tag: String,
     #[serde(default)]
     pub comment_allowed: u16,
     #[serde(default)]
     pub ln_address: Option<String>,
-}
-
-impl LnUrlPayRequestData {
-    pub fn min_sendable_sats(&self) -> u64 {
-        self.min_sendable / 1000
-    }
-
-    pub fn max_sendable_sats(&self) -> u64 {
-        self.max_sendable / 1000
-    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -68,10 +57,6 @@ impl LnUrlPayRequestData {
 pub struct LnUrlPayCallbackResponse {
     pub pr: String,
     pub success_action: Option<LnUrlPaySuccessAction>,
-    #[serde(default)]
-    pub disposable: Option<bool>,
-    #[serde(default)]
-    pub routes: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/domains/lnurl/utils.rs
+++ b/src/domains/lnurl/utils.rs
@@ -39,8 +39,6 @@ pub async fn validate_lnurl_pay(
     Ok(LnUrlPayCallbackResponse {
         pr: callback_resp.pr,
         success_action,
-        disposable: None,
-        routes: None,
     })
 }
 

--- a/src/domains/nostr/nostr_service.rs
+++ b/src/domains/nostr/nostr_service.rs
@@ -31,9 +31,9 @@ impl NostrUseCases for NostrService {
             .await?
             .ok_or_else(|| DataError::NotFound("Nostr ID not found.".to_string()))?;
 
-        if ln_address.allows_nostr && ln_address.nostr_pubkey.is_some() {
+        if let (true, Some(nostr_pubkey)) = (ln_address.allows_nostr, ln_address.nostr_pubkey) {
             debug!(username, "Nostr identifier fetched successfully");
-            Ok(ln_address.nostr_pubkey.unwrap())
+            Ok(nostr_pubkey)
         } else {
             debug!(username, "Nostr identifier not enabled");
             Err(DataError::NotFound("Nostr ID not found.".to_string()).into())

--- a/src/domains/payment/payment_input.rs
+++ b/src/domains/payment/payment_input.rs
@@ -167,11 +167,6 @@ fn parse_bitcoin_payment_input(input: &str) -> Result<PaymentInput, String> {
     bitcoin_address_data_from_unchecked(uri.address, amount_sat, message).map(PaymentInput::BitcoinAddress)
 }
 
-fn parse_bitcoin_address_value(address: &str) -> Result<BitcoinAddressData, String> {
-    let unchecked = Address::from_str(address).map_err(|err| err.to_string())?;
-    bitcoin_address_data_from_unchecked(unchecked, None, None)
-}
-
 fn bitcoin_address_data_from_unchecked(
     unchecked: Address<NetworkUnchecked>,
     amount_sat: Option<u64>,
@@ -261,7 +256,6 @@ fn lnurl_pay_request_data_from_response(
         min_sendable: pay.min_sendable,
         max_sendable: pay.max_sendable,
         metadata: pay.metadata,
-        tag: pay.tag.to_string(),
         comment_allowed,
         ln_address,
     })
@@ -310,8 +304,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_bitcoin_address_value_detects_network() {
-        let data = parse_bitcoin_address_value(MAINNET_ADDRESS).unwrap();
+    fn parse_bitcoin_address_input_detects_network() {
+        let PaymentInput::BitcoinAddress(data) = parse_bitcoin_payment_input(MAINNET_ADDRESS).unwrap() else {
+            panic!("expected bitcoin address payment input");
+        };
 
         assert_eq!(data.address, MAINNET_ADDRESS);
         assert_eq!(data.network, BtcNetwork::Bitcoin);


### PR DESCRIPTION
## Summary

- Remove warning-producing error variants that were only used by the removed Breez Liquid client.
- Trim unused internal LNURL pay DTO fields and helper methods introduced during the Breez SDK replacement path.
- Exercise Bitcoin address parsing through the production parser path instead of a test-only helper.
- Replace the Nostr `is_some()` plus `unwrap()` branch with pattern matching.
- Make `make lint` warning-strict with `cargo clippy --workspace --all-targets --no-deps -- -D warnings`.

## Investigation

The current warnings were reproduced from `main` with `make build`, `make test`, and `make lint`.

- `BitcoinError::Unsupported` and `LightningError::Disconnect` were used by the removed Breez Liquid client before PR #224 and had no remaining callers.
- `LnUrlPayRequestData::tag`, `min_sendable_sats`, and `max_sendable_sats` were internal replacement-path fields/helpers introduced by PR #224 and are not needed by the LNURL payment flow.
- `LnUrlPayCallbackResponse::{disposable,routes}` were internal outgoing-payment callback fields that were always set to `None` and never read. The public LNURL callback response still keeps its used `disposable` and `routes` fields.
- `parse_bitcoin_address_value` was only a test helper after the unit-test baseline; the test now exercises `parse_bitcoin_payment_input` directly.
- The Nostr warning was a real Clippy style issue, fixed without changing behavior.

Closes #230.

## Validation

- `make fmt`
- `make lint`
- `make build`
- `make test`
- `make check`
- `git diff --check`
- Verified validation logs contain no `warning:` diagnostics