### PR TITLE
refactor: remove transaction handles from repository ports

### DIFF
--- a/docs/adr/0001-appstore-uow-wallet-reservations.md
+++ b/docs/adr/0001-appstore-uow-wallet-reservations.md
@@ -188,7 +188,7 @@ pub trait WalletRepository: Send + Sync {
 }
 ```
 
-SeaORM implementations may share helpers generic over `sea_orm::ConnectionTrait` so normal repositories can call helpers with `&DatabaseConnection` and Unit-of-Work implementations can call the same helpers with `&DatabaseTransaction`. That generic helper detail stays in infra.
+SeaORM repositories should be generic over the concrete connection handle they are constructed with. Production store wiring constructs them with `DatabaseConnection`; Unit-of-Work implementations construct the same repositories with `&DatabaseTransaction` and call the normal repository trait methods. Any generic connection adapter stays in infra.
 
 ### 4. Use focused Unit-of-Work ports with named atomic operations
 

--- a/docs/adr/0001-appstore-uow-wallet-reservations.md
+++ b/docs/adr/0001-appstore-uow-wallet-reservations.md
@@ -40,7 +40,7 @@ It also violates the intended dependency direction. `application/entities/store.
 
 ### Transactions leak into repository ports
 
-`PaymentRepository::insert` and `WalletRepository::get_balance` currently accept `Option<&DatabaseTransaction>`. That imports SeaORM into domain/application-facing repository traits.
+Before #238, `PaymentRepository::insert` and `WalletRepository::get_balance` accepted `Option<&DatabaseTransaction>`. That imported SeaORM into domain/application-facing repository traits.
 
 Repository ports should describe data capabilities, not concrete transaction handles. Transaction mechanics should be hidden behind application-level Unit-of-Work ports implemented by infrastructure.
 

--- a/src/domains/payment/payment_repository.rs
+++ b/src/domains/payment/payment_repository.rs
@@ -11,7 +11,6 @@ pub trait PaymentRepository: Send + Sync {
     async fn find(&self, id: Uuid) -> Result<Option<Payment>, DatabaseError>;
     async fn find_by_payment_hash(&self, payment_hash: &str) -> Result<Option<Payment>, DatabaseError>;
     async fn find_many(&self, filter: PaymentFilter) -> Result<Vec<Payment>, DatabaseError>;
-    #[allow(dead_code)]
     async fn insert(&self, payment: Payment) -> Result<Payment, DatabaseError>;
     async fn update(&self, payment: Payment) -> Result<Payment, DatabaseError>;
     async fn delete_many(&self, filter: PaymentFilter) -> Result<u64, DatabaseError>;

--- a/src/domains/payment/payment_repository.rs
+++ b/src/domains/payment/payment_repository.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use sea_orm::DatabaseTransaction;
 use uuid::Uuid;
 
 use crate::application::errors::DatabaseError;
@@ -12,11 +11,8 @@ pub trait PaymentRepository: Send + Sync {
     async fn find(&self, id: Uuid) -> Result<Option<Payment>, DatabaseError>;
     async fn find_by_payment_hash(&self, payment_hash: &str) -> Result<Option<Payment>, DatabaseError>;
     async fn find_many(&self, filter: PaymentFilter) -> Result<Vec<Payment>, DatabaseError>;
-    async fn insert<'a>(
-        &self,
-        txn: Option<&'a DatabaseTransaction>,
-        payment: Payment,
-    ) -> Result<Payment, DatabaseError>;
+    #[allow(dead_code)]
+    async fn insert(&self, payment: Payment) -> Result<Payment, DatabaseError>;
     async fn update(&self, payment: Payment) -> Result<Payment, DatabaseError>;
     async fn delete_many(&self, filter: PaymentFilter) -> Result<u64, DatabaseError>;
     async fn max_btc_block_height(&self) -> Result<Option<u32>, DatabaseError>;

--- a/src/domains/wallet/wallet_repository.rs
+++ b/src/domains/wallet/wallet_repository.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use sea_orm::DatabaseTransaction;
 use uuid::Uuid;
 
 use crate::application::errors::DatabaseError;
@@ -14,7 +13,7 @@ pub trait WalletRepository: Send + Sync {
     async fn find_many(&self, filter: WalletFilter) -> Result<Vec<Wallet>, DatabaseError>;
     async fn find_many_overview(&self) -> Result<Vec<WalletOverview>, DatabaseError>;
     async fn insert(&self, user_id: &str) -> Result<Wallet, DatabaseError>;
-    async fn get_balance<'a>(&self, txn: Option<&'a DatabaseTransaction>, id: Uuid) -> Result<Balance, DatabaseError>;
+    async fn get_balance(&self, id: Uuid) -> Result<Balance, DatabaseError>;
     async fn find_contacts(&self, id: Uuid) -> Result<Vec<Contact>, DatabaseError>;
     async fn delete_many(&self, filter: WalletFilter) -> Result<u64, DatabaseError>;
 }

--- a/src/domains/wallet/wallet_service.rs
+++ b/src/domains/wallet/wallet_service.rs
@@ -83,7 +83,7 @@ impl WalletUseCases for WalletService {
     async fn get_balance(&self, id: Uuid) -> Result<Balance, ApplicationError> {
         trace!(%id, "Fetching balance");
 
-        let balance = self.store.wallet.get_balance(None, id).await?;
+        let balance = self.store.wallet.get_balance(id).await?;
 
         debug!(%id, "Balance fetched successfully");
         Ok(balance)

--- a/src/infra/database/sea_orm/repositories/connection.rs
+++ b/src/infra/database/sea_orm/repositories/connection.rs
@@ -1,0 +1,23 @@
+use sea_orm::{ConnectionTrait, DatabaseConnection, DatabaseTransaction};
+
+pub(crate) trait SeaOrmConnection: Send + Sync {
+    type Connection: ConnectionTrait;
+
+    fn connection(&self) -> &Self::Connection;
+}
+
+impl SeaOrmConnection for DatabaseConnection {
+    type Connection = DatabaseConnection;
+
+    fn connection(&self) -> &Self::Connection {
+        self
+    }
+}
+
+impl SeaOrmConnection for &DatabaseTransaction {
+    type Connection = DatabaseTransaction;
+
+    fn connection(&self) -> &Self::Connection {
+        self
+    }
+}

--- a/src/infra/database/sea_orm/repositories/mod.rs
+++ b/src/infra/database/sea_orm/repositories/mod.rs
@@ -1,3 +1,4 @@
+mod connection;
 mod sea_orm_api_key_repository;
 mod sea_orm_btc_address_repository;
 mod sea_orm_btc_output_repository;
@@ -7,6 +8,7 @@ mod sea_orm_ln_address_repository;
 mod sea_orm_payment_repository;
 mod sea_orm_wallet_repository;
 
+pub(crate) use connection::SeaOrmConnection;
 pub use sea_orm_api_key_repository::*;
 pub use sea_orm_btc_address_repository::*;
 pub use sea_orm_btc_output_repository::*;

--- a/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, DatabaseConnection, DatabaseTransaction, EntityTrait,
-    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, Unchanged,
+    ActiveModelTrait, ActiveValue, ColumnTrait, DatabaseConnection, EntityTrait, FromQueryResult, QueryFilter,
+    QueryOrder, QuerySelect, QueryTrait, Set, Unchanged,
 };
 use uuid::Uuid;
+
+use super::SeaOrmConnection;
 
 use crate::{
     application::errors::DatabaseError,
@@ -16,27 +18,16 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct SeaOrmPaymentRepository {
-    pub db: DatabaseConnection,
+pub struct SeaOrmPaymentRepository<C = DatabaseConnection> {
+    db: C,
 }
 
-impl SeaOrmPaymentRepository {
-    pub fn new(db: DatabaseConnection) -> Self {
+impl<C> SeaOrmPaymentRepository<C> {
+    pub fn new(db: C) -> Self {
         Self { db }
     }
 
-    pub(crate) async fn insert_in_transaction(
-        &self,
-        txn: &DatabaseTransaction,
-        payment: Payment,
-    ) -> Result<Payment, DatabaseError> {
-        self.insert_with(txn, payment).await
-    }
-
-    async fn insert_with<C>(&self, connection: &C, payment: Payment) -> Result<Payment, DatabaseError>
-    where
-        C: ConnectionTrait,
-    {
+    fn active_model_for_insert(payment: Payment) -> ActiveModel {
         let (ln_address, payment_hash, payment_preimage, metadata, success_action) = payment
             .lightning
             .as_ref()
@@ -78,7 +69,7 @@ impl SeaOrmPaymentRepository {
             })
             .unwrap_or((None, None, None));
 
-        let model = ActiveModel {
+        ActiveModel {
             id: Set(Uuid::new_v4()),
             wallet_id: Set(payment.wallet_id),
             ln_address: Set(ln_address.or(internal_ln_address)),
@@ -96,22 +87,18 @@ impl SeaOrmPaymentRepository {
             payment_preimage: Set(payment_preimage),
             btc_block_height: Set(block_height.map(|h| h as i32)),
             ..Default::default()
-        };
-
-        let model = model
-            .insert(connection)
-            .await
-            .map_err(|e| DatabaseError::Insert(e.to_string()))?;
-
-        Ok(model.into())
+        }
     }
 }
 
 #[async_trait]
-impl PaymentRepository for SeaOrmPaymentRepository {
+impl<C> PaymentRepository for SeaOrmPaymentRepository<C>
+where
+    C: SeaOrmConnection,
+{
     async fn find(&self, id: Uuid) -> Result<Option<Payment>, DatabaseError> {
         let model = PaymentEntity::find_by_id(id)
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -121,7 +108,7 @@ impl PaymentRepository for SeaOrmPaymentRepository {
     async fn find_by_payment_hash(&self, payment_hash: &str) -> Result<Option<Payment>, DatabaseError> {
         let model = PaymentEntity::find()
             .filter(Column::PaymentHash.eq(payment_hash))
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -143,7 +130,7 @@ impl PaymentRepository for SeaOrmPaymentRepository {
             .order_by(Column::CreatedAt, filter.order_direction.into())
             .offset(filter.offset)
             .limit(filter.limit)
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -151,7 +138,12 @@ impl PaymentRepository for SeaOrmPaymentRepository {
     }
 
     async fn insert(&self, payment: Payment) -> Result<Payment, DatabaseError> {
-        self.insert_with(&self.db, payment).await
+        let model = Self::active_model_for_insert(payment)
+            .insert(self.db.connection())
+            .await
+            .map_err(|e| DatabaseError::Insert(e.to_string()))?;
+
+        Ok(model.into())
     }
 
     async fn update(&self, payment: Payment) -> Result<Payment, DatabaseError> {
@@ -225,7 +217,7 @@ impl PaymentRepository for SeaOrmPaymentRepository {
         };
 
         let model = model
-            .update(&self.db)
+            .update(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Update(e.to_string()))?;
 
@@ -243,7 +235,7 @@ impl PaymentRepository for SeaOrmPaymentRepository {
             .apply_if(filter.btc_addresses, |q, btc_addresses| {
                 q.filter(Column::BtcAddress.is_in(btc_addresses))
             })
-            .exec(&self.db)
+            .exec(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Delete(e.to_string()))?;
 
@@ -260,7 +252,7 @@ impl PaymentRepository for SeaOrmPaymentRepository {
             .select_only()
             .column_as(Column::BtcBlockHeight.max(), "max")
             .into_model::<MaxBlockHeight>()
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 

--- a/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
@@ -26,69 +26,6 @@ impl<C> SeaOrmPaymentRepository<C> {
     pub fn new(db: C) -> Self {
         Self { db }
     }
-
-    fn active_model_for_insert(payment: Payment) -> ActiveModel {
-        let (ln_address, payment_hash, payment_preimage, metadata, success_action) = payment
-            .lightning
-            .as_ref()
-            .map(|lightning| {
-                (
-                    lightning.ln_address.clone(),
-                    Some(lightning.payment_hash.clone()),
-                    lightning.payment_preimage.clone(),
-                    lightning.metadata.clone(),
-                    lightning
-                        .success_action
-                        .clone()
-                        .and_then(|action| serde_json::to_value(action).ok()),
-                )
-            })
-            .unwrap_or((None, None, None, None, None));
-
-        let (btc_address, btc_txid, block_height) = payment
-            .bitcoin
-            .as_ref()
-            .map(|bitcoin| {
-                (
-                    Some(bitcoin.address.clone()),
-                    Some(bitcoin.txid.clone()),
-                    bitcoin.block_height,
-                )
-            })
-            .unwrap_or((None, None, None));
-
-        let (internal_ln_address, internal_btc_address, internal_payment_hash) = payment
-            .internal
-            .as_ref()
-            .map(|internal| {
-                (
-                    internal.ln_address.clone(),
-                    internal.btc_address.clone(),
-                    internal.payment_hash.clone(),
-                )
-            })
-            .unwrap_or((None, None, None));
-
-        ActiveModel {
-            id: Set(Uuid::new_v4()),
-            wallet_id: Set(payment.wallet_id),
-            ln_address: Set(ln_address.or(internal_ln_address)),
-            btc_address: Set(btc_address.or(internal_btc_address)),
-            amount_msat: Set(payment.amount_msat as i64),
-            status: Set(payment.status.to_string()),
-            ledger: Set(payment.ledger.to_string()),
-            currency: Set(payment.currency.to_string()),
-            fee_msat: Set(payment.fee_msat.map(|v| v as i64)),
-            payment_time: Set(payment.payment_time.map(|t| t.naive_utc())),
-            payment_hash: Set(payment_hash.or(btc_txid).or(internal_payment_hash)),
-            description: Set(payment.description),
-            metadata: Set(metadata),
-            success_action: Set(success_action),
-            payment_preimage: Set(payment_preimage),
-            btc_block_height: Set(block_height.map(|h| h as i32)),
-            ..Default::default()
-        }
-    }
 }
 
 #[async_trait]
@@ -138,10 +75,69 @@ where
     }
 
     async fn insert(&self, payment: Payment) -> Result<Payment, DatabaseError> {
-        let model = Self::active_model_for_insert(payment)
-            .insert(self.db.connection())
-            .await
-            .map_err(|e| DatabaseError::Insert(e.to_string()))?;
+        let (ln_address, payment_hash, payment_preimage, metadata, success_action) = payment
+            .lightning
+            .as_ref()
+            .map(|lightning| {
+                (
+                    lightning.ln_address.clone(),
+                    Some(lightning.payment_hash.clone()),
+                    lightning.payment_preimage.clone(),
+                    lightning.metadata.clone(),
+                    lightning
+                        .success_action
+                        .clone()
+                        .and_then(|action| serde_json::to_value(action).ok()),
+                )
+            })
+            .unwrap_or((None, None, None, None, None));
+
+        let (btc_address, btc_txid, block_height) = payment
+            .bitcoin
+            .as_ref()
+            .map(|bitcoin| {
+                (
+                    Some(bitcoin.address.clone()),
+                    Some(bitcoin.txid.clone()),
+                    bitcoin.block_height,
+                )
+            })
+            .unwrap_or((None, None, None));
+
+        let (internal_ln_address, internal_btc_address, internal_payment_hash) = payment
+            .internal
+            .as_ref()
+            .map(|internal| {
+                (
+                    internal.ln_address.clone(),
+                    internal.btc_address.clone(),
+                    internal.payment_hash.clone(),
+                )
+            })
+            .unwrap_or((None, None, None));
+
+        let model = ActiveModel {
+            id: Set(Uuid::new_v4()),
+            wallet_id: Set(payment.wallet_id),
+            ln_address: Set(ln_address.or(internal_ln_address)),
+            btc_address: Set(btc_address.or(internal_btc_address)),
+            amount_msat: Set(payment.amount_msat as i64),
+            status: Set(payment.status.to_string()),
+            ledger: Set(payment.ledger.to_string()),
+            currency: Set(payment.currency.to_string()),
+            fee_msat: Set(payment.fee_msat.map(|v| v as i64)),
+            payment_time: Set(payment.payment_time.map(|t| t.naive_utc())),
+            payment_hash: Set(payment_hash.or(btc_txid).or(internal_payment_hash)),
+            description: Set(payment.description),
+            metadata: Set(metadata),
+            success_action: Set(success_action),
+            payment_preimage: Set(payment_preimage),
+            btc_block_height: Set(block_height.map(|h| h as i32)),
+            ..Default::default()
+        }
+        .insert(self.db.connection())
+        .await
+        .map_err(|e| DatabaseError::Insert(e.to_string()))?;
 
         Ok(model.into())
     }

--- a/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, DatabaseConnection, DatabaseTransaction, EntityTrait, FromQueryResult,
-    QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, Unchanged,
+    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, DatabaseConnection, DatabaseTransaction, EntityTrait,
+    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, Unchanged,
 };
 use uuid::Uuid;
 
@@ -24,56 +24,19 @@ impl SeaOrmPaymentRepository {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
-}
 
-#[async_trait]
-impl PaymentRepository for SeaOrmPaymentRepository {
-    async fn find(&self, id: Uuid) -> Result<Option<Payment>, DatabaseError> {
-        let model = PaymentEntity::find_by_id(id)
-            .one(&self.db)
-            .await
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
-
-        Ok(model.map(Into::into))
-    }
-
-    async fn find_by_payment_hash(&self, payment_hash: &str) -> Result<Option<Payment>, DatabaseError> {
-        let model = PaymentEntity::find()
-            .filter(Column::PaymentHash.eq(payment_hash))
-            .one(&self.db)
-            .await
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
-
-        Ok(model.map(Into::into))
-    }
-
-    async fn find_many(&self, filter: PaymentFilter) -> Result<Vec<Payment>, DatabaseError> {
-        let models = PaymentEntity::find()
-            .apply_if(filter.wallet_id, |q, wallet| q.filter(Column::WalletId.eq(wallet)))
-            .apply_if(filter.ids, |q, ids| q.filter(Column::Id.is_in(ids)))
-            .apply_if(filter.status, |q, s| q.filter(Column::Status.eq(s.to_string())))
-            .apply_if(filter.ledger, |q, l| q.filter(Column::Ledger.eq(l.to_string())))
-            .apply_if(filter.ln_addresses, |q, ln_addresses| {
-                q.filter(Column::LnAddress.is_in(ln_addresses))
-            })
-            .apply_if(filter.btc_addresses, |q, btc_addresses| {
-                q.filter(Column::BtcAddress.is_in(btc_addresses))
-            })
-            .order_by(Column::CreatedAt, filter.order_direction.into())
-            .offset(filter.offset)
-            .limit(filter.limit)
-            .all(&self.db)
-            .await
-            .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
-
-        Ok(models.into_iter().map(Into::into).collect())
-    }
-
-    async fn insert<'a>(
+    pub(crate) async fn insert_in_transaction(
         &self,
-        txn: Option<&'a DatabaseTransaction>,
+        txn: &DatabaseTransaction,
         payment: Payment,
     ) -> Result<Payment, DatabaseError> {
+        self.insert_with(txn, payment).await
+    }
+
+    async fn insert_with<C>(&self, connection: &C, payment: Payment) -> Result<Payment, DatabaseError>
+    where
+        C: ConnectionTrait,
+    {
         let (ln_address, payment_hash, payment_preimage, metadata, success_action) = payment
             .lightning
             .as_ref()
@@ -135,14 +98,60 @@ impl PaymentRepository for SeaOrmPaymentRepository {
             ..Default::default()
         };
 
-        let result = match txn {
-            Some(txn) => model.insert(txn).await,
-            None => model.insert(&self.db).await,
-        };
-
-        let model = result.map_err(|e| DatabaseError::Insert(e.to_string()))?;
+        let model = model
+            .insert(connection)
+            .await
+            .map_err(|e| DatabaseError::Insert(e.to_string()))?;
 
         Ok(model.into())
+    }
+}
+
+#[async_trait]
+impl PaymentRepository for SeaOrmPaymentRepository {
+    async fn find(&self, id: Uuid) -> Result<Option<Payment>, DatabaseError> {
+        let model = PaymentEntity::find_by_id(id)
+            .one(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
+
+        Ok(model.map(Into::into))
+    }
+
+    async fn find_by_payment_hash(&self, payment_hash: &str) -> Result<Option<Payment>, DatabaseError> {
+        let model = PaymentEntity::find()
+            .filter(Column::PaymentHash.eq(payment_hash))
+            .one(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
+
+        Ok(model.map(Into::into))
+    }
+
+    async fn find_many(&self, filter: PaymentFilter) -> Result<Vec<Payment>, DatabaseError> {
+        let models = PaymentEntity::find()
+            .apply_if(filter.wallet_id, |q, wallet| q.filter(Column::WalletId.eq(wallet)))
+            .apply_if(filter.ids, |q, ids| q.filter(Column::Id.is_in(ids)))
+            .apply_if(filter.status, |q, s| q.filter(Column::Status.eq(s.to_string())))
+            .apply_if(filter.ledger, |q, l| q.filter(Column::Ledger.eq(l.to_string())))
+            .apply_if(filter.ln_addresses, |q, ln_addresses| {
+                q.filter(Column::LnAddress.is_in(ln_addresses))
+            })
+            .apply_if(filter.btc_addresses, |q, btc_addresses| {
+                q.filter(Column::BtcAddress.is_in(btc_addresses))
+            })
+            .order_by(Column::CreatedAt, filter.order_direction.into())
+            .offset(filter.offset)
+            .limit(filter.limit)
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
+
+        Ok(models.into_iter().map(Into::into).collect())
+    }
+
+    async fn insert(&self, payment: Payment) -> Result<Payment, DatabaseError> {
+        self.insert_with(&self.db, payment).await
     }
 
     async fn update(&self, payment: Payment) -> Result<Payment, DatabaseError> {

--- a/src/infra/database/sea_orm/repositories/sea_orm_wallet_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_wallet_repository.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use sea_orm::{
-    sea_query::Expr, ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, DatabaseTransaction,
-    EntityTrait, ModelTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait,
+    sea_query::Expr, ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, DatabaseConnection,
+    DatabaseTransaction, EntityTrait, ModelTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait,
 };
 use uuid::Uuid;
 
@@ -29,6 +29,57 @@ impl SeaOrmWalletRepository {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
+
+    pub(crate) async fn get_balance_in_transaction(
+        &self,
+        txn: &DatabaseTransaction,
+        id: Uuid,
+    ) -> Result<Balance, DatabaseError> {
+        self.get_balance_with(txn, id).await
+    }
+
+    async fn get_balance_with<C>(&self, connection: &C, id: Uuid) -> Result<Balance, DatabaseError>
+    where
+        C: ConnectionTrait,
+    {
+        let received = Invoice::find()
+            .filter(InvoiceColumn::WalletId.eq(id))
+            .select_only()
+            .column_as(
+                Expr::cust("CAST(SUM(invoice.amount_received_msat) AS BIGINT)"),
+                "received_msat",
+            )
+            .into_tuple::<Option<i64>>()
+            .one(connection)
+            .await
+            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
+            .unwrap_or(None);
+
+        let (sent_msat, fees_paid_msat) = Payment::find()
+            .filter(PaymentColumn::WalletId.eq(id))
+            .filter(
+                PaymentColumn::Status.is_in([PaymentStatus::Settled.to_string(), PaymentStatus::Pending.to_string()]),
+            )
+            .select_only()
+            .column_as(Expr::cust("CAST(SUM(payment.amount_msat) AS BIGINT)"), "sent_msat")
+            .column_as(Expr::cust("CAST(SUM(payment.fee_msat) AS BIGINT)"), "fees_paid_msat")
+            .into_tuple::<(Option<i64>, Option<i64>)>()
+            .one(connection)
+            .await
+            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
+            .unwrap_or((None, None));
+
+        let received_msat_i64 = received.unwrap_or(0);
+        let sent_msat_i64 = sent_msat.unwrap_or(0);
+        let fees_paid_msat_i64 = fees_paid_msat.unwrap_or(0);
+
+        Ok(Balance {
+            received_msat: received_msat_i64 as u64,
+            sent_msat: sent_msat_i64 as u64,
+            fees_paid_msat: fees_paid_msat_i64 as u64,
+            available_msat: received_msat_i64 - (sent_msat_i64 + fees_paid_msat_i64),
+        })
+    }
 }
 
 #[async_trait]
@@ -41,7 +92,7 @@ impl WalletRepository for SeaOrmWalletRepository {
 
         match model_opt {
             Some(model) => {
-                let balance = self.get_balance(None, id).await?;
+                let balance = self.get_balance_with(&self.db, id).await?;
                 let payments_with_output = Payment::find()
                     .filter(PaymentColumn::WalletId.eq(id))
                     .all(&self.db)
@@ -219,49 +270,8 @@ impl WalletRepository for SeaOrmWalletRepository {
         Ok(model.into())
     }
 
-    async fn get_balance<'a>(&self, txn: Option<&'a DatabaseTransaction>, id: Uuid) -> Result<Balance, DatabaseError> {
-        let received = Invoice::find()
-            .filter(InvoiceColumn::WalletId.eq(id))
-            .select_only()
-            .column_as(
-                Expr::cust("CAST(SUM(invoice.amount_received_msat) AS BIGINT)"),
-                "received_msat",
-            )
-            .into_tuple::<Option<i64>>();
-
-        let sent = Payment::find()
-            .filter(PaymentColumn::WalletId.eq(id))
-            .filter(
-                PaymentColumn::Status.is_in([PaymentStatus::Settled.to_string(), PaymentStatus::Pending.to_string()]),
-            )
-            .select_only()
-            .column_as(Expr::cust("CAST(SUM(payment.amount_msat) AS BIGINT)"), "sent_msat")
-            .column_as(Expr::cust("CAST(SUM(payment.fee_msat) AS BIGINT)"), "fees_paid_msat")
-            .into_tuple::<(Option<i64>, Option<i64>)>();
-
-        let (received_res, sent_res) = match txn {
-            Some(txn) => (received.one(txn).await, sent.one(txn).await),
-            None => (received.one(&self.db).await, sent.one(&self.db).await),
-        };
-
-        let received = received_res
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
-            .unwrap_or(None);
-
-        let (sent_msat, fees_paid_msat) = sent_res
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
-            .unwrap_or((None, None));
-
-        let received_msat_i64 = received.unwrap_or(0);
-        let sent_msat_i64 = sent_msat.unwrap_or(0);
-        let fees_paid_msat_i64 = fees_paid_msat.unwrap_or(0);
-
-        Ok(Balance {
-            received_msat: received_msat_i64 as u64,
-            sent_msat: sent_msat_i64 as u64,
-            fees_paid_msat: fees_paid_msat_i64 as u64,
-            available_msat: received_msat_i64 - (sent_msat_i64 + fees_paid_msat_i64),
-        })
+    async fn get_balance(&self, id: Uuid) -> Result<Balance, DatabaseError> {
+        self.get_balance_with(&self.db, id).await
     }
 
     async fn find_contacts(&self, id: Uuid) -> Result<Vec<Contact>, DatabaseError> {

--- a/src/infra/database/sea_orm/repositories/sea_orm_wallet_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_wallet_repository.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
 use sea_orm::{
-    sea_query::Expr, ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, DatabaseConnection,
-    DatabaseTransaction, EntityTrait, ModelTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait,
+    sea_query::Expr, ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, ModelTrait,
+    QueryFilter, QueryOrder, QuerySelect, QueryTrait,
 };
 use uuid::Uuid;
+
+use super::SeaOrmConnection;
 
 use crate::{
     application::errors::DatabaseError,
@@ -21,92 +23,44 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct SeaOrmWalletRepository {
-    pub db: DatabaseConnection,
+pub struct SeaOrmWalletRepository<C = DatabaseConnection> {
+    db: C,
 }
 
-impl SeaOrmWalletRepository {
-    pub fn new(db: DatabaseConnection) -> Self {
+impl<C> SeaOrmWalletRepository<C> {
+    pub fn new(db: C) -> Self {
         Self { db }
-    }
-
-    pub(crate) async fn get_balance_in_transaction(
-        &self,
-        txn: &DatabaseTransaction,
-        id: Uuid,
-    ) -> Result<Balance, DatabaseError> {
-        self.get_balance_with(txn, id).await
-    }
-
-    async fn get_balance_with<C>(&self, connection: &C, id: Uuid) -> Result<Balance, DatabaseError>
-    where
-        C: ConnectionTrait,
-    {
-        let received = Invoice::find()
-            .filter(InvoiceColumn::WalletId.eq(id))
-            .select_only()
-            .column_as(
-                Expr::cust("CAST(SUM(invoice.amount_received_msat) AS BIGINT)"),
-                "received_msat",
-            )
-            .into_tuple::<Option<i64>>()
-            .one(connection)
-            .await
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
-            .unwrap_or(None);
-
-        let (sent_msat, fees_paid_msat) = Payment::find()
-            .filter(PaymentColumn::WalletId.eq(id))
-            .filter(
-                PaymentColumn::Status.is_in([PaymentStatus::Settled.to_string(), PaymentStatus::Pending.to_string()]),
-            )
-            .select_only()
-            .column_as(Expr::cust("CAST(SUM(payment.amount_msat) AS BIGINT)"), "sent_msat")
-            .column_as(Expr::cust("CAST(SUM(payment.fee_msat) AS BIGINT)"), "fees_paid_msat")
-            .into_tuple::<(Option<i64>, Option<i64>)>()
-            .one(connection)
-            .await
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
-            .unwrap_or((None, None));
-
-        let received_msat_i64 = received.unwrap_or(0);
-        let sent_msat_i64 = sent_msat.unwrap_or(0);
-        let fees_paid_msat_i64 = fees_paid_msat.unwrap_or(0);
-
-        Ok(Balance {
-            received_msat: received_msat_i64 as u64,
-            sent_msat: sent_msat_i64 as u64,
-            fees_paid_msat: fees_paid_msat_i64 as u64,
-            available_msat: received_msat_i64 - (sent_msat_i64 + fees_paid_msat_i64),
-        })
     }
 }
 
 #[async_trait]
-impl WalletRepository for SeaOrmWalletRepository {
+impl<C> WalletRepository for SeaOrmWalletRepository<C>
+where
+    C: SeaOrmConnection,
+{
     async fn find(&self, id: Uuid) -> Result<Option<Wallet>, DatabaseError> {
         let model_opt = WalletEntity::find_by_id(id)
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
         match model_opt {
             Some(model) => {
-                let balance = self.get_balance_with(&self.db, id).await?;
+                let balance = self.get_balance(id).await?;
                 let payments_with_output = Payment::find()
                     .filter(PaymentColumn::WalletId.eq(id))
-                    .all(&self.db)
+                    .all(self.db.connection())
                     .await
                     .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
                 let invoices_with_output = Invoice::find()
                     .filter(InvoiceColumn::WalletId.eq(id))
                     .find_also_related(BtcOutput)
-                    .all(&self.db)
+                    .all(self.db.connection())
                     .await
                     .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
                 let ln_address = model
                     .find_related(LnAddress)
-                    .one(&self.db)
+                    .one(self.db.connection())
                     .await
                     .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
                 let contacts = self.find_contacts(id).await?;
@@ -134,7 +88,7 @@ impl WalletRepository for SeaOrmWalletRepository {
     async fn find_by_user_id(&self, user_id: &str) -> Result<Option<Wallet>, DatabaseError> {
         let model = WalletEntity::find()
             .filter(Column::UserId.eq(user_id))
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -148,7 +102,7 @@ impl WalletRepository for SeaOrmWalletRepository {
             .order_by(Column::CreatedAt, filter.order_direction.into())
             .offset(filter.offset)
             .limit(filter.limit)
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -159,7 +113,7 @@ impl WalletRepository for SeaOrmWalletRepository {
         // Get all wallets with their ln_address (1-to-1 relation)
         let wallets_with_ln = WalletEntity::find()
             .find_also_related(LnAddress)
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -174,7 +128,7 @@ impl WalletRepository for SeaOrmWalletRepository {
             .column_as(InvoiceColumn::Id.count(), "n_invoices")
             .group_by(InvoiceColumn::WalletId)
             .into_tuple::<(Uuid, Option<i64>, i64)>()
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -205,7 +159,7 @@ impl WalletRepository for SeaOrmWalletRepository {
             .column_as(Expr::col(PaymentColumn::LnAddress).count_distinct(), "n_contacts")
             .group_by(PaymentColumn::WalletId)
             .into_tuple::<(Uuid, Option<i64>, Option<i64>, i64, i64)>()
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -263,7 +217,7 @@ impl WalletRepository for SeaOrmWalletRepository {
         };
 
         let model = model
-            .insert(&self.db)
+            .insert(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Insert(e.to_string()))?;
 
@@ -271,7 +225,43 @@ impl WalletRepository for SeaOrmWalletRepository {
     }
 
     async fn get_balance(&self, id: Uuid) -> Result<Balance, DatabaseError> {
-        self.get_balance_with(&self.db, id).await
+        let received = Invoice::find()
+            .filter(InvoiceColumn::WalletId.eq(id))
+            .select_only()
+            .column_as(
+                Expr::cust("CAST(SUM(invoice.amount_received_msat) AS BIGINT)"),
+                "received_msat",
+            )
+            .into_tuple::<Option<i64>>()
+            .one(self.db.connection())
+            .await
+            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
+            .unwrap_or(None);
+
+        let (sent_msat, fees_paid_msat) = Payment::find()
+            .filter(PaymentColumn::WalletId.eq(id))
+            .filter(
+                PaymentColumn::Status.is_in([PaymentStatus::Settled.to_string(), PaymentStatus::Pending.to_string()]),
+            )
+            .select_only()
+            .column_as(Expr::cust("CAST(SUM(payment.amount_msat) AS BIGINT)"), "sent_msat")
+            .column_as(Expr::cust("CAST(SUM(payment.fee_msat) AS BIGINT)"), "fees_paid_msat")
+            .into_tuple::<(Option<i64>, Option<i64>)>()
+            .one(self.db.connection())
+            .await
+            .map_err(|e| DatabaseError::FindOne(e.to_string()))?
+            .unwrap_or((None, None));
+
+        let received_msat_i64 = received.unwrap_or(0);
+        let sent_msat_i64 = sent_msat.unwrap_or(0);
+        let fees_paid_msat_i64 = fees_paid_msat.unwrap_or(0);
+
+        Ok(Balance {
+            received_msat: received_msat_i64 as u64,
+            sent_msat: sent_msat_i64 as u64,
+            fees_paid_msat: fees_paid_msat_i64 as u64,
+            available_msat: received_msat_i64 - (sent_msat_i64 + fees_paid_msat_i64),
+        })
     }
 
     async fn find_contacts(&self, id: Uuid) -> Result<Vec<Contact>, DatabaseError> {
@@ -285,7 +275,7 @@ impl WalletRepository for SeaOrmWalletRepository {
             .group_by(PaymentColumn::LnAddress)
             .order_by_asc(PaymentColumn::LnAddress)
             .into_model::<ContactModel>()
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -297,7 +287,7 @@ impl WalletRepository for SeaOrmWalletRepository {
         let result = WalletEntity::delete_many()
             .apply_if(filter.user_id, |q, user| q.filter(Column::UserId.eq(user)))
             .apply_if(filter.ids, |q, ids| q.filter(Column::Id.is_in(ids)))
-            .exec(&self.db)
+            .exec(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Delete(e.to_string()))?;
 

--- a/src/infra/database/sea_orm/store.rs
+++ b/src/infra/database/sea_orm/store.rs
@@ -118,24 +118,22 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
             .await
             .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
 
-        let pending_payment = {
-            let wallet_repo = SeaOrmWalletRepository::new(&txn);
-            let payment_repo = SeaOrmPaymentRepository::new(&txn);
+        let wallet_repo = SeaOrmWalletRepository::new(&txn);
+        let payment_repo = SeaOrmPaymentRepository::new(&txn);
 
-            let balance = wallet_repo.get_balance(payment.wallet_id).await?.available_msat as f64;
+        let balance = wallet_repo.get_balance(payment.wallet_id).await?.available_msat as f64;
 
-            let required_balance_msat = if let Some(fee_msat) = payment.fee_msat {
-                (payment.amount_msat.saturating_add(fee_msat)) as f64
-            } else {
-                payment.amount_msat as f64 * (1.0 + fee_buffer)
-            };
-
-            if balance < required_balance_msat {
-                return Err(DataError::InsufficientFunds(required_balance_msat).into());
-            }
-
-            payment_repo.insert(payment).await?
+        let required_balance_msat = if let Some(fee_msat) = payment.fee_msat {
+            (payment.amount_msat.saturating_add(fee_msat)) as f64
+        } else {
+            payment.amount_msat as f64 * (1.0 + fee_buffer)
         };
+
+        if balance < required_balance_msat {
+            return Err(DataError::InsufficientFunds(required_balance_msat).into());
+        }
+
+        let pending_payment = payment_repo.insert(payment).await?;
 
         txn.commit()
             .await

--- a/src/infra/database/sea_orm/store.rs
+++ b/src/infra/database/sea_orm/store.rs
@@ -11,9 +11,8 @@ use crate::{
         errors::{ApplicationError, DataError, DatabaseError},
     },
     domains::{
-        payment::{Payment, PaymentRepository, PaymentUnitOfWork},
+        payment::{Payment, PaymentUnitOfWork},
         system::HealthProbe,
-        wallet::WalletRepository,
     },
 };
 
@@ -122,7 +121,7 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
         let payment_repo = SeaOrmPaymentRepository::new(self.db.clone());
 
         let balance = wallet_repo
-            .get_balance(Some(&txn), payment.wallet_id)
+            .get_balance_in_transaction(&txn, payment.wallet_id)
             .await?
             .available_msat as f64;
 
@@ -136,7 +135,7 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
             return Err(DataError::InsufficientFunds(required_balance_msat).into());
         }
 
-        let pending_payment = payment_repo.insert(Some(&txn), payment).await?;
+        let pending_payment = payment_repo.insert_in_transaction(&txn, payment).await?;
 
         txn.commit()
             .await

--- a/src/infra/database/sea_orm/store.rs
+++ b/src/infra/database/sea_orm/store.rs
@@ -11,8 +11,9 @@ use crate::{
         errors::{ApplicationError, DataError, DatabaseError},
     },
     domains::{
-        payment::{Payment, PaymentUnitOfWork},
+        payment::{Payment, PaymentRepository, PaymentUnitOfWork},
         system::HealthProbe,
+        wallet::WalletRepository,
     },
 };
 
@@ -117,25 +118,24 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
             .await
             .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
 
-        let wallet_repo = SeaOrmWalletRepository::new(self.db.clone());
-        let payment_repo = SeaOrmPaymentRepository::new(self.db.clone());
+        let pending_payment = {
+            let wallet_repo = SeaOrmWalletRepository::new(&txn);
+            let payment_repo = SeaOrmPaymentRepository::new(&txn);
 
-        let balance = wallet_repo
-            .get_balance_in_transaction(&txn, payment.wallet_id)
-            .await?
-            .available_msat as f64;
+            let balance = wallet_repo.get_balance(payment.wallet_id).await?.available_msat as f64;
 
-        let required_balance_msat = if let Some(fee_msat) = payment.fee_msat {
-            (payment.amount_msat.saturating_add(fee_msat)) as f64
-        } else {
-            payment.amount_msat as f64 * (1.0 + fee_buffer)
+            let required_balance_msat = if let Some(fee_msat) = payment.fee_msat {
+                (payment.amount_msat.saturating_add(fee_msat)) as f64
+            } else {
+                payment.amount_msat as f64 * (1.0 + fee_buffer)
+            };
+
+            if balance < required_balance_msat {
+                return Err(DataError::InsufficientFunds(required_balance_msat).into());
+            }
+
+            payment_repo.insert(payment).await?
         };
-
-        if balance < required_balance_msat {
-            return Err(DataError::InsufficientFunds(required_balance_msat).into());
-        }
-
-        let pending_payment = payment_repo.insert_in_transaction(&txn, payment).await?;
 
         txn.commit()
             .await


### PR DESCRIPTION
## Summary

- Removes SeaORM transaction handles from domain repository ports.
- Simplifies `PaymentRepository::insert` and `WalletRepository::get_balance` to normal mockable repository methods.
- Keeps transaction-specific execution inside SeaORM infrastructure through crate-local concrete helpers.
- Updates `PaymentUnitOfWork` to use those infra transaction helpers while preserving the current balance-check/payment-insert transaction path.
- Refreshes the ADR wording for the now-removed repository transaction leak.

Closes #238

## Validation

- `make fmt`
- `git diff --check`
