### PR TITLE
test: add backend service unit tests + coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ certs/
 # Local storage files
 storage/*
 deps/lightningd
+
+# Code coverage
+lcov.info

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test-integration:
 # coverage. Use `coverage-html` for a browsable report and `coverage-lcov` to
 # emit an lcov.info file for CI or editor integrations.
 coverage:
-	@cargo llvm-cov --workspace --bins --summary-only
+	@cargo llvm-cov --workspace --bins
 
 coverage-html:
 	@cargo llvm-cov --workspace --bins --html

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SWISSKNIFE_SERVICE := swissknife
 SWISSKNIFE_SERVER_SERVICE := swissknife-server
 IMAGE_NAME := swissknife:latest
 
-.PHONY: watch up up-swissknife up-server up-postgres up-pgadmin shutdown down generate-certs build build-docker build-docker-server build-docker-dashboard run-docker lint fmt fmt-fix test test-unit test-integration check deps-upgrade deps-outdated install-tools generate-models new-migration run-migrations fresh-migrations
+.PHONY: watch up up-swissknife up-server up-postgres up-pgadmin shutdown down generate-certs build build-docker build-docker-server build-docker-dashboard run-docker lint fmt fmt-fix test test-unit test-integration coverage coverage-html coverage-lcov check deps-upgrade deps-outdated install-tools generate-models new-migration run-migrations fresh-migrations
 
 watch:
 	@cargo watch -x run
@@ -44,6 +44,7 @@ install-tools:
 	@cargo install sea-orm-cli
 	@cargo install cargo-edit
 	@cargo install cargo-outdated
+	@cargo install cargo-llvm-cov
 
 generate-models:
 	@sea-orm-cli generate entity --output-dir src/infra/database/sea_orm/models
@@ -95,6 +96,20 @@ test-integration:
 	else \
 		echo "No integration tests found under tests/"; \
 	fi
+
+# Code coverage via cargo-llvm-cov (install with `make install-tools`).
+# Coverage runs the unit-test suite (`--bins`) and reports line/region/function
+# coverage. Use `coverage-html` for a browsable report and `coverage-lcov` to
+# emit an lcov.info file for CI or editor integrations.
+coverage:
+	@cargo llvm-cov --workspace --bins --summary-only
+
+coverage-html:
+	@cargo llvm-cov --workspace --bins --html
+	@echo "HTML coverage report generated at target/llvm-cov/html/index.html"
+
+coverage-lcov:
+	@cargo llvm-cov --workspace --bins --lcov --output-path lcov.info
 
 check: fmt lint build test
 

--- a/docs/DEVELOPER_GUIDELINES.md
+++ b/docs/DEVELOPER_GUIDELINES.md
@@ -110,3 +110,29 @@ Integration tests should be concise and capability-focused. They should not comb
 ## End-to-End Tests
 
 End-to-end tests cover complete user stories across the deployed system and dashboard.
+
+## Coverage
+
+Backend coverage is measured with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov),
+which uses LLVM source-based coverage and works on both macOS and Linux.
+
+Install it once (also pulled in by `make install-tools`):
+
+```bash
+cargo install cargo-llvm-cov
+rustup component add llvm-tools-preview
+```
+
+Then, from `swissknife/`:
+
+```bash
+make coverage       # line/region/function summary in the terminal
+make coverage-html  # browsable report at target/llvm-cov/html/index.html
+make coverage-lcov  # lcov.info for CI or editor integrations
+```
+
+Coverage is a guide for finding untested branches, not a hard gate. Prefer
+meaningful behavior coverage (validation, conditional branches, error
+propagation) over chasing a percentage. Infrastructure and database adapters are
+expected to be exercised by integration tests rather than unit tests, so they
+will show lower unit coverage by design.

--- a/src/application/entities/services.rs
+++ b/src/application/entities/services.rs
@@ -101,3 +101,64 @@ impl AppServices {
         }
     }
 }
+
+/// Test-only builder that assembles an [`AppServices`] from generated `mockall`
+/// use-case mocks, mirroring `MockAppStoreBuilder`. Configure expectations on the
+/// public mock fields, then call [`MockAppServicesBuilder::build`] to obtain an
+/// `AppServices` suitable for handler unit tests.
+#[cfg(test)]
+pub struct MockAppServicesBuilder {
+    pub invoice: crate::domains::invoice::MockInvoiceUseCases,
+    pub payment: crate::domains::payment::MockPaymentsUseCases,
+    pub wallet: crate::domains::wallet::MockWalletUseCases,
+    pub lnurl: crate::domains::lnurl::MockLnUrlUseCases,
+    pub ln_address: crate::domains::ln_address::MockLnAddressUseCases,
+    pub auth: crate::domains::user::MockAuthUseCases,
+    pub system: crate::domains::system::MockSystemUseCases,
+    pub nostr: crate::domains::nostr::MockNostrUseCases,
+    pub api_key: crate::domains::user::MockApiKeyUseCases,
+    pub bitcoin: crate::domains::bitcoin::MockBitcoinUseCases,
+    pub event: crate::domains::event::MockEventUseCases,
+}
+
+#[cfg(test)]
+impl MockAppServicesBuilder {
+    pub fn new() -> Self {
+        Self {
+            invoice: crate::domains::invoice::MockInvoiceUseCases::new(),
+            payment: crate::domains::payment::MockPaymentsUseCases::new(),
+            wallet: crate::domains::wallet::MockWalletUseCases::new(),
+            lnurl: crate::domains::lnurl::MockLnUrlUseCases::new(),
+            ln_address: crate::domains::ln_address::MockLnAddressUseCases::new(),
+            auth: crate::domains::user::MockAuthUseCases::new(),
+            system: crate::domains::system::MockSystemUseCases::new(),
+            nostr: crate::domains::nostr::MockNostrUseCases::new(),
+            api_key: crate::domains::user::MockApiKeyUseCases::new(),
+            bitcoin: crate::domains::bitcoin::MockBitcoinUseCases::new(),
+            event: crate::domains::event::MockEventUseCases::new(),
+        }
+    }
+
+    pub fn build(self) -> AppServices {
+        AppServices {
+            invoice: Box::new(self.invoice),
+            payment: Box::new(self.payment),
+            wallet: Box::new(self.wallet),
+            lnurl: Box::new(self.lnurl),
+            ln_address: Box::new(self.ln_address),
+            auth: Box::new(self.auth),
+            system: Arc::new(self.system),
+            nostr: Box::new(self.nostr),
+            api_key: Box::new(self.api_key),
+            bitcoin: Box::new(self.bitcoin),
+            event: Arc::new(self.event),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for MockAppServicesBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/domains/bitcoin/bitcoin_service.rs
+++ b/src/domains/bitcoin/bitcoin_service.rs
@@ -164,3 +164,246 @@ impl BitcoinUseCases for BitcoinService {
         Ok(synced)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::{
+        application::entities::MockAppStoreBuilder,
+        domains::{
+            bitcoin::{BtcNetwork, BtcOutput, MockBitcoinWallet, OnchainSyncBatch, OnchainTransaction},
+            event::{MockEventUseCases, OnchainWithdrawalEvent},
+            system::MockSystemUseCases,
+        },
+    };
+
+    use super::*;
+
+    fn service(
+        store: MockAppStoreBuilder,
+        wallet: MockBitcoinWallet,
+        events: MockEventUseCases,
+        system: MockSystemUseCases,
+    ) -> BitcoinService {
+        BitcoinService::new(
+            store.build(),
+            Arc::new(wallet),
+            BtcAddressType::P2wpkh,
+            Arc::new(events),
+            Arc::new(system),
+        )
+    }
+
+    fn btc_address(wallet_id: Uuid, address: &str) -> BtcAddress {
+        BtcAddress {
+            id: Uuid::new_v4(),
+            wallet_id,
+            address: address.to_string(),
+            used: false,
+            address_type: BtcAddressType::P2wpkh,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    mod new_deposit_address {
+        use super::*;
+
+        mod when_an_unused_address_exists {
+            use super::*;
+
+            #[tokio::test]
+            async fn reuses_it_without_deriving_a_new_one() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_wallet_unused()
+                    .withf(move |id, address_type| *id == wallet_id && *address_type == BtcAddressType::P2wpkh)
+                    .times(1)
+                    .returning(move |wallet_id, _| Ok(Some(btc_address(wallet_id, "bc1qreused"))));
+
+                // wallet.new_address and btc_address.insert are intentionally not expected.
+                let service = service(
+                    store,
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                    MockSystemUseCases::new(),
+                );
+
+                let address = service.new_deposit_address(wallet_id, None).await.unwrap();
+
+                assert_eq!(address.address, "bc1qreused");
+            }
+        }
+
+        mod when_no_unused_address_exists {
+            use super::*;
+
+            #[tokio::test]
+            async fn derives_and_persists_a_new_address() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_wallet_unused()
+                    .times(1)
+                    .returning(|_, _| Ok(None));
+                store
+                    .btc_address
+                    .expect_insert()
+                    .withf(|_, address, _| address == "bc1qfresh")
+                    .times(1)
+                    .returning(|wallet_id, address, _| Ok(btc_address(wallet_id, address)));
+
+                let mut wallet = MockBitcoinWallet::new();
+                wallet
+                    .expect_new_address()
+                    .times(1)
+                    .returning(|_| Ok("bc1qfresh".to_string()));
+
+                let service = service(store, wallet, MockEventUseCases::new(), MockSystemUseCases::new());
+
+                let address = service.new_deposit_address(wallet_id, None).await.unwrap();
+
+                assert_eq!(address.address, "bc1qfresh");
+            }
+        }
+    }
+
+    mod get_address {
+        use super::*;
+
+        mod when_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.btc_address.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = service(
+                    store,
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                    MockSystemUseCases::new(),
+                );
+
+                let err = service.get_address(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod delete_address {
+        use super::*;
+
+        mod when_nothing_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.btc_address.expect_delete_many().times(1).returning(|_| Ok(0));
+
+                let service = service(
+                    store,
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                    MockSystemUseCases::new(),
+                );
+
+                let err = service.delete_address(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod sync {
+        use super::*;
+
+        mod with_an_existing_cursor_and_mixed_events {
+            use super::*;
+
+            #[tokio::test]
+            async fn projects_each_event_and_advances_the_cursor() {
+                let mut system = MockSystemUseCases::new();
+                system
+                    .expect_get_onchain_cursor()
+                    .times(1)
+                    .returning(|| Ok(Some(OnchainSyncCursor::BlockHeight(100))));
+                system
+                    .expect_set_onchain_cursor()
+                    .withf(|cursor| *cursor == OnchainSyncCursor::BlockHeight(200))
+                    .times(1)
+                    .returning(|_| Ok(()));
+
+                let mut wallet = MockBitcoinWallet::new();
+                wallet.expect_network().returning(|| BtcNetwork::Regtest);
+                wallet.expect_synchronize().times(1).returning(|_| {
+                    Ok(OnchainSyncBatch {
+                        events: vec![
+                            OnchainTransaction::Deposit(BtcOutput {
+                                amount_sat: 1_000,
+                                ..Default::default()
+                            }),
+                            OnchainTransaction::Withdrawal(OnchainWithdrawalEvent {
+                                txid: "txid".to_string(),
+                                block_height: Some(200),
+                            }),
+                        ],
+                        next_cursor: Some(OnchainSyncCursor::BlockHeight(200)),
+                    })
+                });
+
+                let mut events = MockEventUseCases::new();
+                events.expect_onchain_deposit().times(1).returning(|_, _| Ok(true));
+                events.expect_onchain_withdrawal().times(1).returning(|_| Ok(true));
+
+                let service = service(MockAppStoreBuilder::new(), wallet, events, system);
+
+                assert_eq!(service.sync().await.unwrap(), 2);
+            }
+        }
+
+        mod without_a_cursor {
+            use super::*;
+
+            #[tokio::test]
+            async fn seeds_the_start_height_from_stored_data() {
+                let mut system = MockSystemUseCases::new();
+                system.expect_get_onchain_cursor().times(1).returning(|| Ok(None));
+                // No next cursor is returned, so set_onchain_cursor must not be called.
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_output
+                    .expect_max_block_height()
+                    .times(1)
+                    .returning(|| Ok(Some(50)));
+                store
+                    .payment
+                    .expect_max_btc_block_height()
+                    .times(1)
+                    .returning(|| Ok(None));
+
+                let mut wallet = MockBitcoinWallet::new();
+                wallet.expect_network().returning(|| BtcNetwork::Regtest);
+                wallet
+                    .expect_synchronize()
+                    .withf(|cursor| *cursor == Some(OnchainSyncCursor::BlockHeight(50)))
+                    .times(1)
+                    .returning(|_| Ok(OnchainSyncBatch::default()));
+
+                let service = service(store, wallet, MockEventUseCases::new(), system);
+
+                assert_eq!(service.sync().await.unwrap(), 0);
+            }
+        }
+    }
+}

--- a/src/domains/event/event_service.rs
+++ b/src/domains/event/event_service.rs
@@ -217,3 +217,381 @@ impl EventUseCases for EventService {
         Ok(true)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use crate::{
+        application::entities::MockAppStoreBuilder,
+        domains::{bitcoin::BtcAddress, payment::Payment},
+    };
+
+    use super::*;
+
+    fn service(store: MockAppStoreBuilder) -> EventService {
+        EventService::new(store.build())
+    }
+
+    fn btc_address(used: bool) -> BtcAddress {
+        BtcAddress {
+            id: Uuid::new_v4(),
+            wallet_id: Uuid::new_v4(),
+            address: "bc1qknown".to_string(),
+            used,
+            address_type: crate::domains::bitcoin::BtcAddressType::P2wpkh,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    mod invoice_paid {
+        use super::*;
+
+        mod when_invoice_exists {
+            use super::*;
+
+            #[tokio::test]
+            async fn settles_the_invoice() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Invoice {
+                        status: InvoiceStatus::Pending,
+                        ..Default::default()
+                    }))
+                });
+                store
+                    .invoice
+                    .expect_update()
+                    .withf(|invoice| {
+                        invoice.status == InvoiceStatus::Settled && invoice.amount_received_msat == Some(2_000)
+                    })
+                    .times(1)
+                    .returning(Ok);
+
+                let event = LnInvoicePaidEvent {
+                    payment_hash: "ph".to_string(),
+                    amount_received_msat: 2_000,
+                    fee_msat: 1,
+                    payment_time: Utc::now(),
+                };
+
+                assert!(service(store).invoice_paid(event).await.is_ok());
+            }
+        }
+
+        mod when_invoice_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let event = LnInvoicePaidEvent {
+                    payment_hash: "ph".to_string(),
+                    amount_received_msat: 2_000,
+                    fee_msat: 1,
+                    payment_time: Utc::now(),
+                };
+
+                let err = service(store).invoice_paid(event).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod outgoing_payment {
+        use super::*;
+
+        fn event() -> LnPaySuccessEvent {
+            LnPaySuccessEvent {
+                amount_msat: 1_000,
+                fees_msat: 1,
+                payment_hash: "ph".to_string(),
+                payment_preimage: "preimage".to_string(),
+                payment_time: Utc::now(),
+            }
+        }
+
+        mod when_payment_is_pending {
+            use super::*;
+
+            #[tokio::test]
+            async fn settles_it_with_preimage() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Payment {
+                        status: PaymentStatus::Pending,
+                        ..Default::default()
+                    }))
+                });
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| {
+                        payment.status == PaymentStatus::Settled
+                            && payment
+                                .lightning
+                                .as_ref()
+                                .and_then(|lightning| lightning.payment_preimage.as_deref())
+                                == Some("preimage")
+                    })
+                    .times(1)
+                    .returning(Ok);
+
+                assert!(service(store).outgoing_payment(event()).await.is_ok());
+            }
+        }
+
+        mod when_payment_is_already_settled {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_idempotent_and_does_not_update() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Payment {
+                        status: PaymentStatus::Settled,
+                        ..Default::default()
+                    }))
+                });
+                // update is intentionally not expected.
+
+                assert!(service(store).outgoing_payment(event()).await.is_ok());
+            }
+        }
+
+        mod when_payment_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let err = service(store).outgoing_payment(event()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod failed_payment {
+        use super::*;
+
+        fn event() -> LnPayFailureEvent {
+            LnPayFailureEvent {
+                reason: "no route".to_string(),
+                payment_hash: "ph".to_string(),
+            }
+        }
+
+        mod when_payment_is_pending {
+            use super::*;
+
+            #[tokio::test]
+            async fn marks_it_failed_with_reason() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Payment {
+                        status: PaymentStatus::Pending,
+                        ..Default::default()
+                    }))
+                });
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| {
+                        payment.status == PaymentStatus::Failed && payment.error.as_deref() == Some("no route")
+                    })
+                    .times(1)
+                    .returning(Ok);
+
+                assert!(service(store).failed_payment(event()).await.is_ok());
+            }
+        }
+
+        mod when_payment_is_already_failed {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_idempotent_and_does_not_update() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Payment {
+                        status: PaymentStatus::Failed,
+                        ..Default::default()
+                    }))
+                });
+
+                assert!(service(store).failed_payment(event()).await.is_ok());
+            }
+        }
+    }
+
+    mod onchain_deposit {
+        use super::*;
+
+        mod when_address_is_unknown {
+            use super::*;
+
+            #[tokio::test]
+            async fn ignores_the_output() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let processed = service(store)
+                    .onchain_deposit(OnchainDepositEvent::default(), Currency::Regtest)
+                    .await
+                    .unwrap();
+
+                assert!(!processed);
+            }
+        }
+
+        mod when_address_is_known_and_confirmed {
+            use super::*;
+
+            #[tokio::test]
+            async fn creates_a_settled_deposit_invoice() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(|_| Ok(Some(btc_address(false))));
+                store.btc_output.expect_upsert().times(1).returning(|output| {
+                    Ok(BtcOutput {
+                        id: Uuid::new_v4(),
+                        status: BtcOutputStatus::Confirmed,
+                        amount_sat: 1_000,
+                        ..output
+                    })
+                });
+                // Address was unused, so it must be flagged as used.
+                store.btc_address.expect_mark_used().times(1).returning(|_| Ok(()));
+                store
+                    .invoice
+                    .expect_find_by_btc_output_id()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .invoice
+                    .expect_insert()
+                    .withf(|invoice| {
+                        invoice.ledger == Ledger::Onchain
+                            && invoice.amount_received_msat == Some(1_000_000)
+                            && invoice.payment_time.is_some()
+                    })
+                    .times(1)
+                    .returning(Ok);
+
+                let event = OnchainDepositEvent {
+                    txid: "txid".to_string(),
+                    output_index: 0,
+                    address: "bc1qknown".to_string(),
+                    amount_sat: 1_000,
+                    block_height: Some(800_000),
+                };
+
+                let processed = service(store).onchain_deposit(event, Currency::Bitcoin).await.unwrap();
+
+                assert!(processed);
+            }
+        }
+    }
+
+    mod onchain_withdrawal {
+        use super::*;
+
+        mod when_transaction_is_unconfirmed {
+            use super::*;
+
+            #[tokio::test]
+            async fn ignores_it() {
+                // No store calls expected for an unconfirmed transaction.
+                let event = OnchainWithdrawalEvent {
+                    txid: "txid".to_string(),
+                    block_height: None,
+                };
+
+                let processed = service(MockAppStoreBuilder::new())
+                    .onchain_withdrawal(event)
+                    .await
+                    .unwrap();
+
+                assert!(!processed);
+            }
+        }
+
+        mod when_payment_is_unknown {
+            use super::*;
+
+            #[tokio::test]
+            async fn ignores_it() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let event = OnchainWithdrawalEvent {
+                    txid: "txid".to_string(),
+                    block_height: Some(800_000),
+                };
+
+                let processed = service(store).onchain_withdrawal(event).await.unwrap();
+
+                assert!(!processed);
+            }
+        }
+
+        mod when_payment_matches {
+            use super::*;
+
+            #[tokio::test]
+            async fn settles_the_payment_with_block_height() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(Some(Payment::default())));
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| {
+                        payment.status == PaymentStatus::Settled
+                            && payment.bitcoin.as_ref().and_then(|bitcoin| bitcoin.block_height) == Some(800_000)
+                    })
+                    .times(1)
+                    .returning(Ok);
+
+                let event = OnchainWithdrawalEvent {
+                    txid: "txid".to_string(),
+                    block_height: Some(800_000),
+                };
+
+                let processed = service(store).onchain_withdrawal(event).await.unwrap();
+
+                assert!(processed);
+            }
+        }
+    }
+}

--- a/src/domains/invoice/invoice_service.rs
+++ b/src/domains/invoice/invoice_service.rs
@@ -182,3 +182,249 @@ impl InvoiceUseCases for InvoiceService {
         Ok(synced)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        application::{
+            entities::MockAppStoreBuilder,
+            errors::{DatabaseError, LightningError},
+        },
+        domains::{event::MockEventUseCases, invoice::LnInvoice},
+        infra::lightning::MockLnClient,
+    };
+
+    use super::*;
+
+    const EXPIRY: u32 = 3_600;
+
+    fn service(store: MockAppStoreBuilder, ln_client: MockLnClient, events: MockEventUseCases) -> InvoiceService {
+        InvoiceService::new(store.build(), Arc::new(ln_client), EXPIRY, Arc::new(events))
+    }
+
+    fn lightning_invoice(payment_hash: &str, status: InvoiceStatus) -> Invoice {
+        Invoice {
+            id: Uuid::new_v4(),
+            ledger: Ledger::Lightning,
+            status,
+            ln_invoice: Some(LnInvoice {
+                payment_hash: payment_hash.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    mod invoice {
+        use super::*;
+
+        mod with_defaults {
+            use super::*;
+
+            #[tokio::test]
+            async fn requests_node_invoice_and_persists_it() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_invoice()
+                    .withf(|amount, description, _label, expiry, deschashonly| {
+                        *amount == 1_000
+                            && description == DEFAULT_INVOICE_DESCRIPTION
+                            && *expiry == EXPIRY
+                            && !deschashonly
+                    })
+                    .times(1)
+                    .returning(|amount, _, _, _, _| {
+                        Ok(Invoice {
+                            amount_msat: Some(amount),
+                            ..Default::default()
+                        })
+                    });
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_insert()
+                    .withf(move |invoice| invoice.wallet_id == wallet_id)
+                    .times(1)
+                    .returning(Ok);
+
+                let service = service(store, ln_client, MockEventUseCases::new());
+
+                let invoice = service.invoice(wallet_id, 1_000, None, None).await.unwrap();
+
+                assert_eq!(invoice.wallet_id, wallet_id);
+            }
+        }
+
+        mod when_node_invoice_generation_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn propagates_lightning_error() {
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_invoice()
+                    .times(1)
+                    .returning(|_, _, _, _, _| Err(LightningError::Invoice("node down".to_string())));
+
+                let service = service(MockAppStoreBuilder::new(), ln_client, MockEventUseCases::new());
+
+                let err = service.invoice(Uuid::new_v4(), 1_000, None, None).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Lightning(_)));
+            }
+        }
+
+        mod when_persistence_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn propagates_database_error() {
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_invoice()
+                    .times(1)
+                    .returning(|_, _, _, _, _| Ok(Invoice::default()));
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_insert()
+                    .times(1)
+                    .returning(|_| Err(DatabaseError::Insert("boom".to_string())));
+
+                let service = service(store, ln_client, MockEventUseCases::new());
+
+                let err = service.invoice(Uuid::new_v4(), 1_000, None, None).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Database(DatabaseError::Insert(_))));
+            }
+        }
+    }
+
+    mod get {
+        use super::*;
+
+        mod when_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = service(store, MockLnClient::new(), MockEventUseCases::new());
+
+                let err = service.get(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod delete {
+        use super::*;
+
+        mod when_nothing_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_delete_many().times(1).returning(|_| Ok(0));
+
+                let service = service(store, MockLnClient::new(), MockEventUseCases::new());
+
+                let err = service.delete(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod sync {
+        use super::*;
+
+        mod when_a_pending_invoice_is_settled_on_the_node {
+            use super::*;
+
+            #[tokio::test]
+            async fn fires_invoice_paid_event_and_counts_it() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find_many().times(2).returning(|filter| {
+                    if filter.status == Some(InvoiceStatus::Pending) {
+                        Ok(vec![lightning_invoice("ph1", InvoiceStatus::Pending)])
+                    } else {
+                        Ok(vec![])
+                    }
+                });
+
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_invoice_by_hash()
+                    .withf(|payment_hash| payment_hash == "ph1")
+                    .times(1)
+                    .returning(|_| {
+                        Ok(Some(Invoice {
+                            status: InvoiceStatus::Settled,
+                            amount_received_msat: Some(2_000),
+                            fee_msat: Some(1),
+                            ..Default::default()
+                        }))
+                    });
+
+                let mut events = MockEventUseCases::new();
+                events
+                    .expect_invoice_paid()
+                    .withf(|event| event.payment_hash == "ph1" && event.amount_received_msat == 2_000)
+                    .times(1)
+                    .returning(|_| Ok(()));
+
+                let service = service(store, ln_client, events);
+
+                assert_eq!(service.sync().await.unwrap(), 1);
+            }
+        }
+
+        mod when_invoice_has_no_lightning_details {
+            use super::*;
+
+            #[tokio::test]
+            async fn skips_without_querying_the_node() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find_many().times(2).returning(|filter| {
+                    if filter.status == Some(InvoiceStatus::Pending) {
+                        Ok(vec![Invoice {
+                            ledger: Ledger::Lightning,
+                            ln_invoice: None,
+                            ..Default::default()
+                        }])
+                    } else {
+                        Ok(vec![])
+                    }
+                });
+
+                // invoice_by_hash and invoice_paid are intentionally not expected.
+                let service = service(store, MockLnClient::new(), MockEventUseCases::new());
+
+                assert_eq!(service.sync().await.unwrap(), 0);
+            }
+        }
+
+        mod when_there_is_nothing_pending {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_zero() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find_many().times(2).returning(|_| Ok(vec![]));
+
+                let service = service(store, MockLnClient::new(), MockEventUseCases::new());
+
+                assert_eq!(service.sync().await.unwrap(), 0);
+            }
+        }
+    }
+}

--- a/src/domains/ln_address/ln_address_service.rs
+++ b/src/domains/ln_address/ln_address_service.rs
@@ -176,33 +176,424 @@ fn validate_username(username: &str) -> Result<(), DataError> {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
+    use crate::application::{entities::MockAppStoreBuilder, errors::DatabaseError};
+
     use super::*;
 
-    #[test]
-    fn validate_username_accepts_supported_email_local_part_characters() {
-        assert!(validate_username("alice").is_ok());
-        assert!(validate_username("alice.123_+-").is_ok());
-        assert!(validate_username("a".repeat(MAX_USERNAME_LENGTH).as_str()).is_ok());
+    fn ln_address_fixture(id: Uuid, wallet_id: Uuid, username: &str) -> LnAddress {
+        LnAddress {
+            id,
+            wallet_id,
+            username: username.to_string(),
+            active: true,
+            allows_nostr: false,
+            nostr_pubkey: None,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
     }
 
-    #[test]
-    fn validate_username_rejects_empty_or_too_long_usernames() {
-        let empty_err = validate_username("").unwrap_err();
-        assert!(matches!(empty_err, DataError::Validation(_)));
-        assert!(empty_err.to_string().contains("Invalid username length"));
-
-        let too_long = "a".repeat(MAX_USERNAME_LENGTH + 1);
-        let too_long_err = validate_username(&too_long).unwrap_err();
-        assert!(matches!(too_long_err, DataError::Validation(_)));
-        assert!(too_long_err.to_string().contains("Invalid username length"));
+    fn update_request(username: Option<&str>) -> UpdateLnAddressRequest {
+        UpdateLnAddressRequest {
+            username: username.map(str::to_string),
+            active: None,
+            allows_nostr: None,
+            nostr_pubkey: None,
+        }
     }
 
-    #[test]
-    fn validate_username_rejects_unsupported_characters() {
-        for username in ["Alice", "alice bob", "alice@example", "alice:123"] {
-            let err = validate_username(username).unwrap_err();
-            assert!(matches!(err, DataError::Validation(_)));
-            assert!(err.to_string().contains("Invalid username format"));
+    mod validate_username {
+        use super::*;
+
+        #[test]
+        fn accepts_supported_email_local_part_characters() {
+            assert!(validate_username("alice").is_ok());
+            assert!(validate_username("alice.123_+-").is_ok());
+            assert!(validate_username("a".repeat(MAX_USERNAME_LENGTH).as_str()).is_ok());
+        }
+
+        #[test]
+        fn rejects_empty_or_too_long_usernames() {
+            let empty_err = validate_username("").unwrap_err();
+            assert!(matches!(empty_err, DataError::Validation(_)));
+            assert!(empty_err.to_string().contains("Invalid username length"));
+
+            let too_long = "a".repeat(MAX_USERNAME_LENGTH + 1);
+            let too_long_err = validate_username(&too_long).unwrap_err();
+            assert!(matches!(too_long_err, DataError::Validation(_)));
+            assert!(too_long_err.to_string().contains("Invalid username length"));
+        }
+
+        #[test]
+        fn rejects_unsupported_characters() {
+            for username in ["Alice", "alice bob", "alice@example", "alice:123"] {
+                let err = validate_username(username).unwrap_err();
+                assert!(matches!(err, DataError::Validation(_)));
+                assert!(err.to_string().contains("Invalid username format"));
+            }
+        }
+    }
+
+    mod register {
+        use super::*;
+
+        mod with_valid_new_username {
+            use super::*;
+
+            #[tokio::test]
+            async fn lowercases_username_and_inserts() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_wallet_id()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .withf(|username| username == "alice")
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .ln_address
+                    .expect_insert()
+                    .withf(|_, username, _, _| username == "alice")
+                    .times(1)
+                    .returning(|wallet_id, username, _, _| Ok(ln_address_fixture(Uuid::new_v4(), wallet_id, username)));
+
+                let service = LnAddressService::new(store.build());
+
+                let ln_address = service
+                    .register(wallet_id, "Alice".to_string(), false, None)
+                    .await
+                    .unwrap();
+
+                assert_eq!(ln_address.username, "alice");
+                assert_eq!(ln_address.wallet_id, wallet_id);
+            }
+        }
+
+        mod with_invalid_username {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_without_touching_the_store() {
+                // No store expectations are installed, so any repository call panics.
+                let service = LnAddressService::new(MockAppStoreBuilder::new().build());
+
+                let err = service
+                    .register(Uuid::new_v4(), "invalid username".to_string(), false, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod when_wallet_already_has_an_address {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_conflict() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_wallet_id()
+                    .times(1)
+                    .returning(move |_| Ok(Some(ln_address_fixture(Uuid::new_v4(), wallet_id, "existing"))));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service
+                    .register(wallet_id, "alice".to_string(), false, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
+                assert!(err.to_string().contains("Duplicate User ID"));
+            }
+        }
+
+        mod when_username_is_taken {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_conflict() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_wallet_id()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address_fixture(Uuid::new_v4(), Uuid::new_v4(), "alice"))));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service
+                    .register(Uuid::new_v4(), "alice".to_string(), false, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
+                assert!(err.to_string().contains("Duplicate username"));
+            }
+        }
+
+        mod when_lookup_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn propagates_database_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_wallet_id()
+                    .times(1)
+                    .returning(|_| Err(DatabaseError::FindOne("boom".to_string())));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service
+                    .register(Uuid::new_v4(), "alice".to_string(), false, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Database(DatabaseError::FindOne(_))));
+            }
+        }
+    }
+
+    mod get {
+        use super::*;
+
+        mod when_found {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_address() {
+                let id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find()
+                    .withf(move |queried| *queried == id)
+                    .times(1)
+                    .returning(move |id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+
+                let service = LnAddressService::new(store.build());
+
+                let ln_address = service.get(id).await.unwrap();
+
+                assert_eq!(ln_address.id, id);
+            }
+        }
+
+        mod when_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.ln_address.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service.get(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod list {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_addresses_from_the_repository() {
+            let mut store = MockAppStoreBuilder::new();
+            store
+                .ln_address
+                .expect_find_many()
+                .times(1)
+                .returning(|_| Ok(vec![ln_address_fixture(Uuid::new_v4(), Uuid::new_v4(), "alice")]));
+
+            let service = LnAddressService::new(store.build());
+
+            let addresses = service.list(LnAddressFilter::default()).await.unwrap();
+
+            assert_eq!(addresses.len(), 1);
+        }
+    }
+
+    mod update {
+        use super::*;
+
+        mod when_address_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.ln_address.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service
+                    .update(Uuid::new_v4(), update_request(Some("bob")))
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod with_a_new_unique_username {
+            use super::*;
+
+            #[tokio::test]
+            async fn validates_uniqueness_and_persists() {
+                let id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find()
+                    .times(1)
+                    .returning(move |id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .withf(|username| username == "bob")
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .ln_address
+                    .expect_update()
+                    .withf(|ln_address| ln_address.username == "bob")
+                    .times(1)
+                    .returning(Ok);
+
+                let service = LnAddressService::new(store.build());
+
+                let updated = service.update(id, update_request(Some("Bob"))).await.unwrap();
+
+                assert_eq!(updated.username, "bob");
+            }
+        }
+
+        mod when_username_is_unchanged {
+            use super::*;
+
+            #[tokio::test]
+            async fn skips_uniqueness_check() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find()
+                    .times(1)
+                    .returning(|id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+                // find_by_username is intentionally not expected: an unchanged
+                // username must not trigger a uniqueness lookup.
+                store.ln_address.expect_update().times(1).returning(Ok);
+
+                let service = LnAddressService::new(store.build());
+
+                let updated = service
+                    .update(Uuid::new_v4(), update_request(Some("alice")))
+                    .await
+                    .unwrap();
+
+                assert_eq!(updated.username, "alice");
+            }
+        }
+
+        mod when_new_username_is_taken {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_conflict() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find()
+                    .times(1)
+                    .returning(|id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address_fixture(Uuid::new_v4(), Uuid::new_v4(), "bob"))));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service
+                    .update(Uuid::new_v4(), update_request(Some("bob")))
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
+            }
+        }
+    }
+
+    mod delete {
+        use super::*;
+
+        mod when_a_row_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn succeeds() {
+                let mut store = MockAppStoreBuilder::new();
+                store.ln_address.expect_delete_many().times(1).returning(|_| Ok(1));
+
+                let service = LnAddressService::new(store.build());
+
+                assert!(service.delete(Uuid::new_v4()).await.is_ok());
+            }
+        }
+
+        mod when_nothing_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.ln_address.expect_delete_many().times(1).returning(|_| Ok(0));
+
+                let service = LnAddressService::new(store.build());
+
+                let err = service.delete(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod delete_many {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_deleted_count() {
+            let mut store = MockAppStoreBuilder::new();
+            store.ln_address.expect_delete_many().times(1).returning(|_| Ok(3));
+
+            let service = LnAddressService::new(store.build());
+
+            let deleted = service.delete_many(LnAddressFilter::default()).await.unwrap();
+
+            assert_eq!(deleted, 3);
         }
     }
 }

--- a/src/domains/lnurl/lnurl_service.rs
+++ b/src/domains/lnurl/lnurl_service.rs
@@ -135,3 +135,177 @@ impl LnUrlUseCases for LnUrlService {
         Ok(lnurlp_invoice)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::{
+        application::entities::MockAppStoreBuilder,
+        domains::{
+            invoice::{Invoice, LnInvoice},
+            ln_address::LnAddress,
+        },
+        infra::lightning::MockLnClient,
+    };
+
+    use super::*;
+
+    fn service(store: MockAppStoreBuilder, ln_client: MockLnClient) -> LnUrlService {
+        LnUrlService::new(
+            store.build(),
+            Arc::new(ln_client),
+            3_600,
+            "numeraire.tech".to_string(),
+            "https://numeraire.tech".to_string(),
+        )
+    }
+
+    fn ln_address(active: bool) -> LnAddress {
+        LnAddress {
+            id: Uuid::new_v4(),
+            wallet_id: Uuid::new_v4(),
+            username: "alice".to_string(),
+            active,
+            allows_nostr: false,
+            nostr_pubkey: None,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    mod lnurlp {
+        use super::*;
+
+        mod when_address_is_active {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_pay_request_metadata() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .withf(|username| username == "alice")
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address(true))));
+
+                let request = service(store, MockLnClient::new())
+                    .lnurlp("alice".to_string())
+                    .await
+                    .unwrap();
+
+                assert_eq!(request.tag, "payRequest");
+                assert_eq!(request.min_sendable, MIN_SENDABLE);
+                assert_eq!(request.max_sendable, MAX_SENDABLE);
+                assert!(request.callback.contains("alice"));
+            }
+        }
+
+        mod when_address_is_inactive {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address(false))));
+
+                let err = service(store, MockLnClient::new())
+                    .lnurlp("alice".to_string())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod when_address_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let err = service(store, MockLnClient::new())
+                    .lnurlp("alice".to_string())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod lnurlp_callback {
+        use super::*;
+
+        mod when_address_is_active {
+            use super::*;
+
+            #[tokio::test]
+            async fn issues_and_persists_an_invoice() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address(true))));
+                store.invoice.expect_insert().times(1).returning(Ok);
+
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_invoice()
+                    .withf(|_, _, _, _, deschashonly| *deschashonly)
+                    .times(1)
+                    .returning(|_, _, _, _, _| {
+                        Ok(Invoice {
+                            ln_invoice: Some(LnInvoice {
+                                bolt11: "lnbc1example".to_string(),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })
+                    });
+
+                let callback = service(store, ln_client)
+                    .lnurlp_callback("alice".to_string(), 2_000, None)
+                    .await
+                    .unwrap();
+
+                assert_eq!(callback.pr, "lnbc1example");
+                assert!(callback.success_action.is_some());
+            }
+        }
+
+        mod when_address_is_inactive {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found_without_calling_the_node() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address(false))));
+
+                // ln_client.invoice is intentionally not expected.
+                let err = service(store, MockLnClient::new())
+                    .lnurlp_callback("alice".to_string(), 2_000, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+}

--- a/src/domains/nostr/nostr_service.rs
+++ b/src/domains/nostr/nostr_service.rs
@@ -40,3 +40,141 @@ impl NostrUseCases for NostrService {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use crate::{
+        application::{entities::MockAppStoreBuilder, errors::DatabaseError},
+        domains::ln_address::LnAddress,
+    };
+
+    use super::*;
+
+    // Generator point x-coordinate: a valid x-only (Schnorr) public key.
+    const VALID_PUBKEY_HEX: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    fn ln_address_fixture(allows_nostr: bool, nostr_pubkey: Option<PublicKey>) -> LnAddress {
+        LnAddress {
+            id: Uuid::new_v4(),
+            wallet_id: Uuid::new_v4(),
+            username: "alice".to_string(),
+            active: true,
+            allows_nostr,
+            nostr_pubkey,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    mod get_pubkey {
+        use super::*;
+
+        mod when_nostr_is_enabled_with_a_pubkey {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_the_pubkey() {
+                let pubkey = PublicKey::from_hex(VALID_PUBKEY_HEX).unwrap();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .withf(|username| username == "alice")
+                    .times(1)
+                    .returning(move |_| Ok(Some(ln_address_fixture(true, Some(pubkey)))));
+
+                let service = NostrService::new(store.build());
+
+                let result = service.get_pubkey("alice".to_string()).await.unwrap();
+
+                assert_eq!(result, pubkey);
+            }
+        }
+
+        mod when_address_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let service = NostrService::new(store.build());
+
+                let err = service.get_pubkey("alice".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod when_nostr_is_disabled {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let pubkey = PublicKey::from_hex(VALID_PUBKEY_HEX).unwrap();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(move |_| Ok(Some(ln_address_fixture(false, Some(pubkey)))));
+
+                let service = NostrService::new(store.build());
+
+                let err = service.get_pubkey("alice".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod when_pubkey_is_absent {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address_fixture(true, None))));
+
+                let service = NostrService::new(store.build());
+
+                let err = service.get_pubkey("alice".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod when_lookup_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn propagates_database_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Err(DatabaseError::FindOne("boom".to_string())));
+
+                let service = NostrService::new(store.build());
+
+                let err = service.get_pubkey("alice".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Database(DatabaseError::FindOne(_))));
+            }
+        }
+    }
+}

--- a/src/domains/payment/payment_handler.rs
+++ b/src/domains/payment/payment_handler.rs
@@ -210,3 +210,155 @@ async fn delete_payments(
     let n_deleted = services.payment.delete_many(query_params).await?;
     Ok(n_deleted.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{application::entities::MockAppServicesBuilder, domains::payment::Payment};
+
+    use super::*;
+
+    fn user(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    fn send_request(wallet_id: Option<Uuid>) -> SendPaymentRequest {
+        SendPaymentRequest {
+            wallet_id,
+            input: "bob@numeraire.tech".to_string(),
+            amount_msat: Some(1_000),
+            comment: None,
+        }
+    }
+
+    mod pay {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden_and_does_not_call_the_service() {
+                // No expect_pay installed: any call to the use case panics.
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = pay(State(Arc::new(services)), user(vec![]), Json(send_request(None))).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod when_wallet_id_is_omitted {
+            use super::*;
+
+            #[tokio::test]
+            async fn defaults_to_the_authenticated_users_wallet() {
+                let caller = user(vec![Permission::WriteLnTransaction]);
+                let expected_wallet = caller.wallet_id;
+
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .payment
+                    .expect_pay()
+                    .withf(move |_, _, _, wallet_id| *wallet_id == expected_wallet)
+                    .times(1)
+                    .returning(|_, _, _, _| Ok(Payment::default()));
+
+                let result = pay(State(Arc::new(builder.build())), caller, Json(send_request(None))).await;
+
+                assert!(result.is_ok());
+            }
+        }
+
+        mod when_wallet_id_is_provided {
+            use super::*;
+
+            #[tokio::test]
+            async fn uses_the_explicit_wallet_id() {
+                let explicit = Uuid::new_v4();
+
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .payment
+                    .expect_pay()
+                    .withf(move |_, _, _, wallet_id| *wallet_id == explicit)
+                    .times(1)
+                    .returning(|_, _, _, _| Ok(Payment::default()));
+
+                let result = pay(
+                    State(Arc::new(builder.build())),
+                    user(vec![Permission::WriteLnTransaction]),
+                    Json(send_request(Some(explicit))),
+                )
+                .await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod get_payment {
+        use super::*;
+
+        mod without_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = get_payment(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod with_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_the_payment() {
+                let id = Uuid::new_v4();
+
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .payment
+                    .expect_get()
+                    .withf(move |queried| *queried == id)
+                    .times(1)
+                    .returning(|_| Ok(Payment::default()));
+
+                let result = get_payment(
+                    State(Arc::new(builder.build())),
+                    user(vec![Permission::ReadLnTransaction]),
+                    Path(id),
+                )
+                .await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod delete_payment {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let err = delete_payment(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4()))
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Authorization(_)));
+            }
+        }
+    }
+}

--- a/src/domains/payment/payment_service.rs
+++ b/src/domains/payment/payment_service.rs
@@ -655,7 +655,89 @@ impl PaymentsUseCases for PaymentService {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        application::{entities::MockAppStoreBuilder, errors::BitcoinError},
+        domains::{
+            bitcoin::{BtcAddress, BtcAddressType, BtcNetwork, BtcPreparedTransaction, MockBitcoinWallet},
+            event::MockEventUseCases,
+            ln_address::LnAddress,
+        },
+        infra::lightning::MockLnClient,
+    };
+
     use super::*;
+
+    const DOMAIN: &str = "numeraire.tech";
+    const FEE_BUFFER: f64 = 0.02;
+
+    fn service(
+        store: MockAppStoreBuilder,
+        ln_client: MockLnClient,
+        bitcoin_wallet: MockBitcoinWallet,
+        events: MockEventUseCases,
+    ) -> PaymentService {
+        PaymentService::new(
+            store.build(),
+            Arc::new(ln_client),
+            Arc::new(bitcoin_wallet),
+            DOMAIN.to_string(),
+            FEE_BUFFER,
+            Arc::new(events),
+        )
+    }
+
+    fn ln_address(wallet_id: Uuid, active: bool) -> LnAddress {
+        LnAddress {
+            id: Uuid::new_v4(),
+            wallet_id,
+            username: "bob".to_string(),
+            active,
+            allows_nostr: false,
+            nostr_pubkey: None,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    fn btc_address(wallet_id: Uuid) -> BtcAddress {
+        BtcAddress {
+            id: Uuid::new_v4(),
+            wallet_id,
+            address: "bcrt1qrecipient".to_string(),
+            used: false,
+            address_type: BtcAddressType::P2wpkh,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    fn bitcoin_data(amount_sat: Option<u64>) -> BitcoinAddressData {
+        BitcoinAddressData {
+            address: "bcrt1qrecipient".to_string(),
+            amount_sat,
+            message: None,
+            network: BtcNetwork::Regtest,
+        }
+    }
+
+    fn bolt11(amount_msat: Option<u64>) -> ParsedBolt11Invoice {
+        ParsedBolt11Invoice {
+            bolt11: "lnbc1example".to_string(),
+            amount_msat,
+            payment_hash: "ph".to_string(),
+            description: None,
+            currency: Currency::Bitcoin,
+        }
+    }
+
+    fn prepared_tx() -> BtcPreparedTransaction {
+        BtcPreparedTransaction {
+            txid: "txid".to_string(),
+            fee_sat: 10,
+            psbt: "psbt".to_string(),
+            locked_utxos: vec![],
+        }
+    }
 
     mod validate_amount {
         use super::*;
@@ -691,6 +773,933 @@ mod tests {
             #[test]
             fn rejects_zero() {
                 assert_validation_error(Some(0));
+            }
+        }
+    }
+
+    mod is_internal_payment {
+        use super::*;
+
+        #[test]
+        fn matches_the_configured_domain() {
+            let service = service(
+                MockAppStoreBuilder::new(),
+                MockLnClient::new(),
+                MockBitcoinWallet::new(),
+                MockEventUseCases::new(),
+            );
+
+            assert!(service.is_internal_payment("bob@numeraire.tech"));
+            assert!(!service.is_internal_payment("bob@example.com"));
+            assert!(!service.is_internal_payment("not-an-address"));
+        }
+    }
+
+    mod send_internal {
+        use super::*;
+
+        mod when_recipient_is_active_and_distinct {
+            use super::*;
+
+            #[tokio::test]
+            async fn writes_counterpart_invoice_and_settled_payment() {
+                let sender = Uuid::new_v4();
+                let recipient = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .withf(|username| username == "bob")
+                    .times(1)
+                    .returning(move |_| Ok(Some(ln_address(recipient, true))));
+                store
+                    .invoice
+                    .expect_insert()
+                    .withf(move |invoice| invoice.wallet_id == recipient && invoice.status == InvoiceStatus::Settled)
+                    .times(1)
+                    .returning(Ok);
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .withf(|payment, fee_buffer| payment.ledger == Ledger::Internal && *fee_buffer < f64::EPSILON)
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let payment = service
+                    .send_internal("bob@numeraire.tech".to_string(), Some(1_000), None, sender)
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.status, PaymentStatus::Settled);
+                assert_eq!(payment.ledger, Ledger::Internal);
+            }
+        }
+
+        mod with_zero_amount {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_before_lookup() {
+                let service = service(
+                    MockAppStoreBuilder::new(),
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_internal("bob@numeraire.tech".to_string(), Some(0), None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod when_recipient_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_internal("bob@numeraire.tech".to_string(), Some(1_000), None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod when_recipient_is_inactive {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(Some(ln_address(Uuid::new_v4(), false))));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_internal("bob@numeraire.tech".to_string(), Some(1_000), None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod when_paying_yourself {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(move |_| Ok(Some(ln_address(wallet_id, true))));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_internal("bob@numeraire.tech".to_string(), Some(1_000), None, wallet_id)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+                assert!(err.to_string().contains("Cannot pay to yourself"));
+            }
+        }
+    }
+
+    mod pay {
+        use super::*;
+
+        mod with_an_internal_ln_address {
+            use super::*;
+
+            #[tokio::test]
+            async fn routes_to_the_internal_flow() {
+                let recipient = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(move |_| Ok(Some(ln_address(recipient, true))));
+                store.invoice.expect_insert().times(1).returning(Ok);
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let payment = service
+                    .pay("bob@numeraire.tech".to_string(), Some(1_000), None, Uuid::new_v4())
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.ledger, Ledger::Internal);
+            }
+        }
+    }
+
+    mod send_bitcoin {
+        use super::*;
+
+        mod with_zero_amount {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let service = service(
+                    MockAppStoreBuilder::new(),
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_bitcoin(bitcoin_data(Some(0)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod without_amount {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let service = service(
+                    MockAppStoreBuilder::new(),
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_bitcoin(bitcoin_data(None), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+                assert!(err.to_string().contains("Amount must be defined"));
+            }
+        }
+
+        mod when_address_belongs_to_a_local_wallet {
+            use super::*;
+
+            #[tokio::test]
+            async fn settles_as_an_internal_payment() {
+                let recipient = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(move |_| Ok(Some(btc_address(recipient))));
+                store
+                    .invoice
+                    .expect_insert()
+                    .withf(move |invoice| invoice.wallet_id == recipient && invoice.ledger == Ledger::Internal)
+                    .times(1)
+                    .returning(Ok);
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let payment = service
+                    .send_bitcoin(bitcoin_data(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.status, PaymentStatus::Settled);
+                assert_eq!(payment.ledger, Ledger::Internal);
+            }
+        }
+
+        mod when_paying_your_own_bitcoin_address {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(move |_| Ok(Some(btc_address(wallet_id))));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_bitcoin(bitcoin_data(Some(1_000)), None, None, wallet_id)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod when_broadcasting_externally {
+            use super::*;
+
+            #[tokio::test]
+            async fn reserves_then_signs_and_returns_pending() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .withf(|payment, _| payment.status == PaymentStatus::Pending && payment.ledger == Ledger::Onchain)
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+
+                let mut wallet = MockBitcoinWallet::new();
+                wallet
+                    .expect_prepare_transaction()
+                    .times(1)
+                    .returning(|_, _, _| Ok(prepared_tx()));
+                // No resolved txid, so the payment row is not updated afterwards.
+                wallet.expect_sign_send_transaction().times(1).returning(|_| Ok(None));
+
+                let service = service(store, MockLnClient::new(), wallet, MockEventUseCases::new());
+
+                let payment = service
+                    .send_bitcoin(bitcoin_data(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.status, PaymentStatus::Pending);
+            }
+        }
+
+        mod when_reservation_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn releases_the_prepared_transaction_and_propagates() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .times(1)
+                    .returning(|_, _| Err(DataError::InsufficientFunds(1_000.0).into()));
+
+                let mut wallet = MockBitcoinWallet::new();
+                wallet
+                    .expect_prepare_transaction()
+                    .times(1)
+                    .returning(|_, _, _| Ok(prepared_tx()));
+                // The reservation failed before broadcast, so the lease must be released.
+                wallet
+                    .expect_release_prepared_transaction()
+                    .times(1)
+                    .returning(|_| Ok(()));
+
+                let service = service(store, MockLnClient::new(), wallet, MockEventUseCases::new());
+
+                let err = service
+                    .send_bitcoin(bitcoin_data(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::InsufficientFunds(_))));
+            }
+        }
+
+        mod when_signing_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn releases_lease_and_marks_payment_failed() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| payment.status == PaymentStatus::Failed)
+                    .times(1)
+                    .returning(Ok);
+
+                let mut wallet = MockBitcoinWallet::new();
+                wallet
+                    .expect_prepare_transaction()
+                    .times(1)
+                    .returning(|_, _, _| Ok(prepared_tx()));
+                wallet
+                    .expect_sign_send_transaction()
+                    .times(1)
+                    .returning(|_| Err(BitcoinError::FinalizeTransaction("rejected".to_string())));
+                wallet
+                    .expect_release_prepared_transaction()
+                    .times(1)
+                    .returning(|_| Ok(()));
+
+                let service = service(store, MockLnClient::new(), wallet, MockEventUseCases::new());
+
+                let err = service
+                    .send_bitcoin(bitcoin_data(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Bitcoin(_)));
+            }
+        }
+    }
+
+    mod send_bolt11 {
+        use super::*;
+
+        mod when_invoice_is_internal_and_pending {
+            use super::*;
+
+            #[tokio::test]
+            async fn settles_internally_and_cancels_node_invoice() {
+                let sender = Uuid::new_v4();
+                let recipient = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(move |_| {
+                        Ok(Some(Invoice {
+                            wallet_id: recipient,
+                            status: InvoiceStatus::Pending,
+                            ..Default::default()
+                        }))
+                    });
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .withf(|payment, _| payment.ledger == Ledger::Internal)
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+                store
+                    .invoice
+                    .expect_update()
+                    .withf(move |invoice| invoice.ledger == Ledger::Internal)
+                    .times(1)
+                    .returning(Ok);
+
+                let mut ln_client = MockLnClient::new();
+                ln_client.expect_cancel_invoice().times(1).returning(|_, _| Ok(()));
+
+                let service = service(store, ln_client, MockBitcoinWallet::new(), MockEventUseCases::new());
+
+                let payment = service
+                    .send_bolt11(bolt11(Some(1_000)), None, None, sender)
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.status, PaymentStatus::Settled);
+            }
+        }
+
+        mod when_paying_your_own_invoice {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(move |_| {
+                        Ok(Some(Invoice {
+                            wallet_id,
+                            status: InvoiceStatus::Pending,
+                            ..Default::default()
+                        }))
+                    });
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_bolt11(bolt11(Some(1_000)), None, None, wallet_id)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod when_internal_invoice_is_already_settled {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Invoice {
+                        wallet_id: Uuid::new_v4(),
+                        status: InvoiceStatus::Settled,
+                        ..Default::default()
+                    }))
+                });
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_bolt11(bolt11(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+                assert!(err.to_string().contains("already been paid"));
+            }
+        }
+
+        mod when_internal_invoice_is_expired {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store.invoice.expect_find_by_payment_hash().times(1).returning(|_| {
+                    Ok(Some(Invoice {
+                        wallet_id: Uuid::new_v4(),
+                        status: InvoiceStatus::Expired,
+                        ..Default::default()
+                    }))
+                });
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service
+                    .send_bolt11(bolt11(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+                assert!(err.to_string().contains("expired"));
+            }
+        }
+
+        mod when_invoice_is_external {
+            use super::*;
+
+            #[tokio::test]
+            async fn reserves_pays_and_settles() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .withf(|payment, fee_buffer| payment.ledger == Ledger::Lightning && *fee_buffer > 0.0)
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| payment.status == PaymentStatus::Settled)
+                    .times(1)
+                    .returning(Ok);
+
+                let mut ln_client = MockLnClient::new();
+                ln_client.expect_pay().times(1).returning(|_, _, _| {
+                    Ok(Payment {
+                        status: PaymentStatus::Settled,
+                        lightning: Some(LnPayment {
+                            payment_preimage: Some("preimage".to_string()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    })
+                });
+
+                let service = service(store, ln_client, MockBitcoinWallet::new(), MockEventUseCases::new());
+
+                let payment = service
+                    .send_bolt11(bolt11(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.status, PaymentStatus::Settled);
+            }
+        }
+
+        mod when_external_payment_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn marks_payment_failed_and_propagates() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .invoice
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .payment_uow
+                    .expect_insert_payment()
+                    .times(1)
+                    .returning(|payment, _| Ok(payment));
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| payment.status == PaymentStatus::Failed)
+                    .times(1)
+                    .returning(Ok);
+
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_pay()
+                    .times(1)
+                    .returning(|_, _, _| Err(LightningError::Pay("no route".to_string())));
+
+                let service = service(store, ln_client, MockBitcoinWallet::new(), MockEventUseCases::new());
+
+                let err = service
+                    .send_bolt11(bolt11(Some(1_000)), None, None, Uuid::new_v4())
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Lightning(_)));
+            }
+        }
+    }
+
+    mod handle_processed_payment {
+        use super::*;
+
+        mod when_payment_succeeds {
+            use super::*;
+
+            #[tokio::test]
+            async fn persists_a_settled_payment() {
+                let pending_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_update()
+                    .withf(move |payment| payment.id == pending_id && payment.status == PaymentStatus::Settled)
+                    .times(1)
+                    .returning(Ok);
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let pending = Payment {
+                    id: pending_id,
+                    status: PaymentStatus::Pending,
+                    ..Default::default()
+                };
+                let settled = Payment {
+                    status: PaymentStatus::Settled,
+                    ..Default::default()
+                };
+
+                let payment = service
+                    .handle_processed_payment(pending, Ok(settled), None)
+                    .await
+                    .unwrap();
+
+                assert_eq!(payment.status, PaymentStatus::Settled);
+            }
+        }
+
+        mod when_payment_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn persists_failure_and_returns_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_update()
+                    .withf(|payment| payment.status == PaymentStatus::Failed && payment.error.is_some())
+                    .times(1)
+                    .returning(Ok);
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let pending = Payment {
+                    status: PaymentStatus::Pending,
+                    ..Default::default()
+                };
+
+                let err = service
+                    .handle_processed_payment(pending, Err(LightningError::Pay("boom".to_string())), None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Lightning(_)));
+            }
+        }
+    }
+
+    mod get {
+        use super::*;
+
+        mod when_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service.get(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod delete {
+        use super::*;
+
+        mod when_nothing_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_delete_many().times(1).returning(|_| Ok(0));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service.delete(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod sync {
+        use super::*;
+
+        fn pending_lightning_payment() -> Payment {
+            Payment {
+                id: Uuid::new_v4(),
+                status: PaymentStatus::Pending,
+                ledger: Ledger::Lightning,
+                lightning: Some(LnPayment {
+                    payment_hash: "ph".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+        }
+
+        mod when_node_reports_settled {
+            use super::*;
+
+            #[tokio::test]
+            async fn dispatches_outgoing_payment_event() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_find_many()
+                    .times(1)
+                    .returning(|_| Ok(vec![pending_lightning_payment()]));
+
+                let mut ln_client = MockLnClient::new();
+                ln_client.expect_payment_by_hash().times(1).returning(|_| {
+                    Ok(Some(Payment {
+                        status: PaymentStatus::Settled,
+                        amount_msat: 1_000,
+                        fee_msat: Some(1),
+                        payment_time: Some(Utc::now()),
+                        lightning: Some(LnPayment {
+                            payment_preimage: Some("preimage".to_string()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }))
+                });
+
+                let mut events = MockEventUseCases::new();
+                events
+                    .expect_outgoing_payment()
+                    .withf(|event| event.payment_hash == "ph")
+                    .times(1)
+                    .returning(|_| Ok(()));
+
+                let service = service(store, ln_client, MockBitcoinWallet::new(), events);
+
+                assert_eq!(service.sync().await.unwrap(), 1);
+            }
+        }
+
+        mod when_lightning_metadata_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_inconsistency_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find_many().times(1).returning(|_| {
+                    Ok(vec![Payment {
+                        status: PaymentStatus::Pending,
+                        ledger: Ledger::Lightning,
+                        lightning: None,
+                        ..Default::default()
+                    }])
+                });
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                let err = service.sync().await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Inconsistency(_))));
+            }
+        }
+
+        mod when_there_are_no_pending_payments {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_zero() {
+                let mut store = MockAppStoreBuilder::new();
+                store.payment.expect_find_many().times(1).returning(|_| Ok(vec![]));
+
+                let service = service(
+                    store,
+                    MockLnClient::new(),
+                    MockBitcoinWallet::new(),
+                    MockEventUseCases::new(),
+                );
+
+                assert_eq!(service.sync().await.unwrap(), 0);
             }
         }
     }

--- a/src/domains/system/system_service.rs
+++ b/src/domains/system/system_service.rs
@@ -115,9 +115,19 @@ impl SystemUseCases for SystemService {
 mod tests {
     use std::sync::Arc;
 
-    use crate::{application::entities::MockAppStoreBuilder, infra::lightning::MockLnClient};
+    use crate::{
+        application::{
+            entities::MockAppStoreBuilder,
+            errors::{DatabaseError, LightningError},
+        },
+        infra::lightning::MockLnClient,
+    };
 
     use super::*;
+
+    fn service(store: MockAppStoreBuilder, ln_client: MockLnClient) -> SystemService {
+        SystemService::new(store.build(), Arc::new(ln_client))
+    }
 
     mod health_check {
         use super::*;
@@ -136,14 +146,219 @@ mod tests {
                     .times(1)
                     .returning(|| Ok(HealthStatus::Operational));
 
-                let service = SystemService::new(store.build(), Arc::new(ln_client));
-
-                let health = service.health_check().await;
+                let health = service(store, ln_client).health_check().await;
 
                 assert_eq!(health.database, HealthStatus::Operational);
                 assert_eq!(health.ln_provider, HealthStatus::Operational);
                 assert!(health.is_healthy);
             }
+        }
+
+        mod when_database_is_down {
+            use super::*;
+
+            #[tokio::test]
+            async fn reports_database_unavailable_and_unhealthy() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .health
+                    .expect_ping()
+                    .times(1)
+                    .returning(|| Err(DatabaseError::Ping("down".to_string())));
+
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_health()
+                    .times(1)
+                    .returning(|| Ok(HealthStatus::Operational));
+
+                let health = service(store, ln_client).health_check().await;
+
+                assert_eq!(health.database, HealthStatus::Unavailable);
+                assert_eq!(health.ln_provider, HealthStatus::Operational);
+                assert!(!health.is_healthy);
+            }
+        }
+
+        mod when_lightning_provider_is_down {
+            use super::*;
+
+            #[tokio::test]
+            async fn reports_provider_unavailable_and_unhealthy() {
+                let mut store = MockAppStoreBuilder::new();
+                store.health.expect_ping().times(1).returning(|| Ok(()));
+
+                let mut ln_client = MockLnClient::new();
+                ln_client
+                    .expect_health()
+                    .times(1)
+                    .returning(|| Err(LightningError::HealthCheck("down".to_string())));
+
+                let health = service(store, ln_client).health_check().await;
+
+                assert_eq!(health.database, HealthStatus::Operational);
+                assert_eq!(health.ln_provider, HealthStatus::Unavailable);
+                assert!(!health.is_healthy);
+            }
+        }
+    }
+
+    mod setup_check {
+        use super::*;
+
+        #[tokio::test]
+        async fn reports_completion_flags_from_config() {
+            let mut store = MockAppStoreBuilder::new();
+            // welcome_complete present, password_hash absent.
+            store.config.expect_find().times(2).returning(|key| {
+                if key == WELCOME_COMPLETE_KEY {
+                    Ok(Some(true.into()))
+                } else {
+                    Ok(None)
+                }
+            });
+
+            let service = service(store, MockLnClient::new());
+
+            let info = service.setup_check().await.unwrap();
+
+            assert!(info.welcome_complete);
+            assert!(!info.sign_up_complete);
+        }
+    }
+
+    mod mark_welcome_complete {
+        use super::*;
+
+        mod when_not_yet_completed {
+            use super::*;
+
+            #[tokio::test]
+            async fn inserts_the_flag() {
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(None));
+                store
+                    .config
+                    .expect_insert()
+                    .withf(|key, value| key == WELCOME_COMPLETE_KEY && value == &serde_json::Value::Bool(true))
+                    .times(1)
+                    .returning(|_, _| Ok(()));
+
+                let service = service(store, MockLnClient::new());
+
+                assert!(service.mark_welcome_complete().await.is_ok());
+            }
+        }
+
+        mod when_already_completed {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_idempotent_and_does_not_insert() {
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(Some(true.into())));
+                // insert is intentionally not expected.
+
+                let service = service(store, MockLnClient::new());
+
+                assert!(service.mark_welcome_complete().await.is_ok());
+            }
+        }
+    }
+
+    mod get_onchain_cursor {
+        use super::*;
+
+        mod when_present_and_valid {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_the_cursor() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(|_| Ok(Some(serde_json::to_value(OnchainSyncCursor::BlockHeight(42)).unwrap())));
+
+                let service = service(store, MockLnClient::new());
+
+                let cursor = service.get_onchain_cursor().await.unwrap();
+
+                assert_eq!(cursor, Some(OnchainSyncCursor::BlockHeight(42)));
+            }
+        }
+
+        mod when_absent {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_none() {
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = service(store, MockLnClient::new());
+
+                assert_eq!(service.get_onchain_cursor().await.unwrap(), None);
+            }
+        }
+
+        mod when_stored_value_is_malformed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_malformed_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(|_| Ok(Some(serde_json::Value::String("not a cursor".to_string()))));
+
+                let service = service(store, MockLnClient::new());
+
+                let err = service.get_onchain_cursor().await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Malformed(_))));
+            }
+        }
+    }
+
+    mod set_onchain_cursor {
+        use super::*;
+
+        #[tokio::test]
+        async fn upserts_the_serialized_cursor() {
+            let mut store = MockAppStoreBuilder::new();
+            store
+                .config
+                .expect_upsert()
+                .withf(|key, value| {
+                    key == ONCHAIN_CURSOR_KEY
+                        && *value == serde_json::to_value(OnchainSyncCursor::BlockHeight(7)).unwrap()
+                })
+                .times(1)
+                .returning(|_, _| Ok(()));
+
+            let service = service(store, MockLnClient::new());
+
+            assert!(service
+                .set_onchain_cursor(OnchainSyncCursor::BlockHeight(7))
+                .await
+                .is_ok());
+        }
+    }
+
+    mod version {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_cargo_package_version() {
+            let service = service(MockAppStoreBuilder::new(), MockLnClient::new());
+
+            let version = service.version();
+
+            assert_eq!(version.version, env!("CARGO_PKG_VERSION"));
         }
     }
 }

--- a/src/domains/user/api_key_handler.rs
+++ b/src/domains/user/api_key_handler.rs
@@ -186,3 +186,104 @@ async fn revoke_api_keys(
     let n_revoked = services.api_key.revoke_many(query_params).await?;
     Ok(n_revoked.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{application::entities::MockAppServicesBuilder, domains::user::ApiKey};
+
+    use super::*;
+
+    fn user(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    fn create_request() -> CreateApiKeyRequest {
+        CreateApiKeyRequest {
+            user_id: Some("alice".to_string()),
+            name: "primary".to_string(),
+            permissions: vec![Permission::ReadWallet],
+            description: None,
+            expiry: None,
+        }
+    }
+
+    mod create_api_key {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden_and_does_not_call_the_service() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = create_api_key(State(Arc::new(services)), user(vec![]), Json(create_request())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod with_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn delegates_to_the_service() {
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .api_key
+                    .expect_generate()
+                    .times(1)
+                    .returning(|_, _| Ok(ApiKey::default()));
+
+                let result = create_api_key(
+                    State(Arc::new(builder.build())),
+                    user(vec![Permission::WriteApiKey]),
+                    Json(create_request()),
+                )
+                .await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod get_api_key {
+        use super::*;
+
+        mod without_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = get_api_key(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+    }
+
+    mod revoke_api_key {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let err = revoke_api_key(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4()))
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Authorization(_)));
+            }
+        }
+    }
+}

--- a/src/domains/user/api_key_service.rs
+++ b/src/domains/user/api_key_service.rs
@@ -120,3 +120,249 @@ impl ApiKeyUseCases for ApiKeyService {
         Ok(n_deleted)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        application::{entities::MockAppStoreBuilder, errors::DatabaseError},
+        domains::user::Permission,
+    };
+
+    use super::*;
+
+    fn user_with(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    fn create_request(permissions: Vec<Permission>, expiry: Option<u32>) -> CreateApiKeyRequest {
+        CreateApiKeyRequest {
+            user_id: Some("alice".to_string()),
+            name: "primary".to_string(),
+            permissions,
+            description: None,
+            expiry,
+        }
+    }
+
+    mod generate {
+        use super::*;
+
+        mod with_permitted_permissions_and_no_expiry {
+            use super::*;
+
+            #[tokio::test]
+            async fn inserts_key_and_returns_plaintext_secret() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .api_key
+                    .expect_insert()
+                    .withf(|api_key| {
+                        api_key.user_id == "alice"
+                            && api_key.permissions == vec![Permission::ReadWallet]
+                            && api_key.expires_at.is_none()
+                            && !api_key.key_hash.is_empty()
+                    })
+                    .times(1)
+                    .returning(Ok);
+
+                let service = ApiKeyService::new(store.build());
+
+                let api_key = service
+                    .generate(
+                        user_with(vec![Permission::ReadWallet, Permission::WriteWallet]),
+                        create_request(vec![Permission::ReadWallet], None),
+                    )
+                    .await
+                    .unwrap();
+
+                // The plaintext secret is only attached on creation.
+                assert!(api_key.key.is_some());
+            }
+        }
+
+        mod with_expiry_within_the_limit {
+            use super::*;
+
+            #[tokio::test]
+            async fn sets_an_expiration() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .api_key
+                    .expect_insert()
+                    .withf(|api_key| api_key.expires_at.is_some())
+                    .times(1)
+                    .returning(Ok);
+
+                let service = ApiKeyService::new(store.build());
+
+                let api_key = service
+                    .generate(
+                        user_with(vec![Permission::ReadWallet]),
+                        create_request(vec![Permission::ReadWallet], Some(3_600)),
+                    )
+                    .await
+                    .unwrap();
+
+                assert!(api_key.expires_at.is_some());
+            }
+        }
+
+        mod with_permissions_beyond_the_user {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_with_validation_error() {
+                // No insert expected: the request must be rejected before persistence.
+                let service = ApiKeyService::new(MockAppStoreBuilder::new().build());
+
+                let err = service
+                    .generate(
+                        user_with(vec![Permission::ReadWallet]),
+                        create_request(vec![Permission::WriteWallet], None),
+                    )
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod with_expiry_beyond_the_limit {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_with_validation_error() {
+                let service = ApiKeyService::new(MockAppStoreBuilder::new().build());
+
+                let err = service
+                    .generate(
+                        user_with(vec![Permission::ReadWallet]),
+                        create_request(vec![Permission::ReadWallet], Some(MAX_ALLOWED_EXPIRY_SECONDS + 1)),
+                    )
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod when_insert_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn propagates_database_error() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .api_key
+                    .expect_insert()
+                    .times(1)
+                    .returning(|_| Err(DatabaseError::Insert("boom".to_string())));
+
+                let service = ApiKeyService::new(store.build());
+
+                let err = service
+                    .generate(
+                        user_with(vec![Permission::ReadWallet]),
+                        create_request(vec![Permission::ReadWallet], None),
+                    )
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Database(DatabaseError::Insert(_))));
+            }
+        }
+    }
+
+    mod get {
+        use super::*;
+
+        mod when_found {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_api_key() {
+                let id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_find().times(1).returning(move |id| {
+                    Ok(Some(ApiKey {
+                        id,
+                        ..Default::default()
+                    }))
+                });
+
+                let service = ApiKeyService::new(store.build());
+
+                assert_eq!(service.get(id).await.unwrap().id, id);
+            }
+        }
+
+        mod when_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = ApiKeyService::new(store.build());
+
+                let err = service.get(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod revoke {
+        use super::*;
+
+        mod when_a_key_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn succeeds() {
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_delete_many().times(1).returning(|_| Ok(1));
+
+                let service = ApiKeyService::new(store.build());
+
+                assert!(service.revoke(Uuid::new_v4()).await.is_ok());
+            }
+        }
+
+        mod when_nothing_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_delete_many().times(1).returning(|_| Ok(0));
+
+                let service = ApiKeyService::new(store.build());
+
+                let err = service.revoke(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod revoke_many {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_revoked_count() {
+            let mut store = MockAppStoreBuilder::new();
+            store.api_key.expect_delete_many().times(1).returning(|_| Ok(4));
+
+            let service = ApiKeyService::new(store.build());
+
+            assert_eq!(service.revoke_many(ApiKeyFilter::default()).await.unwrap(), 4);
+        }
+    }
+}

--- a/src/domains/user/auth_service.rs
+++ b/src/domains/user/auth_service.rs
@@ -149,3 +149,348 @@ impl AuthUseCases for AuthService {
         Ok(user)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::{
+        application::entities::MockAppStoreBuilder,
+        domains::{
+            user::{ApiKey, AuthClaims},
+            wallet::Wallet,
+        },
+        infra::jwt::MockJWTAuthenticator,
+    };
+
+    use super::*;
+
+    fn service(jwt: MockJWTAuthenticator, store: MockAppStoreBuilder, provider: AuthProvider) -> AuthService {
+        AuthService::new(Arc::new(jwt), store.build(), provider)
+    }
+
+    fn claims(sub: &str) -> AuthClaims {
+        AuthClaims {
+            exp: 0,
+            iat: 0,
+            sub: sub.to_string(),
+            permissions: vec![Permission::ReadWallet],
+        }
+    }
+
+    fn wallet_fixture(id: Uuid, user_id: &str) -> Wallet {
+        Wallet {
+            id,
+            user_id: user_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    mod sign_up {
+        use super::*;
+
+        mod when_provider_is_not_jwt {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_unsupported_operation() {
+                let service = service(
+                    MockJWTAuthenticator::new(),
+                    MockAppStoreBuilder::new(),
+                    AuthProvider::OAuth2,
+                );
+
+                let err = service.sign_up("password".to_string()).await.unwrap_err();
+
+                assert!(matches!(
+                    err,
+                    ApplicationError::Authentication(AuthenticationError::UnsupportedOperation)
+                ));
+            }
+        }
+
+        mod when_admin_already_exists {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_conflict() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(|_| Ok(Some("existing-hash".into())));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_up("password".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
+            }
+        }
+
+        mod when_first_admin {
+            use super::*;
+
+            #[tokio::test]
+            async fn persists_hash_and_returns_token() {
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(None));
+                store
+                    .config
+                    .expect_insert()
+                    .withf(|key, _| key == PASSWORD_HASH_KEY)
+                    .times(1)
+                    .returning(|_, _| Ok(()));
+
+                let mut jwt = MockJWTAuthenticator::new();
+                jwt.expect_encode().times(1).returning(|_, _| Ok("token".to_string()));
+
+                let service = service(jwt, store, AuthProvider::Jwt);
+
+                let token = service.sign_up("password".to_string()).await.unwrap();
+
+                assert_eq!(token, "token");
+            }
+        }
+    }
+
+    mod sign_in {
+        use super::*;
+
+        mod when_credentials_are_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_in("password".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+
+        mod with_a_wrong_password {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_invalid_credentials() {
+                let stored_hash = hash("correct", 4).unwrap();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(move |_| Ok(Some(stored_hash.clone().into())));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_in("wrong".to_string()).await.unwrap_err();
+
+                assert!(matches!(
+                    err,
+                    ApplicationError::Authentication(AuthenticationError::InvalidCredentials)
+                ));
+            }
+        }
+
+        mod with_the_correct_password {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_token() {
+                let stored_hash = hash("correct", 4).unwrap();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(move |_| Ok(Some(stored_hash.clone().into())));
+
+                let mut jwt = MockJWTAuthenticator::new();
+                jwt.expect_encode().times(1).returning(|_, _| Ok("token".to_string()));
+
+                let service = service(jwt, store, AuthProvider::Jwt);
+
+                let token = service.sign_in("correct".to_string()).await.unwrap();
+
+                assert_eq!(token, "token");
+            }
+        }
+
+        mod when_stored_hash_is_not_a_string {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_inconsistency() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(|_| Ok(Some(serde_json::json!(42))));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_in("password".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Inconsistency(_))));
+            }
+        }
+    }
+
+    mod authenticate_jwt {
+        use super::*;
+
+        mod when_wallet_exists {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_user_for_existing_wallet() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut jwt = MockJWTAuthenticator::new();
+                jwt.expect_decode().times(1).returning(|_| Ok(claims("alice")));
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .wallet
+                    .expect_find_by_user_id()
+                    .withf(|user_id| user_id == "alice")
+                    .times(1)
+                    .returning(move |user_id| Ok(Some(wallet_fixture(wallet_id, user_id))));
+
+                let service = service(jwt, store, AuthProvider::Jwt);
+
+                let user = service.authenticate_jwt("token").await.unwrap();
+
+                assert_eq!(user.id, "alice");
+                assert_eq!(user.wallet_id, wallet_id);
+            }
+        }
+
+        mod when_wallet_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn provisions_a_wallet_on_first_login() {
+                let mut jwt = MockJWTAuthenticator::new();
+                jwt.expect_decode().times(1).returning(|_| Ok(claims("alice")));
+
+                let mut store = MockAppStoreBuilder::new();
+                store.wallet.expect_find_by_user_id().times(1).returning(|_| Ok(None));
+                store
+                    .wallet
+                    .expect_insert()
+                    .withf(|user_id| user_id == "alice")
+                    .times(1)
+                    .returning(|user_id| Ok(wallet_fixture(Uuid::new_v4(), user_id)));
+
+                let service = service(jwt, store, AuthProvider::Jwt);
+
+                let user = service.authenticate_jwt("token").await.unwrap();
+
+                assert_eq!(user.id, "alice");
+            }
+        }
+
+        mod when_token_is_invalid {
+            use super::*;
+
+            #[tokio::test]
+            async fn propagates_authentication_error() {
+                let mut jwt = MockJWTAuthenticator::new();
+                jwt.expect_decode()
+                    .times(1)
+                    .returning(|_| Err(AuthenticationError::InvalidCredentials));
+
+                let service = service(jwt, MockAppStoreBuilder::new(), AuthProvider::Jwt);
+
+                let err = service.authenticate_jwt("token").await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Authentication(_)));
+            }
+        }
+    }
+
+    mod authenticate_api_key {
+        use super::*;
+
+        mod when_key_is_unknown {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_invalid_credentials() {
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_find_by_key_hash().times(1).returning(|_| Ok(None));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.authenticate_api_key(vec![1, 2, 3]).await.unwrap_err();
+
+                assert!(matches!(
+                    err,
+                    ApplicationError::Authentication(AuthenticationError::InvalidCredentials)
+                ));
+            }
+        }
+
+        mod when_key_and_wallet_exist {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_user_with_api_key_permissions() {
+                let wallet_id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_find_by_key_hash().times(1).returning(|_| {
+                    Ok(Some(ApiKey {
+                        user_id: "alice".to_string(),
+                        permissions: vec![Permission::ReadWallet],
+                        ..Default::default()
+                    }))
+                });
+                store
+                    .wallet
+                    .expect_find_by_user_id()
+                    .times(1)
+                    .returning(move |user_id| Ok(Some(wallet_fixture(wallet_id, user_id))));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let user = service.authenticate_api_key(vec![1, 2, 3]).await.unwrap();
+
+                assert_eq!(user.wallet_id, wallet_id);
+                assert_eq!(user.permissions, vec![Permission::ReadWallet]);
+            }
+        }
+
+        mod when_key_exists_without_wallet {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_inconsistency() {
+                let mut store = MockAppStoreBuilder::new();
+                store.api_key.expect_find_by_key_hash().times(1).returning(|_| {
+                    Ok(Some(ApiKey {
+                        user_id: "alice".to_string(),
+                        ..Default::default()
+                    }))
+                });
+                store.wallet.expect_find_by_user_id().times(1).returning(|_| Ok(None));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.authenticate_api_key(vec![1, 2, 3]).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Inconsistency(_))));
+            }
+        }
+    }
+}

--- a/src/domains/wallet/user_wallet_handler.rs
+++ b/src/domains/wallet/user_wallet_handler.rs
@@ -717,3 +717,143 @@ async fn revoke_wallet_api_keys(
     let n_revoked = services.api_key.revoke_many(filter).await?;
     Ok(n_revoked.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::{
+        application::entities::MockAppServicesBuilder,
+        domains::{
+            bitcoin::{BtcAddress, BtcAddressType},
+            payment::Payment,
+            wallet::Wallet,
+        },
+    };
+
+    use super::*;
+
+    // The /v1/me endpoints take no permission gate; instead every call must be
+    // scoped to the authenticated user's wallet. These tests lock that invariant.
+    fn user() -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions: vec![],
+        }
+    }
+
+    fn btc_address(wallet_id: Uuid) -> BtcAddress {
+        BtcAddress {
+            id: Uuid::new_v4(),
+            wallet_id,
+            address: "bcrt1qexample".to_string(),
+            used: false,
+            address_type: BtcAddressType::P2wpkh,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    mod get_user_wallet {
+        use super::*;
+
+        #[tokio::test]
+        async fn fetches_the_authenticated_users_wallet() {
+            let caller = user();
+            let wallet_id = caller.wallet_id;
+
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .wallet
+                .expect_get()
+                .withf(move |id| *id == wallet_id)
+                .times(1)
+                .returning(|_| Ok(Wallet::default()));
+
+            let result = get_user_wallet(State(Arc::new(builder.build())), caller).await;
+
+            assert!(result.is_ok());
+        }
+    }
+
+    mod wallet_pay {
+        use super::*;
+
+        #[tokio::test]
+        async fn ignores_payload_wallet_id_and_uses_the_authenticated_user() {
+            let caller = user();
+            let own_wallet = caller.wallet_id;
+            let attacker_wallet = Uuid::new_v4();
+
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .payment
+                .expect_pay()
+                // Anti-IDOR: must use the caller's wallet, never the one in the body.
+                .withf(move |_, _, _, wallet_id| *wallet_id == own_wallet)
+                .times(1)
+                .returning(|_, _, _, _| Ok(Payment::default()));
+
+            let payload = SendPaymentRequest {
+                wallet_id: Some(attacker_wallet),
+                input: "bob@numeraire.tech".to_string(),
+                amount_msat: Some(1_000),
+                comment: None,
+            };
+
+            let result = wallet_pay(State(Arc::new(builder.build())), caller, Json(payload)).await;
+
+            assert!(result.is_ok());
+        }
+    }
+
+    mod new_wallet_btc_address {
+        use super::*;
+
+        #[tokio::test]
+        async fn scopes_address_derivation_to_the_authenticated_user() {
+            let caller = user();
+            let wallet_id = caller.wallet_id;
+
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .bitcoin
+                .expect_new_deposit_address()
+                .withf(move |id, _| *id == wallet_id)
+                .times(1)
+                .returning(|id, _| Ok(btc_address(id)));
+
+            let payload = NewBtcAddressRequest {
+                wallet_id: Some(Uuid::new_v4()),
+                address_type: None,
+            };
+
+            let result = new_wallet_btc_address(State(Arc::new(builder.build())), caller, Json(payload)).await;
+
+            assert!(result.is_ok());
+        }
+    }
+
+    mod get_wallet_address {
+        use super::*;
+
+        #[tokio::test]
+        async fn lists_only_the_authenticated_users_addresses() {
+            let caller = user();
+            let wallet_id = caller.wallet_id;
+
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .ln_address
+                .expect_list()
+                .withf(move |filter| filter.wallet_id == Some(wallet_id))
+                .times(1)
+                .returning(|_| Ok(vec![]));
+
+            let result = get_wallet_address(State(Arc::new(builder.build())), caller).await;
+
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/src/domains/wallet/wallet_service.rs
+++ b/src/domains/wallet/wallet_service.rs
@@ -127,3 +127,258 @@ impl WalletUseCases for WalletService {
         Ok(n_deleted)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::application::{entities::MockAppStoreBuilder, errors::DatabaseError};
+
+    use super::*;
+
+    fn wallet_fixture(id: Uuid, user_id: &str) -> Wallet {
+        Wallet {
+            id,
+            user_id: user_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    mod register {
+        use super::*;
+
+        mod with_a_valid_new_user_id {
+            use super::*;
+
+            #[tokio::test]
+            async fn inserts_and_returns_wallet() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .wallet
+                    .expect_find_by_user_id()
+                    .withf(|user_id| user_id == "alice")
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .wallet
+                    .expect_insert()
+                    .withf(|user_id| user_id == "alice")
+                    .times(1)
+                    .returning(|user_id| Ok(wallet_fixture(Uuid::new_v4(), user_id)));
+
+                let service = WalletService::new(store.build());
+
+                let wallet = service.register("alice".to_string()).await.unwrap();
+
+                assert_eq!(wallet.user_id, "alice");
+            }
+        }
+
+        mod with_an_invalid_length {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_empty_user_id() {
+                let service = WalletService::new(MockAppStoreBuilder::new().build());
+
+                let err = service.register(String::new()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+
+            #[tokio::test]
+            async fn rejects_too_long_user_id() {
+                let service = WalletService::new(MockAppStoreBuilder::new().build());
+
+                let err = service.register("a".repeat(MAX_USER_LENGTH + 1)).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+            }
+        }
+
+        mod with_an_invalid_format {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_disallowed_characters() {
+                let service = WalletService::new(MockAppStoreBuilder::new().build());
+
+                let err = service.register("alice bob".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+                assert!(err.to_string().contains("Invalid user_id format"));
+            }
+        }
+
+        mod when_user_id_already_exists {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_conflict() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .wallet
+                    .expect_find_by_user_id()
+                    .times(1)
+                    .returning(|user_id| Ok(Some(wallet_fixture(Uuid::new_v4(), user_id))));
+
+                let service = WalletService::new(store.build());
+
+                let err = service.register("alice".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
+            }
+        }
+    }
+
+    mod get {
+        use super::*;
+
+        mod when_found {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_wallet() {
+                let id = Uuid::new_v4();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .wallet
+                    .expect_find()
+                    .withf(move |queried| *queried == id)
+                    .times(1)
+                    .returning(|id| Ok(Some(wallet_fixture(id, "alice"))));
+
+                let service = WalletService::new(store.build());
+
+                assert_eq!(service.get(id).await.unwrap().id, id);
+            }
+        }
+
+        mod when_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.wallet.expect_find().times(1).returning(|_| Ok(None));
+
+                let service = WalletService::new(store.build());
+
+                let err = service.get(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+
+    mod get_balance {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_balance_from_the_repository() {
+            let id = Uuid::new_v4();
+
+            let mut store = MockAppStoreBuilder::new();
+            store
+                .wallet
+                .expect_get_balance()
+                .withf(move |queried| *queried == id)
+                .times(1)
+                .returning(|_| {
+                    Ok(Balance {
+                        available_msat: 5_000,
+                        ..Default::default()
+                    })
+                });
+
+            let service = WalletService::new(store.build());
+
+            assert_eq!(service.get_balance(id).await.unwrap().available_msat, 5_000);
+        }
+
+        #[tokio::test]
+        async fn propagates_database_error() {
+            let mut store = MockAppStoreBuilder::new();
+            store
+                .wallet
+                .expect_get_balance()
+                .times(1)
+                .returning(|_| Err(DatabaseError::FindOne("boom".to_string())));
+
+            let service = WalletService::new(store.build());
+
+            let err = service.get_balance(Uuid::new_v4()).await.unwrap_err();
+
+            assert!(matches!(err, ApplicationError::Database(DatabaseError::FindOne(_))));
+        }
+    }
+
+    mod list_overviews {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_overviews() {
+            let mut store = MockAppStoreBuilder::new();
+            store
+                .wallet
+                .expect_find_many_overview()
+                .times(1)
+                .returning(|| Ok(vec![WalletOverview::default()]));
+
+            let service = WalletService::new(store.build());
+
+            assert_eq!(service.list_overviews().await.unwrap().len(), 1);
+        }
+    }
+
+    mod list_contacts {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_contacts() {
+            let mut store = MockAppStoreBuilder::new();
+            store
+                .wallet
+                .expect_find_contacts()
+                .times(1)
+                .returning(|_| Ok(vec![Contact::default()]));
+
+            let service = WalletService::new(store.build());
+
+            assert_eq!(service.list_contacts(Uuid::new_v4()).await.unwrap().len(), 1);
+        }
+    }
+
+    mod delete {
+        use super::*;
+
+        mod when_a_row_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn succeeds() {
+                let mut store = MockAppStoreBuilder::new();
+                store.wallet.expect_delete_many().times(1).returning(|_| Ok(1));
+
+                let service = WalletService::new(store.build());
+
+                assert!(service.delete(Uuid::new_v4()).await.is_ok());
+            }
+        }
+
+        mod when_nothing_is_removed {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_not_found() {
+                let mut store = MockAppStoreBuilder::new();
+                store.wallet.expect_delete_many().times(1).returning(|_| Ok(0));
+
+                let service = WalletService::new(store.build());
+
+                let err = service.delete(Uuid::new_v4()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **issue #15** (backend unit tests), unblocked by the [`AppStore` trait-container + Unit-of-Work refactor](docs/adr/0001-appstore-uow-wallet-reservations.md) (ADR 0001, landed in #243/#244) and the generated `mockall` mocks (#234).

Now that `AppStore` is a pure trait container with a `#[cfg(test)] MockAppStoreBuilder`, every service is unit-testable with generated mocks and no real database, Lightning, or Bitcoin node. This PR adds **124 service unit tests** (19 → 143 total) plus a coverage component.

All tests follow the nested `describe`/`it`-style module convention from `docs/DEVELOPER_GUIDELINES.md` (`mod method { mod when_context { fn behavior } }`) and assert service **policy + dependency interactions** via `mockall` expectations.

## What's covered

| Service | Highlights |
| --- | --- |
| `payment` | internal vs external routing, `send_internal`/`send_bitcoin`/`send_bolt11` validation & settlement, external **reserve → sign**, **release-on-failure** rollback paths, `handle_processed_payment`, `sync` dispatch & inconsistency |
| `event` | idempotent incoming/outgoing/failed payment projection, on-chain deposit/withdrawal credit branches |
| `auth` | provider gating, sign-up conflict/first-admin, credential verification, JWT auth w/ lazy wallet provisioning, API-key auth ownership/consistency |
| `ln_address` | register validation/conflict, get/update/delete, unchanged-username skip |
| `wallet` | register validation/conflict, balance + CRUD propagation |
| `api_key` | permission-subset & expiry validation, secret attachment, CRUD |
| `invoice` | generate, error propagation, node-settlement `sync` |
| `bitcoin` | deposit-address reuse vs derivation, `sync` with/without cursor |
| `lnurl` | `lnurlp` metadata, active/inactive gating, callback issuance |
| `system` | `health_check` degraded paths, setup/welcome/cursor flows |
| `nostr` | `get_pubkey` enablement/not-found branches |

The payment-critical accounting flows the ADR cares about (reserve/settle/release, internal ledger moves, idempotent credits) are exercised against the `PaymentUnitOfWork` and `EventUseCases` seams.

## Coverage

Adds `cargo-llvm-cov` (`make coverage` / `coverage-html` / `coverage-lcov`, wired into `make install-tools`), documented in the developer guidelines.

Baseline for the **service layer** targeted here:

```
domains/event/event_service.rs          100.00%
domains/ln_address/ln_address_service.rs 100.00%
domains/nostr/nostr_service.rs          100.00%
domains/system/system_service.rs         99.49%
domains/user/auth_service.rs             99.22%
domains/lnurl/lnurl_service.rs           99.33%
domains/user/api_key_service.rs          98.85%
domains/bitcoin/bitcoin_service.rs       98.00%
domains/wallet/wallet_service.rs         97.91%
domains/invoice/invoice_service.rs       97.88%
domains/payment/payment_service.rs       94.90%
```

Global line coverage is ~41% because `infra/` (SeaORM repositories, CLN/LND clients & listeners) is the majority of the codebase and is **intentionally** left to integration tests per the testing strategy in the ADR and developer guidelines — not unit-tested with mocks.

## Test plan

- `make fmt` ✅
- `make lint` (clippy `--all-targets -D warnings`) ✅ — 0 warnings
- `make test` ✅ — **143 passed; 0 failed**
- `make coverage` ✅

## Notes

- No production code changed — tests only, plus the coverage tooling and docs.
- Out of scope (future ADR steps): the asset-scoped balance/reservation schema (#237), the full `PaymentUnitOfWork` reserve/settle/fail API (#239), and DB-backed concurrency integration tests (#240).