### PR TITLE
test: add unit tests for remaining handlers and pure parsers

### DIFF
--- a/src/domains/bitcoin/bitcoin_address_handler.rs
+++ b/src/domains/bitcoin/bitcoin_address_handler.rs
@@ -190,3 +190,98 @@ async fn delete_btc_addresses(
     let n_deleted = services.bitcoin.delete_many_addresses(query_params).await?;
     Ok(n_deleted.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::{application::entities::MockAppServicesBuilder, domains::bitcoin::BtcAddress};
+
+    use super::*;
+
+    fn user(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    fn btc_address(wallet_id: Uuid) -> BtcAddress {
+        BtcAddress {
+            id: Uuid::new_v4(),
+            wallet_id,
+            address: "bcrt1qexample".to_string(),
+            used: false,
+            address_type: BtcAddressType::P2wpkh,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    mod generate_btc_address {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden_and_does_not_call_the_service() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let payload = NewBtcAddressRequest {
+                    wallet_id: None,
+                    address_type: None,
+                };
+
+                let result = generate_btc_address(State(Arc::new(services)), user(vec![]), Json(payload)).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod when_wallet_id_is_omitted {
+            use super::*;
+
+            #[tokio::test]
+            async fn defaults_to_the_authenticated_users_wallet() {
+                let caller = user(vec![Permission::WriteBtcAddress]);
+                let expected_wallet = caller.wallet_id;
+
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .bitcoin
+                    .expect_new_deposit_address()
+                    .withf(move |wallet_id, _| *wallet_id == expected_wallet)
+                    .times(1)
+                    .returning(|wallet_id, _| Ok(btc_address(wallet_id)));
+
+                let payload = NewBtcAddressRequest {
+                    wallet_id: None,
+                    address_type: None,
+                };
+
+                let result = generate_btc_address(State(Arc::new(builder.build())), caller, Json(payload)).await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod get_btc_address {
+        use super::*;
+
+        mod without_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = get_btc_address(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+    }
+}

--- a/src/domains/invoice/invoice_handler.rs
+++ b/src/domains/invoice/invoice_handler.rs
@@ -200,3 +200,89 @@ async fn delete_invoices(
     let n_deleted = services.invoice.delete_many(query_params).await?;
     Ok(n_deleted.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{application::entities::MockAppServicesBuilder, domains::invoice::Invoice};
+
+    use super::*;
+
+    fn user(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    fn new_invoice_request(wallet_id: Option<Uuid>) -> NewInvoiceRequest {
+        NewInvoiceRequest {
+            wallet_id,
+            amount_msat: 1_000,
+            description: None,
+            expiry: None,
+        }
+    }
+
+    mod generate_invoice {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden_and_does_not_call_the_service() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result =
+                    generate_invoice(State(Arc::new(services)), user(vec![]), Json(new_invoice_request(None))).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod when_wallet_id_is_omitted {
+            use super::*;
+
+            #[tokio::test]
+            async fn defaults_to_the_authenticated_users_wallet() {
+                let caller = user(vec![Permission::WriteLnTransaction]);
+                let expected_wallet = caller.wallet_id;
+
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .invoice
+                    .expect_invoice()
+                    .withf(move |wallet_id, _, _, _| *wallet_id == expected_wallet)
+                    .times(1)
+                    .returning(|_, _, _, _| Ok(Invoice::default()));
+
+                let result = generate_invoice(
+                    State(Arc::new(builder.build())),
+                    caller,
+                    Json(new_invoice_request(None)),
+                )
+                .await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod get_invoice {
+        use super::*;
+
+        mod without_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = get_invoice(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+    }
+}

--- a/src/domains/ln_address/ln_address_handler.rs
+++ b/src/domains/ln_address/ln_address_handler.rs
@@ -228,3 +228,100 @@ async fn delete_addresses(
     let n_deleted = services.ln_address.delete_many(query_params).await?;
     Ok(n_deleted.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use crate::application::{dtos::RegisterLnAddressRequest, entities::MockAppServicesBuilder};
+
+    use super::*;
+
+    fn user(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    fn ln_address(wallet_id: Uuid) -> LnAddress {
+        LnAddress {
+            id: Uuid::new_v4(),
+            wallet_id,
+            username: "alice".to_string(),
+            active: true,
+            allows_nostr: false,
+            nostr_pubkey: None,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    fn register_request(wallet_id: Option<Uuid>) -> RegisterLnAddressRequest {
+        RegisterLnAddressRequest {
+            wallet_id,
+            username: "alice".to_string(),
+            allows_nostr: false,
+            nostr_pubkey: None,
+        }
+    }
+
+    mod register_address {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden_and_does_not_call_the_service() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result =
+                    register_address(State(Arc::new(services)), user(vec![]), Json(register_request(None))).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod when_wallet_id_is_omitted {
+            use super::*;
+
+            #[tokio::test]
+            async fn defaults_to_the_authenticated_users_wallet() {
+                let caller = user(vec![Permission::WriteLnAddress]);
+                let expected_wallet = caller.wallet_id;
+
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .ln_address
+                    .expect_register()
+                    .withf(move |wallet_id, _, _, _| *wallet_id == expected_wallet)
+                    .times(1)
+                    .returning(|wallet_id, _, _, _| Ok(ln_address(wallet_id)));
+
+                let result =
+                    register_address(State(Arc::new(builder.build())), caller, Json(register_request(None))).await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod get_address {
+        use super::*;
+
+        mod without_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = get_address(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+    }
+}

--- a/src/domains/lnurl/lnurl_handler.rs
+++ b/src/domains/lnurl/lnurl_handler.rs
@@ -79,3 +79,58 @@ async fn callback(
         .await?;
     Ok(Json(callback.into()))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::application::{entities::MockAppServicesBuilder, errors::DataError};
+
+    use super::*;
+
+    mod well_known {
+        use super::*;
+
+        #[tokio::test]
+        async fn forwards_the_username_and_propagates_not_found() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .lnurl
+                .expect_lnurlp()
+                .withf(|username| username == "alice")
+                .times(1)
+                .returning(|_| Err(DataError::NotFound("missing".to_string()).into()));
+
+            let result = well_known(Path("alice".to_string()), State(Arc::new(builder.build()))).await;
+
+            assert!(matches!(result, Err(ApplicationError::Data(DataError::NotFound(_)))));
+        }
+    }
+
+    mod callback {
+        use super::*;
+
+        #[tokio::test]
+        async fn forwards_amount_and_comment_to_the_service() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .lnurl
+                .expect_lnurlp_callback()
+                .withf(|username, amount, comment| {
+                    username == "alice" && *amount == 2_000 && comment.as_deref() == Some("thanks")
+                })
+                .times(1)
+                .returning(|_, _, _| Err(DataError::NotFound("missing".to_string()).into()));
+
+            let result = callback(
+                Path("alice".to_string()),
+                Query(LNUrlpInvoiceQueryParams {
+                    amount: 2_000,
+                    comment: Some("thanks".to_string()),
+                }),
+                State(Arc::new(builder.build())),
+            )
+            .await;
+
+            assert!(matches!(result, Err(ApplicationError::Data(DataError::NotFound(_)))));
+        }
+    }
+}

--- a/src/domains/lnurl/utils.rs
+++ b/src/domains/lnurl/utils.rs
@@ -299,4 +299,134 @@ mod tests {
         let err = parse_lnurl_pay_invoice_response(r#"{"status":"ERROR","reason":"bad comment"}"#).unwrap_err();
         assert!(err.to_string().contains("bad comment"));
     }
+
+    // A 24-character string is the expected length of a base64-encoded 16-byte IV.
+    const VALID_IV: &str = "123456789012345678901234";
+
+    fn aes_params(iv: &str) -> LnurlAesParams {
+        LnurlAesParams {
+            description: "description".to_string(),
+            ciphertext: "ciphertext".to_string(),
+            iv: iv.to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_aes_success_action_accepts_valid_params() {
+        assert!(validate_aes_success_action(&aes_params(VALID_IV)).is_ok());
+    }
+
+    #[test]
+    fn validate_aes_success_action_rejects_wrong_iv_length() {
+        let err = validate_aes_success_action(&aes_params("tooshort")).unwrap_err();
+        assert!(err.to_string().contains("IV"));
+    }
+
+    #[test]
+    fn validate_aes_success_action_rejects_oversized_ciphertext() {
+        let mut params = aes_params(VALID_IV);
+        params.ciphertext = "a".repeat(4097);
+
+        let err = validate_aes_success_action(&params).unwrap_err();
+        assert!(err.to_string().contains("ciphertext"));
+    }
+
+    #[test]
+    fn validate_success_action_url_accepts_matching_domain() {
+        let action = Url::parse("https://example.com/success").unwrap();
+        assert!(validate_success_action_url("https://example.com/callback", &action).is_ok());
+    }
+
+    #[test]
+    fn validate_success_action_url_rejects_cross_domain() {
+        let action = Url::parse("https://evil.com/success").unwrap();
+        let err = validate_success_action_url("https://example.com/callback", &action).unwrap_err();
+        assert!(err.to_string().contains("different domain"));
+    }
+
+    #[test]
+    fn convert_success_action_maps_message() {
+        match convert_success_action(
+            LnurlSuccessAction::Message("thanks".to_string()),
+            "https://example.com/cb",
+        )
+        .unwrap()
+        {
+            LnUrlPaySuccessAction::Message { message } => assert_eq!(message, "thanks"),
+            other => panic!("expected message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_success_action_rejects_overlong_message() {
+        let action = LnurlSuccessAction::Message("a".repeat(145));
+        assert!(convert_success_action(action, "https://example.com/cb").is_err());
+    }
+
+    #[test]
+    fn convert_success_action_maps_matching_url() {
+        let action = LnurlSuccessAction::Url {
+            url: Url::parse("https://example.com/x").unwrap(),
+            description: "description".to_string(),
+        };
+
+        let result = convert_success_action(action, "https://example.com/cb").unwrap();
+
+        assert!(matches!(result, LnUrlPaySuccessAction::Url { .. }));
+    }
+
+    #[test]
+    fn convert_success_action_rejects_cross_domain_url() {
+        let action = LnurlSuccessAction::Url {
+            url: Url::parse("https://evil.com/x").unwrap(),
+            description: "description".to_string(),
+        };
+
+        assert!(convert_success_action(action, "https://example.com/cb").is_err());
+    }
+
+    #[test]
+    fn process_success_action_maps_message() {
+        let action = process_success_action(
+            LnUrlPaySuccessAction::Message {
+                message: "hi".to_string(),
+            },
+            "preimage",
+        )
+        .unwrap();
+
+        assert_eq!(action.tag, "message");
+        assert_eq!(action.message.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn process_success_action_maps_url() {
+        let action = process_success_action(
+            LnUrlPaySuccessAction::Url {
+                description: "description".to_string(),
+                url: "https://example.com".to_string(),
+            },
+            "preimage",
+        )
+        .unwrap();
+
+        assert_eq!(action.tag, "url");
+        assert_eq!(action.url.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn process_success_action_returns_none_for_aes_with_invalid_preimage() {
+        let action = LnUrlPaySuccessAction::Aes {
+            description: "description".to_string(),
+            ciphertext: "ciphertext".to_string(),
+            iv: "iv".to_string(),
+        };
+
+        assert!(process_success_action(action, "not-a-valid-preimage").is_none());
+    }
+
+    #[test]
+    fn decrypt_success_action_returns_none_for_invalid_preimage() {
+        assert!(decrypt_success_action("ciphertext".to_string(), "iv".to_string(), "not-hex").is_none());
+    }
 }

--- a/src/domains/nostr/nostr_handler.rs
+++ b/src/domains/nostr/nostr_handler.rs
@@ -45,3 +45,54 @@ pub async fn well_known_nostr(
     let pubkey = services.nostr.get_pubkey(query_params.name.clone()).await?;
     Ok(NostrNIP05Response::new(query_params.name, pubkey).into())
 }
+
+#[cfg(test)]
+mod tests {
+    use nostr_sdk::PublicKey;
+
+    use crate::application::{entities::MockAppServicesBuilder, errors::DataError};
+
+    use super::*;
+
+    // Generator point x-coordinate: a valid x-only (Schnorr) public key.
+    const VALID_PUBKEY_HEX: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    fn query(name: &str) -> NostrNIP05QueryParams {
+        NostrNIP05QueryParams { name: name.to_string() }
+    }
+
+    mod well_known_nostr {
+        use super::*;
+
+        #[tokio::test]
+        async fn forwards_the_name_and_returns_the_pubkey() {
+            let pubkey = PublicKey::from_hex(VALID_PUBKEY_HEX).unwrap();
+
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .nostr
+                .expect_get_pubkey()
+                .withf(|name| name == "alice")
+                .times(1)
+                .returning(move |_| Ok(pubkey));
+
+            let result = well_known_nostr(Query(query("alice")), State(Arc::new(builder.build()))).await;
+
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn propagates_not_found() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .nostr
+                .expect_get_pubkey()
+                .times(1)
+                .returning(|_| Err(DataError::NotFound("missing".to_string()).into()));
+
+            let result = well_known_nostr(Query(query("alice")), State(Arc::new(builder.build()))).await;
+
+            assert!(matches!(result, Err(ApplicationError::Data(DataError::NotFound(_)))));
+        }
+    }
+}

--- a/src/domains/payment/payment_input.rs
+++ b/src/domains/payment/payment_input.rs
@@ -328,4 +328,76 @@ mod tests {
         assert_eq!(data.amount_sat, Some(123));
         assert_eq!(data.message, Some("hello there".to_string()));
     }
+
+    #[test]
+    fn currency_from_bolt11_maps_every_network() {
+        assert_eq!(currency_from_bolt11(Bolt11Currency::Bitcoin), Currency::Bitcoin);
+        assert_eq!(
+            currency_from_bolt11(Bolt11Currency::BitcoinTestnet),
+            Currency::BitcoinTestnet
+        );
+        assert_eq!(currency_from_bolt11(Bolt11Currency::Regtest), Currency::Regtest);
+        assert_eq!(currency_from_bolt11(Bolt11Currency::Simnet), Currency::Simnet);
+        assert_eq!(currency_from_bolt11(Bolt11Currency::Signet), Currency::Signet);
+    }
+
+    #[test]
+    fn looks_like_lnurl_detects_lnurl_http_and_lightning_addresses() {
+        assert!(looks_like_lnurl("lnurl1example"));
+        assert!(looks_like_lnurl("LIGHTNING:lnurl1example"));
+        assert!(looks_like_lnurl("http://example.com/lnurlp/alice"));
+        assert!(looks_like_lnurl("https://example.com/lnurlp/alice"));
+        assert!(looks_like_lnurl("alice@example.com"));
+    }
+
+    #[test]
+    fn looks_like_lnurl_rejects_plain_text_and_addresses() {
+        assert!(!looks_like_lnurl("hello there"));
+        assert!(!looks_like_lnurl(MAINNET_ADDRESS));
+        assert!(!looks_like_lnurl(""));
+    }
+
+    #[test]
+    fn lnurl_endpoint_resolves_a_lightning_address() {
+        let (url, ln_address) = lnurl_endpoint("alice@example.com").unwrap();
+
+        assert!(url.contains("example.com"));
+        assert!(url.contains("alice"));
+        assert_eq!(ln_address, Some("alice@example.com".to_string()));
+    }
+
+    #[test]
+    fn lnurl_endpoint_accepts_a_raw_https_url() {
+        let (url, ln_address) = lnurl_endpoint("https://example.com/.well-known/lnurlp/alice").unwrap();
+
+        assert_eq!(url, "https://example.com/.well-known/lnurlp/alice");
+        assert_eq!(ln_address, None);
+    }
+
+    #[test]
+    fn lnurl_endpoint_rejects_unsupported_scheme() {
+        assert!(lnurl_endpoint("ftp://example.com/lnurlp/alice").is_err());
+    }
+
+    #[tokio::test]
+    async fn parse_payment_input_rejects_empty_input() {
+        let err = parse_payment_input("   ").await.unwrap_err();
+        assert!(err.contains("cannot be empty"));
+    }
+
+    #[tokio::test]
+    async fn parse_payment_input_detects_a_bitcoin_address() {
+        let PaymentInput::BitcoinAddress(data) = parse_payment_input(MAINNET_ADDRESS).await.unwrap() else {
+            panic!("expected bitcoin address payment input");
+        };
+        assert_eq!(data.network, BtcNetwork::Bitcoin);
+    }
+
+    #[tokio::test]
+    async fn parse_payment_input_rejects_unsupported_input() {
+        // Spaces ensure this is neither a bolt11, a bitcoin address, nor a
+        // lightning address, so no network resolution is attempted.
+        let err = parse_payment_input("*** not a payment ***").await.unwrap_err();
+        assert!(err.contains("Unsupported payment input"));
+    }
 }

--- a/src/domains/system/system_handler.rs
+++ b/src/domains/system/system_handler.rs
@@ -131,3 +131,42 @@ async fn mark_welcome_complete(
     services.system.mark_welcome_complete().await?;
     Ok(StatusCode::NO_CONTENT)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::application::entities::MockAppServicesBuilder;
+
+    use super::*;
+
+    mod health_check {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_200_when_healthy() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .system
+                .expect_health_check()
+                .times(1)
+                .returning(|| HealthCheck::new(HealthStatus::Operational, HealthStatus::Operational));
+
+            let response = health_check(State(Arc::new(builder.build()))).await.into_response();
+
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn returns_503_when_a_dependency_is_unavailable() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .system
+                .expect_health_check()
+                .times(1)
+                .returning(|| HealthCheck::new(HealthStatus::Unavailable, HealthStatus::Operational));
+
+            let response = health_check(State(Arc::new(builder.build()))).await.into_response();
+
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        }
+    }
+}

--- a/src/domains/user/auth_handler.rs
+++ b/src/domains/user/auth_handler.rs
@@ -79,3 +79,60 @@ async fn sign_in(
     let token = services.auth.sign_in(payload.password).await?;
     Ok(SignInResponse { token }.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::application::{entities::MockAppServicesBuilder, errors::DataError};
+
+    use super::*;
+
+    mod sign_up {
+        use super::*;
+
+        #[tokio::test]
+        async fn returns_the_issued_token() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .auth
+                .expect_sign_up()
+                .withf(|password| password == "secret")
+                .times(1)
+                .returning(|_| Ok("token".to_string()));
+
+            let result = sign_up(
+                State(Arc::new(builder.build())),
+                Json(SignUpRequest {
+                    password: "secret".to_string(),
+                }),
+            )
+            .await;
+
+            let Json(response) = result.unwrap();
+            assert_eq!(response.token, "token");
+        }
+    }
+
+    mod sign_in {
+        use super::*;
+
+        #[tokio::test]
+        async fn propagates_service_errors() {
+            let mut builder = MockAppServicesBuilder::new();
+            builder
+                .auth
+                .expect_sign_in()
+                .times(1)
+                .returning(|_| Err(DataError::NotFound("missing".to_string()).into()));
+
+            let result = sign_in(
+                State(Arc::new(builder.build())),
+                Json(SignInRequest {
+                    password: "secret".to_string(),
+                }),
+            )
+            .await;
+
+            assert!(matches!(result, Err(ApplicationError::Data(DataError::NotFound(_)))));
+        }
+    }
+}

--- a/src/domains/wallet/wallet_handler.rs
+++ b/src/domains/wallet/wallet_handler.rs
@@ -213,3 +213,85 @@ async fn delete_wallets(
     let n_deleted = services.wallet.delete_many(query_params).await?;
     Ok(n_deleted.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{application::entities::MockAppServicesBuilder, domains::wallet::Wallet};
+
+    use super::*;
+
+    fn user(permissions: Vec<Permission>) -> User {
+        User {
+            id: "alice".to_string(),
+            wallet_id: Uuid::new_v4(),
+            permissions,
+        }
+    }
+
+    mod register_wallet {
+        use super::*;
+
+        mod without_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden_and_does_not_call_the_service() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = register_wallet(
+                    State(Arc::new(services)),
+                    user(vec![]),
+                    Json(RegisterWalletRequest {
+                        user_id: "bob".to_string(),
+                    }),
+                )
+                .await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+
+        mod with_the_write_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn delegates_to_the_service() {
+                let mut builder = MockAppServicesBuilder::new();
+                builder
+                    .wallet
+                    .expect_register()
+                    .withf(|user_id| user_id == "bob")
+                    .times(1)
+                    .returning(|_| Ok(Wallet::default()));
+
+                let result = register_wallet(
+                    State(Arc::new(builder.build())),
+                    user(vec![Permission::WriteWallet]),
+                    Json(RegisterWalletRequest {
+                        user_id: "bob".to_string(),
+                    }),
+                )
+                .await;
+
+                assert!(result.is_ok());
+            }
+        }
+    }
+
+    mod get_wallet {
+        use super::*;
+
+        mod without_the_read_permission {
+            use super::*;
+
+            #[tokio::test]
+            async fn is_forbidden() {
+                let services = MockAppServicesBuilder::new().build();
+
+                let result = get_wallet(State(Arc::new(services)), user(vec![]), Path(Uuid::new_v4())).await;
+
+                assert!(matches!(result, Err(ApplicationError::Authorization(_))));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #245 — completes the handler layer by adding unit tests for the 8 remaining handlers (only `payment`, `api_key`, and `user_wallet` were covered there).

Reuses the `MockAppServicesBuilder` seam from #245: handler fns are called directly with constructed extractors (`State`, `User`, `Json`/`Path`/`Query`) over mocked use cases — no real router, DB, or nodes.

## What's covered

**Admin handlers — permission gating + `wallet_id` scoping:**
- `wallet` — register/get permission gates + delegation
- `invoice` — write/read gates + `wallet_id` defaults to the caller when omitted
- `ln_address` — write/read gates + `wallet_id` scoping
- `bitcoin_address` — write/read gates + `wallet_id` scoping

**Public handlers — delegation, param-passing, status mapping:**
- `auth` — sign-up token mapping, sign-in error propagation
- `lnurl` — forwards username/amount/comment, propagates not-found
- `nostr` — forwards name, returns pubkey / propagates not-found
- `system` — `health_check` maps healthy → 200, degraded → 503


## Also: pure parser coverage

Adds tests for the previously partially-covered pure functions:

- `payment_input`: currency mapping, lnurl/lightning-address detection, endpoint resolution, and bitcoin/empty/unsupported routing in `parse_payment_input`
- `lnurl/utils`: success-action conversion, AES/URL guards, and `process_success_action`/`decrypt` branches

These passed as written — no bug surfaced in the parsers (they're well-contained pure validators).

**Total: 199 tests pass (+42 vs main).**