### PR TITLE
feat: atomic on-chain deposit projection (EventProjectionUnitOfWork)

### DIFF
--- a/src/domains/event/event_service.rs
+++ b/src/domains/event/event_service.rs
@@ -120,6 +120,7 @@ impl EventUseCases for EventService {
 
         let address = event.address;
         let status = Self::output_status(event.block_height);
+        let is_confirmed = status == BtcOutputStatus::Confirmed;
         let output = BtcOutput {
             outpoint: outpoint.clone(),
             txid: event.txid.clone(),
@@ -132,68 +133,33 @@ impl EventUseCases for EventService {
         };
 
         let Some(btc_address) = self.store.btc_address.find_by_address(&address).await? else {
-            trace!(%address, outpoint = outpoint.clone(),
-                "Ignoring bitcoin output not matching any known wallet address");
+            trace!(%address, %outpoint, "Ignoring bitcoin output not matching any known wallet address");
             return Ok(false);
         };
 
-        let stored_output = self.store.btc_output.upsert(output.clone()).await?;
+        let amount_msat = event.amount_sat.saturating_mul(1000);
+        let now = Utc::now();
+        let deposit_invoice = Invoice {
+            wallet_id: btc_address.wallet_id,
+            description: Some(DEFAULT_DEPOSIT_DESCRIPTION.to_string()),
+            amount_msat: Some(amount_msat),
+            amount_received_msat: is_confirmed.then_some(amount_msat),
+            timestamp: now,
+            ledger: Ledger::Onchain,
+            currency,
+            payment_time: is_confirmed.then_some(now),
+            ..Default::default()
+        };
 
-        if !btc_address.used {
-            self.store.btc_address.mark_used(btc_address.id).await?;
-        }
+        // Output upsert, address mark-used, and invoice settle/insert (+ balance credit when
+        // confirmed) are applied atomically; idempotent if the event is replayed.
+        let invoice = self
+            .store
+            .event_uow
+            .project_onchain_deposit(output, btc_address, deposit_invoice)
+            .await?;
 
-        let existing_invoice = self.store.invoice.find_by_btc_output_id(stored_output.id).await?;
-        let status: InvoiceStatus = stored_output.status.into();
-
-        let is_confirmed = stored_output.status == BtcOutputStatus::Confirmed;
-
-        if let Some(mut invoice) = existing_invoice {
-            invoice.status = status;
-            invoice.btc_output_id = Some(stored_output.id);
-            invoice.bitcoin_output = Some(stored_output.clone());
-
-            if is_confirmed {
-                invoice.payment_time = Some(Utc::now());
-                invoice.amount_received_msat = Some(stored_output.amount_sat.saturating_mul(1000));
-                // Settle and credit the receiver atomically; idempotent if the event is replayed.
-                self.store.event_uow.settle_incoming_invoice(invoice.clone()).await?;
-            } else {
-                self.store.invoice.update(invoice.clone()).await?;
-            }
-
-            info!(invoice_id = %invoice.id, outpoint = outpoint.clone(), address = %btc_address.address,
-                "Existing onchain deposit processed");
-        } else {
-            let amount_msat = stored_output.amount_sat.saturating_mul(1000);
-            let payment_time = if is_confirmed { Some(Utc::now()) } else { None };
-            let amount_received_msat = if is_confirmed { Some(amount_msat) } else { None };
-
-            let invoice = Invoice {
-                wallet_id: btc_address.wallet_id,
-                description: Some(DEFAULT_DEPOSIT_DESCRIPTION.to_string()),
-                amount_msat: Some(amount_msat),
-                amount_received_msat,
-                timestamp: Utc::now(),
-                ledger: Ledger::Onchain,
-                currency,
-                payment_time,
-                btc_output_id: Some(stored_output.id),
-                bitcoin_output: Some(stored_output.clone()),
-                ..Default::default()
-            };
-
-            let stored_invoice = if is_confirmed {
-                // Insert the settled deposit and credit the receiver atomically.
-                self.store.event_uow.settle_incoming_invoice(invoice.clone()).await?
-            } else {
-                self.store.invoice.insert(invoice.clone()).await?
-            };
-
-            info!(invoice_id = %stored_invoice.id, outpoint = %outpoint.clone(), address = %btc_address.address,
-                "New onchain deposit processed");
-        }
-
+        info!(invoice_id = %invoice.id, %outpoint, %address, "Onchain deposit processed");
         Ok(true)
     }
 
@@ -476,38 +442,23 @@ mod tests {
             use super::*;
 
             #[tokio::test]
-            async fn creates_a_settled_deposit_invoice() {
+            async fn projects_a_settled_deposit_invoice() {
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .btc_address
                     .expect_find_by_address()
                     .times(1)
                     .returning(|_| Ok(Some(btc_address(false))));
-                store.btc_output.expect_upsert().times(1).returning(|output| {
-                    Ok(BtcOutput {
-                        id: Uuid::new_v4(),
-                        status: BtcOutputStatus::Confirmed,
-                        amount_sat: 1_000,
-                        ..output
-                    })
-                });
-                // Address was unused, so it must be flagged as used.
-                store.btc_address.expect_mark_used().times(1).returning(|_| Ok(()));
-                store
-                    .invoice
-                    .expect_find_by_btc_output_id()
-                    .times(1)
-                    .returning(|_| Ok(None));
                 store
                     .event_uow
-                    .expect_settle_incoming_invoice()
-                    .withf(|invoice| {
+                    .expect_project_onchain_deposit()
+                    .withf(|_output, _address, invoice| {
                         invoice.ledger == Ledger::Onchain
                             && invoice.amount_received_msat == Some(1_000_000)
                             && invoice.payment_time.is_some()
                     })
                     .times(1)
-                    .returning(Ok);
+                    .returning(|_, _, invoice| Ok(invoice));
 
                 let event = OnchainDepositEvent {
                     txid: "txid".to_string(),
@@ -515,6 +466,42 @@ mod tests {
                     address: "bc1qknown".to_string(),
                     amount_sat: 1_000,
                     block_height: Some(800_000),
+                };
+
+                let processed = service(store).onchain_deposit(event, Currency::Bitcoin).await.unwrap();
+
+                assert!(processed);
+            }
+        }
+
+        mod when_address_is_known_and_unconfirmed {
+            use super::*;
+
+            #[tokio::test]
+            async fn projects_a_pending_deposit_invoice() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .btc_address
+                    .expect_find_by_address()
+                    .times(1)
+                    .returning(|_| Ok(Some(btc_address(false))));
+                store
+                    .event_uow
+                    .expect_project_onchain_deposit()
+                    .withf(|_output, _address, invoice| {
+                        invoice.ledger == Ledger::Onchain
+                            && invoice.amount_received_msat.is_none()
+                            && invoice.payment_time.is_none()
+                    })
+                    .times(1)
+                    .returning(|_, _, invoice| Ok(invoice));
+
+                let event = OnchainDepositEvent {
+                    txid: "txid".to_string(),
+                    output_index: 0,
+                    address: "bc1qknown".to_string(),
+                    amount_sat: 1_000,
+                    block_height: None,
                 };
 
                 let processed = service(store).onchain_deposit(event, Currency::Bitcoin).await.unwrap();

--- a/src/domains/event/event_unit_of_work.rs
+++ b/src/domains/event/event_unit_of_work.rs
@@ -1,6 +1,12 @@
 use async_trait::async_trait;
 
-use crate::{application::errors::ApplicationError, domains::invoice::Invoice};
+use crate::{
+    application::errors::ApplicationError,
+    domains::{
+        bitcoin::{BtcAddress, BtcOutput},
+        invoice::Invoice,
+    },
+};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
@@ -8,4 +14,15 @@ pub trait EventProjectionUnitOfWork: Send + Sync {
     /// Settle an incoming invoice and credit the receiver's wallet balance in one transaction.
     /// Idempotent: a replayed settle event credits the wallet at most once.
     async fn settle_incoming_invoice(&self, invoice: Invoice) -> Result<Invoice, ApplicationError>;
+
+    /// Project an on-chain deposit in one transaction: upsert the output, mark the receiving
+    /// address used, and settle-or-insert the linked invoice (crediting the receiver when
+    /// confirmed). `deposit_invoice` is the desired invoice for a first sighting; when an invoice
+    /// already exists for the output it is settled idempotently instead.
+    async fn project_onchain_deposit(
+        &self,
+        output: BtcOutput,
+        address: BtcAddress,
+        deposit_invoice: Invoice,
+    ) -> Result<Invoice, ApplicationError>;
 }

--- a/src/infra/database/sea_orm/repositories/sea_orm_btc_address_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_btc_address_repository.rs
@@ -6,6 +6,8 @@ use sea_orm::{
 };
 use uuid::Uuid;
 
+use super::SeaOrmConnection;
+
 use crate::{
     application::errors::DatabaseError,
     domains::bitcoin::{BtcAddress, BtcAddressFilter, BtcAddressRepository, BtcAddressType},
@@ -16,21 +18,24 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct SeaOrmBitcoinAddressRepository {
-    pub db: DatabaseConnection,
+pub struct SeaOrmBitcoinAddressRepository<C = DatabaseConnection> {
+    db: C,
 }
 
-impl SeaOrmBitcoinAddressRepository {
-    pub fn new(db: DatabaseConnection) -> Self {
+impl<C> SeaOrmBitcoinAddressRepository<C> {
+    pub fn new(db: C) -> Self {
         Self { db }
     }
 }
 
 #[async_trait]
-impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
+impl<C> BtcAddressRepository for SeaOrmBitcoinAddressRepository<C>
+where
+    C: SeaOrmConnection,
+{
     async fn find(&self, id: Uuid) -> Result<Option<BtcAddress>, DatabaseError> {
         let model = BtcAddressEntity::find_by_id(id)
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -47,7 +52,7 @@ impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
             .filter(Column::Used.eq(false))
             .filter(Column::AddressType.eq(address_type.to_string()))
             .order_by_desc(Column::CreatedAt)
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -57,7 +62,7 @@ impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
     async fn find_by_address(&self, address: &str) -> Result<Option<BtcAddress>, DatabaseError> {
         let model = BtcAddressEntity::find()
             .filter(Column::Address.eq(address))
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -76,7 +81,7 @@ impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
             .order_by(Column::CreatedAt, filter.order_direction.into())
             .offset(filter.offset)
             .limit(filter.limit)
-            .all(&self.db)
+            .all(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
 
@@ -99,7 +104,7 @@ impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
         };
 
         let model = model
-            .insert(&self.db)
+            .insert(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Insert(e.to_string()))?;
 
@@ -115,7 +120,7 @@ impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
         };
 
         active_model
-            .update(&self.db)
+            .update(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Update(e.to_string()))?;
 
@@ -127,7 +132,7 @@ impl BtcAddressRepository for SeaOrmBitcoinAddressRepository {
             .apply_if(filter.wallet_id, |q, id| q.filter(Column::WalletId.eq(id)))
             .apply_if(filter.ids, |q, ids| q.filter(Column::Id.is_in(ids)))
             .apply_if(filter.address, |q, address| q.filter(Column::Address.eq(address)))
-            .exec(&self.db)
+            .exec(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Delete(e.to_string()))?;
 

--- a/src/infra/database/sea_orm/repositories/sea_orm_btc_output_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_btc_output_repository.rs
@@ -6,6 +6,8 @@ use sea_orm::{
 };
 use uuid::Uuid;
 
+use super::SeaOrmConnection;
+
 use crate::{
     application::errors::DatabaseError,
     domains::bitcoin::{BtcOutput, BtcOutputRepository},
@@ -16,22 +18,25 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct SeaOrmBitcoinOutputRepository {
-    pub db: DatabaseConnection,
+pub struct SeaOrmBitcoinOutputRepository<C = DatabaseConnection> {
+    db: C,
 }
 
-impl SeaOrmBitcoinOutputRepository {
-    pub fn new(db: DatabaseConnection) -> Self {
+impl<C> SeaOrmBitcoinOutputRepository<C> {
+    pub fn new(db: C) -> Self {
         Self { db }
     }
 }
 
 #[async_trait]
-impl BtcOutputRepository for SeaOrmBitcoinOutputRepository {
+impl<C> BtcOutputRepository for SeaOrmBitcoinOutputRepository<C>
+where
+    C: SeaOrmConnection,
+{
     async fn find_by_outpoint(&self, outpoint: &str) -> Result<Option<BtcOutput>, DatabaseError> {
         let model = BtcOutputEntity::find()
             .filter(Column::Outpoint.eq(outpoint))
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
@@ -53,7 +58,7 @@ impl BtcOutputRepository for SeaOrmBitcoinOutputRepository {
             };
 
             let model = active_model
-                .update(&self.db)
+                .update(self.db.connection())
                 .await
                 .map_err(|e| DatabaseError::Update(e.to_string()))?;
 
@@ -73,7 +78,7 @@ impl BtcOutputRepository for SeaOrmBitcoinOutputRepository {
         };
 
         let model = model
-            .insert(&self.db)
+            .insert(self.db.connection())
             .await
             .map_err(|e| DatabaseError::Insert(e.to_string()))?;
 
@@ -90,7 +95,7 @@ impl BtcOutputRepository for SeaOrmBitcoinOutputRepository {
             .select_only()
             .column_as(Column::BlockHeight.max(), "max")
             .into_model::<MaxBlockHeight>()
-            .one(&self.db)
+            .one(self.db.connection())
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 

--- a/src/infra/database/sea_orm/uow.rs
+++ b/src/infra/database/sea_orm/uow.rs
@@ -4,6 +4,7 @@ use sea_orm::{DatabaseConnection, TransactionTrait};
 use crate::{
     application::errors::{ApplicationError, DataError, DatabaseError},
     domains::{
+        bitcoin::{BtcAddress, BtcAddressRepository, BtcOutput, BtcOutputRepository},
         event::EventProjectionUnitOfWork,
         invoice::{Invoice, InvoiceRepository},
         payment::{Payment, PaymentRepository, PaymentUnitOfWork},
@@ -11,7 +12,10 @@ use crate::{
     },
 };
 
-use super::{SeaOrmInvoiceRepository, SeaOrmPaymentRepository, SeaOrmWalletBalanceRepository};
+use super::{
+    SeaOrmBitcoinAddressRepository, SeaOrmBitcoinOutputRepository, SeaOrmInvoiceRepository, SeaOrmPaymentRepository,
+    SeaOrmWalletBalanceRepository,
+};
 
 #[derive(Clone)]
 pub struct SeaOrmPaymentUnitOfWork {
@@ -214,5 +218,74 @@ impl EventProjectionUnitOfWork for SeaOrmEventProjectionUnitOfWork {
             .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
 
         Ok(settled)
+    }
+
+    async fn project_onchain_deposit(
+        &self,
+        output: BtcOutput,
+        address: BtcAddress,
+        mut deposit_invoice: Invoice,
+    ) -> Result<Invoice, ApplicationError> {
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
+
+        let output_repo = SeaOrmBitcoinOutputRepository::new(&txn);
+        let address_repo = SeaOrmBitcoinAddressRepository::new(&txn);
+        let invoice_repo = SeaOrmInvoiceRepository::new(&txn);
+        let balance_repo = SeaOrmWalletBalanceRepository::new(&txn);
+
+        let stored_output = output_repo.upsert(output).await?;
+
+        if !address.used {
+            address_repo.mark_used(address.id).await?;
+        }
+
+        // The caller only sets payment_time/amount_received once the deposit is confirmed.
+        let confirmed = deposit_invoice.payment_time.is_some();
+
+        let invoice = match invoice_repo.find_by_btc_output_id(stored_output.id).await? {
+            Some(mut existing) => {
+                if confirmed {
+                    // Confirm the previously-pending deposit invoice exactly once.
+                    existing.payment_time = deposit_invoice.payment_time;
+                    existing.amount_received_msat = deposit_invoice.amount_received_msat;
+                    if invoice_repo.settle(&existing).await? {
+                        if let Some(received_msat) = existing.amount_received_msat {
+                            balance_repo
+                                .credit(existing.wallet_id, &existing.currency, received_msat)
+                                .await?;
+                        }
+                    }
+                    invoice_repo
+                        .find(existing.id)
+                        .await?
+                        .ok_or_else(|| DataError::NotFound("Invoice not found.".to_string()))?
+                } else {
+                    // Still unconfirmed: keep the invoice linked to the (re-)seen output.
+                    existing.btc_output_id = Some(stored_output.id);
+                    invoice_repo.update(existing).await?
+                }
+            }
+            None => {
+                deposit_invoice.btc_output_id = Some(stored_output.id);
+                if confirmed {
+                    if let Some(received_msat) = deposit_invoice.amount_received_msat {
+                        balance_repo
+                            .credit(deposit_invoice.wallet_id, &deposit_invoice.currency, received_msat)
+                            .await?;
+                    }
+                }
+                invoice_repo.insert(deposit_invoice).await?
+            }
+        };
+
+        txn.commit()
+            .await
+            .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
+
+        Ok(invoice)
     }
 }


### PR DESCRIPTION
Closes #241.

`onchain_deposit` previously performed the BTC **output upsert**, **address mark-used**, and **invoice update/insert** as three independent repository calls — a failure after the first left the projection inconsistent.

## What changed
- **`EventProjectionUnitOfWork::project_onchain_deposit`** now does the whole projection in one transaction: upsert the output, mark the receiving address used, settle-or-insert the linked invoice, and credit the receiver when confirmed. Confirmation routes through the conditional `InvoiceRepository::settle` (`WHERE payment_time IS NULL`), so a replayed deposit event credits at most once.
- **`SeaOrmBitcoinOutputRepository` / `SeaOrmBitcoinAddressRepository`** are now generic over `SeaOrmConnection` (like the invoice/wallet-balance repos), so they can run inside the UoW transaction.
- **`EventService::onchain_deposit`** keeps the event parsing, the address guard, and the confirmation policy (it builds the desired deposit invoice), then delegates the atomic writes to the UoW — no SeaORM transaction type leaks into the service.

## Acceptance criteria
- ✅ `onchain_deposit` no longer performs output/address/invoice writes as independent repository calls.
- ✅ Output upsert, address mark-used, and invoice update/insert succeed or fail atomically.
- ✅ No SeaORM transaction type leaks into domain service or repository trait signatures.
- ➡️ Real-DB coverage of the existing-invoice update vs new-invoice insert paths is part of the integration/concurrency suite tracked in #240. Service-level unit tests verify the confirmed/unconfirmed routing here.

## Validation
- `cargo fmt`, `clippy -D warnings`, `cargo test` (203 passed).
