### PR TITLE
fix(payment): single-winner settle/fail (stop double-release race)

### DIFF
--- a/src/domains/payment/payment_repository.rs
+++ b/src/domains/payment/payment_repository.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::application::errors::DatabaseError;
 
-use super::{Payment, PaymentFilter};
+use super::{Payment, PaymentFilter, PaymentStatus};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
@@ -13,6 +13,10 @@ pub trait PaymentRepository: Send + Sync {
     async fn find_many(&self, filter: PaymentFilter) -> Result<Vec<Payment>, DatabaseError>;
     async fn insert(&self, payment: Payment) -> Result<Payment, DatabaseError>;
     async fn update(&self, payment: Payment) -> Result<Payment, DatabaseError>;
+    /// Atomically move a payment from `from` to `to`, returning whether this
+    /// call performed the transition. Makes finalization single-winner when the
+    /// synchronous result and the success/failure event race for one payment.
+    async fn try_transition(&self, id: Uuid, from: PaymentStatus, to: PaymentStatus) -> Result<bool, DatabaseError>;
     async fn delete_many(&self, filter: PaymentFilter) -> Result<u64, DatabaseError>;
     async fn max_btc_block_height(&self) -> Result<Option<u32>, DatabaseError>;
 }

--- a/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_payment_repository.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, DatabaseConnection, EntityTrait, FromQueryResult, QueryFilter,
-    QueryOrder, QuerySelect, QueryTrait, Set, Unchanged,
+    sea_query::Expr, ActiveModelTrait, ActiveValue, ColumnTrait, DatabaseConnection, EntityTrait, FromQueryResult,
+    QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, Unchanged,
 };
 use uuid::Uuid;
 
@@ -10,7 +10,7 @@ use super::SeaOrmConnection;
 
 use crate::{
     application::errors::DatabaseError,
-    domains::payment::{Payment, PaymentFilter, PaymentRepository},
+    domains::payment::{Payment, PaymentFilter, PaymentRepository, PaymentStatus},
     infra::database::sea_orm::models::{
         payment::{ActiveModel, Column},
         prelude::Payment as PaymentEntity,
@@ -223,6 +223,18 @@ where
             .map_err(|e| DatabaseError::Update(e.to_string()))?;
 
         Ok(model.into())
+    }
+
+    async fn try_transition(&self, id: Uuid, from: PaymentStatus, to: PaymentStatus) -> Result<bool, DatabaseError> {
+        let result = PaymentEntity::update_many()
+            .col_expr(Column::Status, Expr::value(to.to_string()))
+            .filter(Column::Id.eq(id))
+            .filter(Column::Status.eq(from.to_string()))
+            .exec(self.db.connection())
+            .await
+            .map_err(|e| DatabaseError::Update(e.to_string()))?;
+
+        Ok(result.rows_affected == 1)
     }
 
     async fn delete_many(&self, filter: PaymentFilter) -> Result<u64, DatabaseError> {

--- a/src/infra/database/sea_orm/uow.rs
+++ b/src/infra/database/sea_orm/uow.rs
@@ -7,7 +7,7 @@ use crate::{
         bitcoin::{BtcAddress, BtcAddressRepository, BtcOutput, BtcOutputRepository},
         event::EventProjectionUnitOfWork,
         invoice::{Invoice, InvoiceRepository},
-        payment::{Payment, PaymentRepository, PaymentUnitOfWork},
+        payment::{Payment, PaymentRepository, PaymentStatus, PaymentUnitOfWork},
         wallet::WalletBalanceRepository,
     },
 };
@@ -62,6 +62,26 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
             .await
             .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
 
+        let payment_repo = SeaOrmPaymentRepository::new(&txn);
+
+        // Single-winner: the synchronous pay result and the success event can
+        // both reach this for the same payment. Only the one that wins the
+        // Pending->Settled transition runs the balance side effects; the other
+        // returns the already-settled payment untouched.
+        if !payment_repo
+            .try_transition(payment.id, PaymentStatus::Pending, PaymentStatus::Settled)
+            .await?
+        {
+            let settled = payment_repo
+                .find(payment.id)
+                .await?
+                .ok_or_else(|| DataError::NotFound(format!("Payment {} not found", payment.id)))?;
+            txn.commit()
+                .await
+                .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
+            return Ok(settled);
+        }
+
         let balance_repo = SeaOrmWalletBalanceRepository::new(&txn);
 
         if payment.reserved_amount > 0
@@ -84,7 +104,7 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
         }
         payment.reserved_amount = 0;
 
-        let payment = SeaOrmPaymentRepository::new(&txn).update(payment).await?;
+        let payment = payment_repo.update(payment).await?;
 
         txn.commit()
             .await
@@ -100,6 +120,25 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
             .await
             .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
 
+        let payment_repo = SeaOrmPaymentRepository::new(&txn);
+
+        // Single-winner: only the caller that wins the Pending->Failed
+        // transition releases the reservation; a duplicate (sync result +
+        // failure event) returns the already-failed payment.
+        if !payment_repo
+            .try_transition(payment.id, PaymentStatus::Pending, PaymentStatus::Failed)
+            .await?
+        {
+            let failed = payment_repo
+                .find(payment.id)
+                .await?
+                .ok_or_else(|| DataError::NotFound(format!("Payment {} not found", payment.id)))?;
+            txn.commit()
+                .await
+                .map_err(|e| DatabaseError::Transaction(e.to_string()))?;
+            return Ok(failed);
+        }
+
         let balance_repo = SeaOrmWalletBalanceRepository::new(&txn);
         if payment.reserved_amount > 0
             && !balance_repo
@@ -112,7 +151,7 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
         }
         payment.reserved_amount = 0;
 
-        let payment = SeaOrmPaymentRepository::new(&txn).update(payment).await?;
+        let payment = payment_repo.update(payment).await?;
 
         txn.commit()
             .await


### PR DESCRIPTION
Fixes a payment double-settle race surfaced by the new integration suites — it flaked #260's `cln_rest` cell and is the code side of #240.

## The bug

An outgoing payment is finalized by **two** paths: the synchronous `pay()` result ([payment_service.rs:493](src/domains/payment/payment_service.rs#L493)) and the `LnPaySuccess`/`LnPayFailure` event listener ([event_service.rs:81](src/domains/event/event_service.rs#L81)). The event path guards with `if status == Settled { skip }`, but it's **check-then-act**: when the event reads the payment as still `Pending` (before the sync path commits), both call `payment_uow.settle()`/`fail()`, both try to release the reservation, and the loser hits `DataError::Inconsistency("Reserved balance missing")` → **500**. Timing-dependent; more parallel load makes it more likely (which is why the bitcoin suite exposed it).

## The fix

`PaymentRepository::try_transition(id, from, to)` does an atomic conditional `UPDATE … SET status WHERE id = ? AND status = ?` — single-winner (the conditional write serializes on both SQLite and Postgres). The UoW's `settle`/`fail` claim the `Pending → Settled/Failed` transition first and run the balance side effects (release + debit) **only if they won**; the loser returns the already-finalized payment untouched. Same idea as the invoice single-winner settle.

Invoices are intentionally untouched: they have no `status` column (status is derived from `payment_time`), and they go `uow.settle_internal → repo.settle` (no name clash), so the pattern doesn't transfer 1:1.

## Validation

`cln_rest` (sqlite) ran **3× under the bitcoin-suite parallelism** (the load that surfaced it) — 26/26 each, no 500s. Deterministic settle-twice / concurrent-overdraw tests land with the #240 DB-backed concurrency suite.
