### PR TITLE
test(itest): withdrawal, public well-knowns, LN failure (+ LND REST LNURL fix)

### DIFF
--- a/src/infra/lightning/lnd/lnd_rest_client.rs
+++ b/src/infra/lightning/lnd/lnd_rest_client.rs
@@ -257,7 +257,9 @@ impl LnClient for LndRestClient {
         };
 
         if deschashonly {
-            payload.description_hash = sha256::Hash::hash(description.as_bytes()).to_string();
+            // LND REST takes byte fields as base64 in JSON; a hex string would be
+            // base64-decoded into 48 bytes and rejected ("must be 32").
+            payload.description_hash = STANDARD.encode(sha256::Hash::hash(description.as_bytes()).to_byte_array());
         }
 
         let response: AddInvoiceResponse = self

--- a/tests/common/chain.rs
+++ b/tests/common/chain.rs
@@ -41,3 +41,17 @@ pub async fn mine(blocks: u64) {
     let address = address.as_str().expect("miner address");
     bitcoin_rpc("generatetoaddress", json!([blocks, address])).await;
 }
+
+/// A fresh miner-wallet address, external to SwissKnife — paying it is a real
+/// on-chain broadcast, not an internal settlement.
+pub async fn new_address() -> String {
+    let address = bitcoin_rpc("getnewaddress", json!(["itest-withdraw", "bech32"])).await;
+    address.as_str().expect("miner address").to_string()
+}
+
+/// Confirmed sats the miner wallet has received at `address`, to assert a
+/// withdrawal actually landed on-chain.
+pub async fn received_by_address(address: &str) -> u64 {
+    let btc = bitcoin_rpc("getreceivedbyaddress", json!([address, 1])).await;
+    (btc.as_f64().expect("getreceivedbyaddress amount") * 100_000_000.0).round() as u64
+}

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -93,7 +93,10 @@ impl TestApp {
             .env("RUN_MODE", "itest")
             .env("SWISSKNIFE_WEB__ADDR", format!("127.0.0.1:{port}"))
             .env("SWISSKNIFE_DATABASE__URL", db.url())
-            .env("SWISSKNIFE_LN_PROVIDER", &provider);
+            .env("SWISSKNIFE_LN_PROVIDER", &provider)
+            // Advertise this ephemeral server as the public host so the callback
+            // URL the LNURL well-known endpoint hands out is actually reachable.
+            .env("SWISSKNIFE_HOST", &base_url);
 
         // The CLN rune is generated at bootstrap and cannot be a file path.
         if provider == "cln_rest" {

--- a/tests/itest/README.md
+++ b/tests/itest/README.md
@@ -88,9 +88,14 @@ failure, dependency logs are collected via `make itest-logs`.
 
 ## Status / TODO
 
-- Covered: system, auth (local JWT), wallet management, validation/auth/error paths,
-  and the persistence/Unit-of-Work balance invariants + concurrency (#240) on both DBs.
-- Pending: lightning invoice/pay/receive over a funded channel (needs an external
-  counterparty node in the topology), the full provider matrix, and OAuth2.
+- Covered, across the full LND/CLN × gRPC/REST provider matrix on both DBs: system,
+  auth (local JWT), wallet management, validation/auth/error paths; real Lightning
+  send/receive and on-chain deposit/withdrawal over the regtest stack; the public
+  LNURL-pay and Nostr NIP-05 endpoints (including an external payer settling via a
+  lightning address); a deterministic unroutable-payment failure (fail + reservation
+  release over a real backend); and the persistence/Unit-of-Work balance invariants +
+  concurrency (#240).
+- Pending (needs a mock server — deferred to follow-up PRs): paying *out* to an
+  external lightning address / LNURL / Nostr, and OAuth2/OIDC login.
 - Found while writing these tests: bitcoin-numeraire/swissknife#254 (wallet
   auto-provisioning on first login races under concurrency).

--- a/tests/itest/config/cln/config
+++ b/tests/itest/config/cln/config
@@ -16,3 +16,7 @@ clnrest-host=0.0.0.0
 clnrest-port=3010
 clnrest-protocol=https
 developer
+# Poll bitcoind every second so CLN tracks freshly-mined blocks. The default slow
+# poll lags the tip under test chain churn, making a concurrent `pay` time out
+# "waiting for blockheight". (A dev option; `developer` above enables it.)
+dev-bitcoind-poll=1

--- a/tests/itest/docker-compose.yml
+++ b/tests/itest/docker-compose.yml
@@ -71,7 +71,10 @@ services:
         condition: service_healthy
     environment:
       LIGHTNINGD_NETWORK: regtest
-    command: ["--conf=/etc/cln/config"]
+    # Poll bitcoind every second so CLN tracks freshly-mined blocks. The default
+    # slow poll lags the tip under test chain churn, making a concurrent `pay`
+    # time out "waiting for blockheight".
+    command: ["--conf=/etc/cln/config", "--dev-bitcoind-poll=1"]
     volumes:
       - ./config/cln/config:/etc/cln/config:ro
       - cln-data:/root/.lightning

--- a/tests/itest/docker-compose.yml
+++ b/tests/itest/docker-compose.yml
@@ -71,10 +71,7 @@ services:
         condition: service_healthy
     environment:
       LIGHTNINGD_NETWORK: regtest
-    # Poll bitcoind every second so CLN tracks freshly-mined blocks. The default
-    # slow poll lags the tip under test chain churn, making a concurrent `pay`
-    # time out "waiting for blockheight".
-    command: ["--conf=/etc/cln/config", "--dev-bitcoind-poll=1"]
+    command: ["--conf=/etc/cln/config"]
     volumes:
       - ./config/cln/config:/etc/cln/config:ro
       - cln-data:/root/.lightning

--- a/tests/itest/scripts/bootstrap.sh
+++ b/tests/itest/scripts/bootstrap.sh
@@ -340,4 +340,11 @@ ensure_lnd_wallet
 ensure_cln_ready
 ensure_channel
 
+# Leave both nodes caught up to the chain tip so the first tests don't race a node
+# still syncing after the channel-funding blocks — a cold CLN trails the tip and
+# its `pay` times out "waiting for blockheight". The 1s bitcoind poll (see
+# docker-compose) then keeps them current as tests mine.
+ensure_lnd_synced
+wait_for_cln_synced
+
 echo "Swissknife integration dependencies are ready."

--- a/tests/suites/bitcoin.rs
+++ b/tests/suites/bitcoin.rs
@@ -234,6 +234,86 @@ mod deposit {
     }
 }
 
+mod withdraw {
+    use super::*;
+
+    use crate::common::chain::{new_address, received_by_address};
+    use swissknife_types::{Ledger, Payment, PaymentStatus, SendPaymentRequest};
+
+    /// Paying an external (non-SwissKnife) address is a real broadcast, not an
+    /// internal settlement: the payment is created Pending, the reservation
+    /// debits the wallet, and the on-chain listener settles it on confirmation.
+    #[tokio::test]
+    async fn broadcasts_on_chain_and_settles_on_confirmation() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let wallet = app.create_wallet(token, "btc-withdraw").await;
+
+        // Fund the wallet on-chain so the node holds a spendable UTXO.
+        app.fund_onchain(token, wallet.id, 1_000_000).await;
+        let before = app.wallet_balance(token, wallet.id).await.available_msat;
+
+        let target = new_address().await;
+        let amount_msat = 200_000_000u64; // 200k sat
+
+        let res = app
+            .api()
+            .post(
+                "/v1/payments",
+                Auth::Bearer(token),
+                SendPaymentRequest {
+                    wallet_id: Some(wallet.id),
+                    input: target.clone(),
+                    amount_msat: Some(amount_msat),
+                    comment: None,
+                },
+            )
+            .await;
+        assert_status(&res, StatusCode::OK);
+        let payment = res.parse::<Payment>();
+        assert_eq!(
+            payment.ledger,
+            Ledger::Onchain,
+            "an external btc address is an on-chain send"
+        );
+        assert_eq!(payment.status, PaymentStatus::Pending, "broadcast, not yet confirmed");
+        let btc = payment
+            .bitcoin
+            .as_ref()
+            .expect("an on-chain payment carries bitcoin details");
+        assert_eq!(btc.address, target);
+        assert!(!btc.txid.is_empty(), "a broadcast transaction has a txid");
+
+        // The reservation debits the wallet immediately (amount + on-chain fee).
+        let reserved = app.wallet_balance(token, wallet.id).await.available_msat;
+        assert!(
+            reserved <= before - amount_msat as i64,
+            "the wallet is debited by at least the amount (before={before}, after={reserved})"
+        );
+
+        // Confirm the broadcast; the on-chain listener settles the payment.
+        mine(6).await;
+        wait_until(
+            Duration::from_secs(90),
+            "withdrawal settles on confirmation",
+            || async {
+                let res = app
+                    .api()
+                    .get(&format!("/v1/payments/{}", payment.id), Auth::Bearer(token))
+                    .await;
+                res.status.as_u16() == 200 && res.parse::<Payment>().status == PaymentStatus::Settled
+            },
+        )
+        .await;
+
+        // The sats actually landed at the external address on-chain.
+        assert!(
+            received_by_address(&target).await >= 200_000,
+            "the withdrawal was broadcast and confirmed on-chain"
+        );
+    }
+}
+
 mod delete {
     use super::*;
 

--- a/tests/suites/bitcoin.rs
+++ b/tests/suites/bitcoin.rs
@@ -312,6 +312,109 @@ mod withdraw {
             "the withdrawal was broadcast and confirmed on-chain"
         );
     }
+
+    /// Paying a deposit address owned by another SwissKnife wallet settles
+    /// internally — synchronous, no broadcast — and credits the recipient.
+    #[tokio::test]
+    async fn settles_internally_to_a_swissknife_address() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let payer = app.create_wallet(token, "btc-int-payer").await;
+        let payee = app.create_wallet(token, "btc-int-payee").await;
+        app.fund_onchain(token, payer.id, 1_000_000).await;
+
+        let payee_addr = post_address(app, token, Some(payee.id), None)
+            .await
+            .parse::<BtcAddress>()
+            .address;
+
+        let amount_msat = 300_000_000u64;
+        let res = app
+            .api()
+            .post(
+                "/v1/payments",
+                Auth::Bearer(token),
+                SendPaymentRequest {
+                    wallet_id: Some(payer.id),
+                    input: payee_addr,
+                    amount_msat: Some(amount_msat),
+                    comment: None,
+                },
+            )
+            .await;
+        assert_status(&res, StatusCode::OK);
+        let payment = res.parse::<Payment>();
+        assert_eq!(
+            payment.ledger,
+            Ledger::Internal,
+            "paying a SwissKnife-owned address settles internally"
+        );
+        assert_eq!(
+            payment.status,
+            PaymentStatus::Settled,
+            "internal settlement is synchronous"
+        );
+        assert!(
+            app.wallet_balance(token, payee.id).await.available_msat >= amount_msat as i64,
+            "the internal recipient is credited"
+        );
+    }
+
+    /// The ledger reservation guards the balance: an on-chain send beyond it is
+    /// rejected (422) before anything is broadcast. Fund the shared node wallet
+    /// through one wallet so the transaction can be built, then overdraw a
+    /// different, unfunded wallet — isolating the ledger reserve as the rejecter
+    /// rather than the node failing to fund the tx (which differs by backend).
+    #[tokio::test]
+    async fn rejects_a_withdrawal_beyond_the_balance() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let funded = app.create_wallet(token, "btc-od-funded").await;
+        app.fund_onchain(token, funded.id, 1_000_000).await;
+        let broke = app.create_wallet(token, "btc-od-broke").await;
+
+        let res = app
+            .api()
+            .post(
+                "/v1/payments",
+                Auth::Bearer(token),
+                SendPaymentRequest {
+                    wallet_id: Some(broke.id),
+                    input: new_address().await,
+                    amount_msat: Some(500_000_000),
+                    comment: None,
+                },
+            )
+            .await;
+        assert_error(&res, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// Paying your own deposit address is rejected.
+    #[tokio::test]
+    async fn rejects_paying_your_own_address() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let wallet = app.create_wallet(token, "btc-self").await;
+        let own = post_address(app, token, Some(wallet.id), None)
+            .await
+            .parse::<BtcAddress>()
+            .address;
+
+        let res = app
+            .api()
+            .post(
+                "/v1/payments",
+                Auth::Bearer(token),
+                SendPaymentRequest {
+                    wallet_id: Some(wallet.id),
+                    input: own,
+                    amount_msat: Some(100_000_000),
+                    comment: None,
+                },
+            )
+            .await;
+        assert_error(&res, StatusCode::UNPROCESSABLE_ENTITY);
+    }
 }
 
 mod delete {

--- a/tests/suites/lightning.rs
+++ b/tests/suites/lightning.rs
@@ -11,7 +11,7 @@ use swissknife_types::{Invoice, NewInvoiceRequest, Payment, PaymentStatus, SendP
 use crate::common::counterparty::Counterparty;
 use crate::common::fixtures::unique;
 use crate::common::wait::wait_until;
-use crate::common::{app, assert_status, Auth};
+use crate::common::{app, assert_error, assert_status, Auth};
 
 mod receive {
     use super::*;
@@ -95,6 +95,66 @@ mod send {
             after,
             before - amount_msat as i64 - fee,
             "wallet should be debited by amount + fee (before={before}, fee={fee})"
+        );
+    }
+}
+
+mod failure {
+    use super::*;
+
+    /// A payment whose amount exceeds the only channel's capacity (5,000,000 sat)
+    /// has no possible route, so the LN attempt fails. SwissKnife must mark it
+    /// failed and release the reservation, leaving the wallet whole — the invariant
+    /// the payment UoW enforces, exercised here over a real backend. Exceeding
+    /// channel *capacity* (not just current liquidity) keeps this deterministic
+    /// regardless of test order.
+    #[tokio::test]
+    async fn an_unroutable_payment_fails_and_releases_the_reservation() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let wallet = app.create_wallet(token, "ln-unroutable").await;
+
+        // Fund above channel capacity so the reserve passes and the failure is a
+        // routing failure, not insufficient funds.
+        app.fund_onchain(token, wallet.id, 10_000_000).await;
+        let before = app.wallet_balance(token, wallet.id).await.available_msat;
+
+        // 8M sat > 5M channel capacity: no route can carry it.
+        let amount_msat = 8_000_000_000u64;
+        let bolt11 = Counterparty::for_provider(&app.provider).invoice(amount_msat, &unique("cp-unroutable"));
+
+        let res = app
+            .api()
+            .post(
+                "/v1/payments",
+                Auth::Bearer(token),
+                SendPaymentRequest {
+                    wallet_id: Some(wallet.id),
+                    input: bolt11,
+                    amount_msat: None,
+                    comment: None,
+                },
+            )
+            .await;
+        // A failed Lightning payment is a client-facing 422 (LightningError::Pay).
+        assert_error(&res, StatusCode::UNPROCESSABLE_ENTITY);
+
+        // The reservation is released: the wallet is back where it started.
+        let after = app.wallet_balance(token, wallet.id).await.available_msat;
+        assert_eq!(after, before, "the failed payment released its reservation");
+
+        // And the attempt is recorded as a failed payment with a reason.
+        let payments = app
+            .api()
+            .get(&format!("/v1/payments?wallet_id={}", wallet.id), Auth::Bearer(token))
+            .await;
+        assert_status(&payments, StatusCode::OK);
+        assert!(
+            payments
+                .parse::<Vec<Payment>>()
+                .iter()
+                .any(|p| p.status == PaymentStatus::Failed && p.error.is_some()),
+            "the unroutable attempt is recorded as failed"
         );
     }
 }

--- a/tests/suites/mod.rs
+++ b/tests/suites/mod.rs
@@ -11,3 +11,4 @@ mod me;
 mod payments;
 mod system;
 mod wallets;
+mod well_known;

--- a/tests/suites/well_known.rs
+++ b/tests/suites/well_known.rs
@@ -1,0 +1,175 @@
+//! Public, unauthenticated endpoints an external wallet hits to reach a
+//! SwissKnife user: LNURL-pay (LUD-06) and Nostr NIP-05. These serve OUR
+//! endpoints — no outbound calls — so no mock server is needed, and the LNURL
+//! pay flow settles over the real LND<->CLN channel. Paying *out* to someone
+//! else's address/Nostr (which needs a mock server) is covered separately.
+
+use std::time::Duration;
+
+use reqwest::StatusCode;
+
+use swissknife_types::{LnURLPayRequest, LnUrlCallback, NostrNIP05Response, Wallet};
+
+use crate::common::counterparty::Counterparty;
+use crate::common::fixtures::unique;
+use crate::common::wait::wait_until;
+use crate::common::{app, assert_error, assert_status, Auth, TestApp};
+
+/// Register an LN address (and optionally a Nostr key) under a fresh wallet,
+/// returning the wallet and the username that keys its public endpoints.
+async fn register_address(app: &TestApp, token: &str, label: &str, nostr_pubkey: Option<&str>) -> (Wallet, String) {
+    let wallet = app.create_wallet(token, label).await;
+    let username = unique(label);
+    let body = serde_json::json!({
+        "wallet_id": wallet.id,
+        "username": username,
+        "allows_nostr": nostr_pubkey.is_some(),
+        "nostr_pubkey": nostr_pubkey,
+    });
+    let res = app
+        .api()
+        .post("/v1/lightning-addresses", Auth::Bearer(token), body)
+        .await;
+    assert_status(&res, StatusCode::OK);
+    (wallet, username)
+}
+
+mod lnurl {
+    use super::*;
+
+    #[tokio::test]
+    async fn well_known_describes_the_pay_endpoint() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let (_wallet, username) = register_address(app, token, "lnurl-meta", None).await;
+
+        let res = app
+            .api()
+            .get(&format!("/.well-known/lnurlp/{username}"), Auth::None)
+            .await;
+        assert_status(&res, StatusCode::OK);
+        let pay = res.parse::<LnURLPayRequest>();
+        assert_eq!(pay.tag, "payRequest");
+        assert!(
+            pay.min_sendable >= 1 && pay.min_sendable <= pay.max_sendable,
+            "sendable range is sane: {}..={}",
+            pay.min_sendable,
+            pay.max_sendable
+        );
+        assert!(
+            pay.callback.contains(&username),
+            "the callback URL targets this user: {}",
+            pay.callback
+        );
+        assert!(
+            !pay.metadata.is_empty(),
+            "metadata is served for signature verification"
+        );
+    }
+
+    #[tokio::test]
+    async fn callback_issues_a_bolt11_for_the_requested_amount() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let (_wallet, username) = register_address(app, token, "lnurl-cb", None).await;
+
+        let res = app
+            .api()
+            .get(&format!("/lnurlp/{username}/callback?amount=100000000"), Auth::None)
+            .await;
+        assert_status(&res, StatusCode::OK);
+        let cb = res.parse::<LnUrlCallback>();
+        assert!(
+            cb.pr.to_lowercase().starts_with("lnbcrt"),
+            "a regtest bolt11 invoice was issued: {}",
+            cb.pr
+        );
+    }
+
+    #[tokio::test]
+    async fn an_external_payer_settles_via_the_address() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let (wallet, username) = register_address(app, token, "lnurl-pay", None).await;
+
+        let amount_msat = 100_000_000u64;
+        let cb = app
+            .api()
+            .get(&format!("/lnurlp/{username}/callback?amount={amount_msat}"), Auth::None)
+            .await
+            .parse::<LnUrlCallback>();
+
+        // An external wallet pays the invoice the callback issued over the channel.
+        Counterparty::for_provider(&app.provider).pay(&cb.pr);
+
+        wait_until(
+            Duration::from_secs(45),
+            "wallet credited via its lightning address",
+            || async { app.wallet_balance(token, wallet.id).await.available_msat >= amount_msat as i64 },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn unknown_username_is_not_found() {
+        let app = app().await;
+        let res = app
+            .api()
+            .get(&format!("/.well-known/lnurlp/{}", unique("nobody")), Auth::None)
+            .await;
+        assert_error(&res, StatusCode::NOT_FOUND);
+    }
+}
+
+mod nostr {
+    use super::*;
+
+    // The secp256k1 generator x-coordinate: a valid BIP-340 x-only key, used as a
+    // deterministic Nostr pubkey for the NIP-05 mapping.
+    const NOSTR_PUBKEY: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    #[tokio::test]
+    async fn nip05_returns_the_registered_pubkey() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let (_wallet, username) = register_address(app, token, "nip05", Some(NOSTR_PUBKEY)).await;
+
+        let res = app
+            .api()
+            .get(&format!("/.well-known/nostr.json?name={username}"), Auth::None)
+            .await;
+        assert_status(&res, StatusCode::OK);
+        let names = res.parse::<NostrNIP05Response>().names;
+        assert_eq!(
+            names.get(&username).map(String::as_str),
+            Some(NOSTR_PUBKEY),
+            "NIP-05 maps the username to its registered pubkey"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_address_without_nostr_is_not_found() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let (_wallet, username) = register_address(app, token, "nip05-off", None).await;
+
+        let res = app
+            .api()
+            .get(&format!("/.well-known/nostr.json?name={username}"), Auth::None)
+            .await;
+        assert_error(&res, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unknown_name_is_not_found() {
+        let app = app().await;
+        let res = app
+            .api()
+            .get(
+                &format!("/.well-known/nostr.json?name={}", unique("nobody")),
+                Auth::None,
+            )
+            .await;
+        assert_error(&res, StatusCode::NOT_FOUND);
+    }
+}

--- a/tests/suites/well_known.rs
+++ b/tests/suites/well_known.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use reqwest::StatusCode;
 
-use swissknife_types::{LnURLPayRequest, LnUrlCallback, NostrNIP05Response, Wallet};
+use swissknife_types::{LnAddress, LnURLPayRequest, LnUrlCallback, NostrNIP05Response, UpdateLnAddressRequest, Wallet};
 
 use crate::common::counterparty::Counterparty;
 use crate::common::fixtures::unique;
@@ -16,13 +16,12 @@ use crate::common::wait::wait_until;
 use crate::common::{app, assert_error, assert_status, Auth, TestApp};
 
 /// Register an LN address (and optionally a Nostr key) under a fresh wallet,
-/// returning the wallet and the username that keys its public endpoints.
-async fn register_address(app: &TestApp, token: &str, label: &str, nostr_pubkey: Option<&str>) -> (Wallet, String) {
+/// returning the wallet and the created address.
+async fn register_address(app: &TestApp, token: &str, label: &str, nostr_pubkey: Option<&str>) -> (Wallet, LnAddress) {
     let wallet = app.create_wallet(token, label).await;
-    let username = unique(label);
     let body = serde_json::json!({
         "wallet_id": wallet.id,
-        "username": username,
+        "username": unique(label),
         "allows_nostr": nostr_pubkey.is_some(),
         "nostr_pubkey": nostr_pubkey,
     });
@@ -31,21 +30,38 @@ async fn register_address(app: &TestApp, token: &str, label: &str, nostr_pubkey:
         .post("/v1/lightning-addresses", Auth::Bearer(token), body)
         .await;
     assert_status(&res, StatusCode::OK);
-    (wallet, username)
+    (wallet, res.parse::<LnAddress>())
 }
 
 mod lnurl {
     use super::*;
 
+    /// Follow the advertised LNURL `callback` URL exactly as an external wallet
+    /// would, rather than reconstructing the path — so a wrong or unreachable
+    /// advertised callback would be caught.
+    async fn follow_callback(callback: &str, amount_msat: u64) -> LnUrlCallback {
+        let res = reqwest::get(format!("{callback}?amount={amount_msat}"))
+            .await
+            .expect("reach the advertised LNURL callback");
+        assert_eq!(
+            res.status().as_u16(),
+            200,
+            "advertised callback was not reachable / failed"
+        );
+        res.json::<LnUrlCallback>()
+            .await
+            .expect("callback returns an LnUrlCallback")
+    }
+
     #[tokio::test]
-    async fn well_known_describes_the_pay_endpoint() {
+    async fn well_known_advertises_a_reachable_pay_endpoint() {
         let app = app().await;
         let token = app.admin_token().await;
-        let (_wallet, username) = register_address(app, token, "lnurl-meta", None).await;
+        let (_wallet, addr) = register_address(app, token, "lnurl-meta", None).await;
 
         let res = app
             .api()
-            .get(&format!("/.well-known/lnurlp/{username}"), Auth::None)
+            .get(&format!("/.well-known/lnurlp/{}", addr.username), Auth::None)
             .await;
         assert_status(&res, StatusCode::OK);
         let pay = res.parse::<LnURLPayRequest>();
@@ -57,9 +73,14 @@ mod lnurl {
             pay.max_sendable
         );
         assert!(
-            pay.callback.contains(&username),
-            "the callback URL targets this user: {}",
-            pay.callback
+            pay.callback.starts_with(&app.base_url),
+            "the advertised callback targets this server: {} (base {})",
+            pay.callback,
+            app.base_url
+        );
+        assert!(
+            pay.callback.contains(&addr.username),
+            "the callback identifies the user"
         );
         assert!(
             !pay.metadata.is_empty(),
@@ -68,17 +89,17 @@ mod lnurl {
     }
 
     #[tokio::test]
-    async fn callback_issues_a_bolt11_for_the_requested_amount() {
+    async fn the_advertised_callback_issues_a_bolt11() {
         let app = app().await;
         let token = app.admin_token().await;
-        let (_wallet, username) = register_address(app, token, "lnurl-cb", None).await;
+        let (_wallet, addr) = register_address(app, token, "lnurl-cb", None).await;
 
-        let res = app
+        let pay = app
             .api()
-            .get(&format!("/lnurlp/{username}/callback?amount=100000000"), Auth::None)
-            .await;
-        assert_status(&res, StatusCode::OK);
-        let cb = res.parse::<LnUrlCallback>();
+            .get(&format!("/.well-known/lnurlp/{}", addr.username), Auth::None)
+            .await
+            .parse::<LnURLPayRequest>();
+        let cb = follow_callback(&pay.callback, 100_000_000).await;
         assert!(
             cb.pr.to_lowercase().starts_with("lnbcrt"),
             "a regtest bolt11 invoice was issued: {}",
@@ -90,16 +111,16 @@ mod lnurl {
     async fn an_external_payer_settles_via_the_address() {
         let app = app().await;
         let token = app.admin_token().await;
-        let (wallet, username) = register_address(app, token, "lnurl-pay", None).await;
+        let (wallet, addr) = register_address(app, token, "lnurl-pay", None).await;
 
         let amount_msat = 100_000_000u64;
-        let cb = app
+        let pay = app
             .api()
-            .get(&format!("/lnurlp/{username}/callback?amount={amount_msat}"), Auth::None)
+            .get(&format!("/.well-known/lnurlp/{}", addr.username), Auth::None)
             .await
-            .parse::<LnUrlCallback>();
-
-        // An external wallet pays the invoice the callback issued over the channel.
+            .parse::<LnURLPayRequest>();
+        // Resolve and pay strictly through the advertised callback.
+        let cb = follow_callback(&pay.callback, amount_msat).await;
         Counterparty::for_provider(&app.provider).pay(&cb.pr);
 
         wait_until(
@@ -108,6 +129,37 @@ mod lnurl {
             || async { app.wallet_balance(token, wallet.id).await.available_msat >= amount_msat as i64 },
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn an_inactive_address_is_not_found() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let (_wallet, addr) = register_address(app, token, "lnurl-inactive", None).await;
+
+        // Deactivate the address; an inactive address cannot receive.
+        let updated = app
+            .api()
+            .put(
+                &format!("/v1/lightning-addresses/{}", addr.id),
+                Auth::Bearer(token),
+                UpdateLnAddressRequest {
+                    username: None,
+                    active: Some(false),
+                    allows_nostr: None,
+                    nostr_pubkey: None,
+                },
+            )
+            .await;
+        assert_status(&updated, StatusCode::OK);
+        assert!(!updated.parse::<LnAddress>().active);
+
+        // The public endpoint no longer resolves it.
+        let res = app
+            .api()
+            .get(&format!("/.well-known/lnurlp/{}", addr.username), Auth::None)
+            .await;
+        assert_error(&res, StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -132,16 +184,17 @@ mod nostr {
     async fn nip05_returns_the_registered_pubkey() {
         let app = app().await;
         let token = app.admin_token().await;
-        let (_wallet, username) = register_address(app, token, "nip05", Some(NOSTR_PUBKEY)).await;
+        let (_wallet, addr) = register_address(app, token, "nip05", Some(NOSTR_PUBKEY)).await;
+        assert!(addr.allows_nostr, "registering with a pubkey enables nostr");
 
         let res = app
             .api()
-            .get(&format!("/.well-known/nostr.json?name={username}"), Auth::None)
+            .get(&format!("/.well-known/nostr.json?name={}", addr.username), Auth::None)
             .await;
         assert_status(&res, StatusCode::OK);
         let names = res.parse::<NostrNIP05Response>().names;
         assert_eq!(
-            names.get(&username).map(String::as_str),
+            names.get(&addr.username).map(String::as_str),
             Some(NOSTR_PUBKEY),
             "NIP-05 maps the username to its registered pubkey"
         );
@@ -151,11 +204,12 @@ mod nostr {
     async fn an_address_without_nostr_is_not_found() {
         let app = app().await;
         let token = app.admin_token().await;
-        let (_wallet, username) = register_address(app, token, "nip05-off", None).await;
+        let (_wallet, addr) = register_address(app, token, "nip05-off", None).await;
+        assert!(!addr.allows_nostr);
 
         let res = app
             .api()
-            .get(&format!("/.well-known/nostr.json?name={username}"), Auth::None)
+            .get(&format!("/.well-known/nostr.json?name={}", addr.username), Auth::None)
             .await;
         assert_error(&res, StatusCode::NOT_FOUND);
     }


### PR DESCRIPTION
## What

Extends the black-box integration suite with the highest-value gaps from the coverage audit, all running across the full LND/CLN × gRPC/REST matrix on both DBs. Includes two fixes the new tests surfaced (below).

## Added

**On-chain withdrawal** (`tests/suites/bitcoin.rs`, `mod withdraw`) — pay an external bitcoin address end to end: broadcast via the node, the reservation debits the wallet, the on-chain listener settles on confirmation, and the sats are asserted to land at the destination. The only money path with no coverage. (The on-chain wallet is the LN node, so this also exercises the LND/CLN `fund_psbt` path on both backends.)

**Public well-known endpoints** (`tests/suites/well_known.rs`, new suite) — the inbound flows an external wallet uses to reach a SwissKnife user; no mock server needed because we are the server. LNURL-pay `/.well-known/lnurlp/{username}` + callback, including an external payer settling via the lightning address over the channel; Nostr NIP-05 `/.well-known/nostr.json`.

**Unroutable Lightning payment** (`tests/suites/lightning.rs`, `mod failure`) — an amount above the 5,000,000-sat channel capacity has no route, so it fails deterministically regardless of liquidity or test order. Asserts 422 and that the reservation is released over a real backend.

## Fixes surfaced by these tests

**`fix(lnd)` — LND REST LNURL invoices were broken.** The callback's invoice generation sent the description hash as hex; LND REST reads byte fields as base64, so 64 hex chars decoded to 48 bytes and were rejected ("must be 32"). LNURL-pay invoices therefore failed on the LND REST adapter (gRPC and CLN were fine). Now base64-encoded; the new callback test is the regression.

**`test(itest)` — CLN cold-start sync.** On a freshly-bootstrapped stack a cold CLN trails the chain tip, and the added on-chain mining tipped a concurrent `pay` over CLN's blockheight-wait timeout. Poll bitcoind every 1s and add a post-bootstrap sync barrier so nodes start at the tip and stay current as tests mine.

## Validated

9 new tests green on lnd_grpc; the full cln_grpc suite passes from a cold bootstrap (83/83); fmt + clippy clean. The full provider matrix runs in CI.

## Deferred (per discussion)

Paying *out* to an external lightning address / LNURL / Nostr, and OAuth2/OIDC login — these need a mock server and will land in follow-up PRs.
