### PR TITLE
fix(events): don't drop on-chain deposits on write failure

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -20,7 +20,6 @@ certs_dir = "certs/lightningd"
 maxfeepercent = 0.5
 payment_timeout = "60s"
 payment_exemptfee = 5000
-retry_delay = "5s"
 
 [cln_rest_config]
 endpoint = "http://localhost:3010"
@@ -49,8 +48,6 @@ accept_invalid_certs = false
 accept_invalid_hostnames = false
 payment_timeout = "60s"
 fee_limit_msat = 25000
-ws_min_reconnect_delay = "1s"
-ws_max_reconnect_delay = "30s"
 reorg_buffer_blocks = 2
 
 [lnd_grpc_config]
@@ -59,7 +56,6 @@ cert_path = "certs/lnd/tls.cert"
 macaroon_path = "certs/lnd/admin.macaroon"
 payment_timeout = "60s"
 fee_limit_msat = 25000
-retry_delay = "2s"
 reorg_buffer_blocks = 2
 
 # Logging
@@ -96,3 +92,6 @@ min_connections = 0
 acquire_timeout = "5s"
 connect_timeout = "30s"
 sqlx_logging = false
+# SQLite-only: how long a writer waits for the lock before failing with SQLITE_BUSY.
+# Ignored for Postgres.
+busy_timeout = "10s"

--- a/config/itest.toml
+++ b/config/itest.toml
@@ -38,7 +38,6 @@ cert_path = "tests/itest/runtime/lnd/ca.cert"
 macaroon_path = "tests/itest/runtime/lnd/data/chain/bitcoin/regtest/admin.macaroon"
 fee_limit_msat = 25000
 payment_timeout = "10s"
-retry_delay = "1s"
 reorg_buffer_blocks = 2
 
 [lnd_rest_config]
@@ -52,8 +51,6 @@ accept_invalid_certs = true
 accept_invalid_hostnames = true
 fee_limit_msat = 25000
 payment_timeout = "10s"
-ws_min_reconnect_delay = "1s"
-ws_max_reconnect_delay = "5s"
 reorg_buffer_blocks = 2
 
 [cln_grpc_config]
@@ -62,7 +59,6 @@ certs_dir = "tests/itest/runtime/cln/regtest"
 maxfeepercent = 0.5
 payment_timeout = "10s"
 payment_exemptfee = 5000
-retry_delay = "1s"
 
 [cln_rest_config]
 endpoint = "https://127.0.0.1:3010"

--- a/src/application/errors/lightning_error.rs
+++ b/src/application/errors/lightning_error.rs
@@ -20,6 +20,9 @@ pub enum LightningError {
     #[error("Lightning event listener failure: {0}")]
     Listener(String),
 
+    #[error("Failed to process Lightning node event: {0}")]
+    EventProcessing(String),
+
     #[error("Failed to generate Lightning invoice: {0}")]
     Invoice(String),
 

--- a/src/infra/app/event_listener.rs
+++ b/src/infra/app/event_listener.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
+
+use tokio::time::{sleep, Instant};
+use tracing::{error, warn};
 
 use crate::{
     application::{
@@ -13,6 +16,15 @@ use crate::{
         EventsListener,
     },
 };
+
+/// Backoff bounds for the listener supervisor. The listener owns deposit/invoice
+/// ingestion, so it must never stay down: on any exit we reconnect (and re-sync)
+/// with exponential backoff rather than letting the task die silently (issue #267).
+const LISTENER_MIN_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const LISTENER_MAX_RECONNECT_DELAY: Duration = Duration::from_secs(60);
+/// A connection that stayed up at least this long is considered healthy, so the
+/// next failure restarts from the minimum delay instead of the grown backoff.
+const LISTENER_STABLE_THRESHOLD: Duration = Duration::from_secs(60);
 
 pub struct EventListener {
     listener: Arc<dyn EventsListener>,
@@ -74,8 +86,26 @@ impl EventListener {
     pub async fn start(&self) -> Result<(), ApplicationError> {
         let listener = self.listener.clone();
         tokio::spawn(async move {
-            if let Err(err) = listener.listen().await {
-                panic!("Critical: Lightning listener failed: {}", err);
+            let mut backoff = LISTENER_MIN_RECONNECT_DELAY;
+
+            loop {
+                let started = Instant::now();
+                let outcome = listener.listen().await;
+                let uptime = started.elapsed();
+
+                match outcome {
+                    // `listen()` only returns on failure (or a clean stream close); either
+                    // way the listener is no longer ingesting events, so reconnect.
+                    Ok(()) => warn!("Lightning listener stopped; reconnecting"),
+                    Err(err) => error!(%err, ?backoff, "Lightning listener failed; reconnecting"),
+                }
+
+                sleep(backoff).await;
+                backoff = if uptime >= LISTENER_STABLE_THRESHOLD {
+                    LISTENER_MIN_RECONNECT_DELAY
+                } else {
+                    (backoff * 2).min(LISTENER_MAX_RECONNECT_DELAY)
+                };
             }
         });
 

--- a/src/infra/database/sea_orm/config.rs
+++ b/src/infra/database/sea_orm/config.rs
@@ -18,4 +18,8 @@ pub struct SeaOrmConfig {
     #[serde(deserialize_with = "deserialize_duration")]
     pub max_lifetime: Duration,
     pub sqlx_logging: Option<bool>,
+    /// SQLite-only: how long a writer waits for the lock before failing with
+    /// `SQLITE_BUSY`. Ignored for Postgres.
+    #[serde(deserialize_with = "deserialize_duration")]
+    pub busy_timeout: Duration,
 }

--- a/src/infra/database/sea_orm/store.rs
+++ b/src/infra/database/sea_orm/store.rs
@@ -1,8 +1,14 @@
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use migration::{Migrator, MigratorTrait};
-use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm::{
+    sqlx::{
+        sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+        ConnectOptions as SqlxConnectOptions,
+    },
+    ConnectOptions, Database, DatabaseConnection, SqlxSqliteConnector,
+};
 use tracing::{debug, trace};
 
 use crate::{
@@ -41,6 +47,26 @@ impl SeaOrmStore {
     }
 
     async fn connect_database(config: SeaOrmConfig) -> Result<DatabaseConnection, DatabaseError> {
+        // SQLite needs WAL + a busy_timeout to survive concurrent writers.
+        // sea-orm's ConnectOptions exposes no SQLite pragma API and sqlx-sqlite ignores
+        // them as URL query params, so build the sqlx pool directly for SQLite. Postgres
+        // serializes writes and keeps the standard sea-orm path.
+        let db_conn = if config.url.starts_with("sqlite:") {
+            Self::connect_sqlite(&config).await?
+        } else {
+            Self::connect_generic(config).await?
+        };
+
+        trace!("Running database migrations");
+        Migrator::up(&db_conn, None)
+            .await
+            .map_err(|e| DatabaseError::Migrations(e.to_string()))?;
+        debug!("Database migrations completed successfully");
+
+        Ok(db_conn)
+    }
+
+    async fn connect_generic(config: SeaOrmConfig) -> Result<DatabaseConnection, DatabaseError> {
         let mut opt = ConnectOptions::new(config.url);
 
         opt.connect_timeout(config.connect_timeout);
@@ -60,17 +86,48 @@ impl SeaOrmStore {
             opt.sqlx_logging(sqlx_logging);
         }
 
-        let db_conn = Database::connect(opt)
+        Database::connect(opt)
+            .await
+            .map_err(|e| DatabaseError::Connect(e.to_string()))
+    }
+
+    async fn connect_sqlite(config: &SeaOrmConfig) -> Result<DatabaseConnection, DatabaseError> {
+        let mut connect_opts = SqliteConnectOptions::from_str(&config.url)
+            .map_err(|e| DatabaseError::Connect(e.to_string()))?
+            // WAL lets readers proceed without blocking the single writer; the busy
+            // timeout makes a contending writer wait for the lock instead of failing
+            // instantly with SQLITE_BUSY. FULL keeps commits durable (a crash cannot
+            // lose a committed deposit). Writers stay serialized, so balance updates
+            // (atomic `SET x = x ± n` statements) are unaffected.
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(config.busy_timeout)
+            .synchronous(SqliteSynchronous::Full);
+
+        if !config.sqlx_logging.unwrap_or(false) {
+            connect_opts = connect_opts.disable_statement_logging();
+        }
+
+        let mut pool_opts = SqlitePoolOptions::new()
+            .acquire_timeout(config.acquire_timeout)
+            .idle_timeout(config.idle_timeout)
+            .max_lifetime(config.max_lifetime);
+
+        if let Some(max_connections) = config.max_connections {
+            pool_opts = pool_opts.max_connections(max_connections);
+        }
+
+        if let Some(min_connections) = config.min_connections {
+            pool_opts = pool_opts.min_connections(min_connections);
+        }
+
+        let pool = pool_opts
+            .connect_with(connect_opts)
             .await
             .map_err(|e| DatabaseError::Connect(e.to_string()))?;
 
-        trace!("Running database migrations");
-        Migrator::up(&db_conn, None)
-            .await
-            .map_err(|e| DatabaseError::Migrations(e.to_string()))?;
-        debug!("Database migrations completed successfully");
+        debug!(busy_timeout = ?config.busy_timeout, "SQLite connection pool configured with WAL journal mode");
 
-        Ok(db_conn)
+        Ok(SqlxSqliteConnector::from_sqlx_sqlite_pool(pool))
     }
 }
 

--- a/src/infra/lightning/cln/cln_grpc_client.rs
+++ b/src/infra/lightning/cln/cln_grpc_client.rs
@@ -59,8 +59,6 @@ pub struct ClnClientConfig {
     #[serde(deserialize_with = "deserialize_duration")]
     pub payment_timeout: Duration,
     pub payment_exemptfee: Option<u64>,
-    #[serde(deserialize_with = "deserialize_duration")]
-    pub retry_delay: Duration,
 }
 
 const DEFAULT_CLIENT_CERT_FILENAME: &str = "client.pem";

--- a/src/infra/lightning/cln/cln_grpc_listener.rs
+++ b/src/infra/lightning/cln/cln_grpc_listener.rs
@@ -1,10 +1,9 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
-use tokio::time::sleep;
-use tonic::{transport::Channel, Code};
-use tracing::{error, trace, warn};
+use tonic::transport::Channel;
+use tracing::{trace, warn};
 
 use super::{
     cln::{
@@ -35,7 +34,6 @@ pub struct ClnGrpcListener {
     client: NodeClient<Channel>,
     services: Arc<AppServices>,
     wallet: Arc<dyn BitcoinWallet>,
-    retry_delay: Duration,
 }
 
 impl ClnGrpcListener {
@@ -50,26 +48,7 @@ impl ClnGrpcListener {
             client,
             services,
             wallet,
-            retry_delay: config.retry_delay,
         })
-    }
-
-    /// Handles a gRPC error by sleeping and returning Ok(()) for retryable errors,
-    /// or returning Err for fatal errors.
-    async fn handle_grpc_error(&self, err: tonic::Status, context: &str) -> Result<(), LightningError> {
-        match err.code() {
-            Code::Aborted
-            | Code::Cancelled
-            | Code::DeadlineExceeded
-            | Code::Internal
-            | Code::FailedPrecondition
-            | Code::Unavailable => {
-                error!(err = err.message(), "{}. Retrying...", context);
-                sleep(self.retry_delay).await;
-                Ok(())
-            }
-            _ => Err(LightningError::Listener(err.to_string())),
-        }
     }
 
     async fn listen_invoices(&self) -> Result<(), LightningError> {
@@ -78,70 +57,56 @@ impl ClnGrpcListener {
         loop {
             trace!(next_index, "Waiting for invoice update...");
 
-            let result = {
-                let mut client = self.client.clone();
-                client
-                    .wait(WaitRequest {
-                        subsystem: WaitSubsystem::Invoices as i32,
-                        indexname: WaitIndexname::Updated as i32,
-                        nextvalue: next_index,
-                    })
-                    .await
-            };
+            let response = self
+                .client
+                .clone()
+                .wait(WaitRequest {
+                    subsystem: WaitSubsystem::Invoices as i32,
+                    indexname: WaitIndexname::Updated as i32,
+                    nextvalue: next_index,
+                })
+                .await
+                .map_err(|e| LightningError::Listener(e.to_string()))?
+                .into_inner();
 
-            match result {
-                Ok(response) => {
-                    let response = response.into_inner();
-                    let updated_index = response.updated;
+            let updated_index = response.updated;
 
-                    if let Some(invoices) = response.invoices {
-                        match invoices.status() {
-                            WaitInvoicesStatus::Paid => {
-                                let Some(label) = invoices.label.clone() else {
-                                    warn!("Invoice update missing label");
-                                    if let Some(index) = updated_index {
-                                        next_index = index.saturating_add(1);
-                                    }
-                                    continue;
-                                };
+            if let Some(invoices) = response.invoices {
+                match invoices.status() {
+                    WaitInvoicesStatus::Paid => {
+                        let Some(label) = invoices.label.clone() else {
+                            warn!("Invoice update missing label");
+                            if let Some(index) = updated_index {
+                                next_index = index.saturating_add(1);
+                            }
+                            continue;
+                        };
 
-                                let invoice = loop {
-                                    let result = {
-                                        let mut client = self.client.clone();
-                                        client.wait_invoice(WaitinvoiceRequest { label: label.clone() }).await
-                                    };
+                        let invoice = self
+                            .client
+                            .clone()
+                            .wait_invoice(WaitinvoiceRequest { label })
+                            .await
+                            .map_err(|e| LightningError::Listener(e.to_string()))?
+                            .into_inner();
 
-                                    match result {
-                                        Ok(response) => break response.into_inner(),
-                                        Err(err) => {
-                                            self.handle_grpc_error(err, "Error waiting for invoice").await?;
-                                        }
-                                    }
-                                };
-
-                                match invoice.status() {
-                                    WaitinvoiceStatus::Paid => {
-                                        if let Err(err) = self.services.event.invoice_paid(invoice.clone().into()).await
-                                        {
-                                            warn!(%err, "Failed to process incoming payment");
-                                        }
-                                    }
-                                    WaitinvoiceStatus::Expired => {}
+                        match invoice.status() {
+                            WaitinvoiceStatus::Paid => {
+                                if let Err(err) = self.services.event.invoice_paid(invoice.clone().into()).await {
+                                    warn!(%err, "Failed to process incoming payment");
                                 }
                             }
-                            WaitInvoicesStatus::Expired | WaitInvoicesStatus::Unpaid => {}
+                            WaitinvoiceStatus::Expired => {}
                         }
-                    } else if next_index != 0 {
-                        warn!("Invoice wait response missing invoice details");
                     }
+                    WaitInvoicesStatus::Expired | WaitInvoicesStatus::Unpaid => {}
+                }
+            } else if next_index != 0 {
+                warn!("Invoice wait response missing invoice details");
+            }
 
-                    if let Some(index) = updated_index {
-                        next_index = index.saturating_add(1);
-                    }
-                }
-                Err(err) => {
-                    self.handle_grpc_error(err, "Error waiting for invoice").await?;
-                }
+            if let Some(index) = updated_index {
+                next_index = index.saturating_add(1);
             }
         }
     }
@@ -152,58 +117,49 @@ impl ClnGrpcListener {
         loop {
             trace!(next_index, "Waiting for new sendpay update...");
 
-            let result = {
-                let mut client = self.client.clone();
-                client
-                    .wait(WaitRequest {
-                        subsystem: WaitSubsystem::Sendpays as i32,
-                        indexname: WaitIndexname::Updated as i32,
-                        nextvalue: next_index,
-                    })
-                    .await
-            };
+            let response = self
+                .client
+                .clone()
+                .wait(WaitRequest {
+                    subsystem: WaitSubsystem::Sendpays as i32,
+                    indexname: WaitIndexname::Updated as i32,
+                    nextvalue: next_index,
+                })
+                .await
+                .map_err(|e| LightningError::Listener(e.to_string()))?
+                .into_inner();
 
-            match result {
-                Ok(response) => {
-                    let response = response.into_inner();
+            if let Some(sendpays) = response.sendpays {
+                let Some(payment_hash_bytes) = sendpays.payment_hash.clone() else {
+                    warn!("Sendpay update missing payment hash");
+                    continue;
+                };
 
-                    if let Some(sendpays) = response.sendpays {
-                        let Some(payment_hash_bytes) = sendpays.payment_hash.clone() else {
-                            warn!("Sendpay update missing payment hash");
-                            continue;
-                        };
-
-                        let payment_hash = hex::encode(&payment_hash_bytes);
-                        match sendpays.status() {
-                            WaitSendpaysStatus::Complete => {
-                                if let Err(err) = self
-                                    .handle_sendpay_complete(payment_hash_bytes, sendpays.partid, sendpays.groupid)
-                                    .await
-                                {
-                                    warn!(%err, "Failed to process completed outgoing payment");
-                                }
-                            }
-                            WaitSendpaysStatus::Failed => {
-                                let failure_event = LnPayFailureEvent {
-                                    reason: "Payment failed".to_string(),
-                                    payment_hash,
-                                };
-                                if let Err(err) = self.services.event.failed_payment(failure_event).await {
-                                    warn!(%err, "Failed to process failed outgoing payment");
-                                }
-                            }
-                            WaitSendpaysStatus::Pending => {}
+                let payment_hash = hex::encode(&payment_hash_bytes);
+                match sendpays.status() {
+                    WaitSendpaysStatus::Complete => {
+                        if let Err(err) = self
+                            .handle_sendpay_complete(payment_hash_bytes, sendpays.partid, sendpays.groupid)
+                            .await
+                        {
+                            warn!(%err, "Failed to process completed outgoing payment");
                         }
                     }
-
-                    let updated_index = response.updated;
-                    if let Some(index) = updated_index {
-                        next_index = index.saturating_add(1);
+                    WaitSendpaysStatus::Failed => {
+                        let failure_event = LnPayFailureEvent {
+                            reason: "Payment failed".to_string(),
+                            payment_hash,
+                        };
+                        if let Err(err) = self.services.event.failed_payment(failure_event).await {
+                            warn!(%err, "Failed to process failed outgoing payment");
+                        }
                     }
+                    WaitSendpaysStatus::Pending => {}
                 }
-                Err(err) => {
-                    self.handle_grpc_error(err, "Error waiting for sendpay updates").await?;
-                }
+            }
+
+            if let Some(index) = response.updated {
+                next_index = index.saturating_add(1);
             }
         }
     }
@@ -224,46 +180,32 @@ impl ClnGrpcListener {
         loop {
             trace!(next_index, "Waiting for new chainmove...");
 
-            let result = {
-                let mut client = self.client.clone();
-                client
-                    .wait(WaitRequest {
-                        subsystem: WaitSubsystem::Chainmoves as i32,
-                        indexname: WaitIndexname::Created as i32,
-                        nextvalue: next_index,
-                    })
-                    .await
+            let response = self
+                .client
+                .clone()
+                .wait(WaitRequest {
+                    subsystem: WaitSubsystem::Chainmoves as i32,
+                    indexname: WaitIndexname::Created as i32,
+                    nextvalue: next_index,
+                })
+                .await
+                .map_err(|e| LightningError::Listener(e.to_string()))?
+                .into_inner();
+
+            let Some(created_index) = response.created else {
+                warn!("Chainmoves wait response missing created index");
+                continue;
             };
 
-            match result {
-                Ok(response) => {
-                    let response = response.into_inner();
-                    let Some(created_index) = response.created else {
-                        warn!("Chainmoves wait response missing created index");
-                        continue;
-                    };
-
-                    match self.handle_chainmoves(created_index).await {
-                        Ok(max_index) => {
-                            next_index = max_index.saturating_add(1);
-                            if let Err(err) = self
-                                .services
-                                .system
-                                .set_onchain_cursor(OnchainSyncCursor::CreatedIndex(next_index))
-                                .await
-                            {
-                                warn!(%err, "Failed to persist chainmoves cursor");
-                            }
-                        }
-                        Err(err) => {
-                            warn!(%err, "Failed to process onchain chainmoves");
-                        }
-                    }
-                }
-                Err(err) => {
-                    self.handle_grpc_error(err, "Error waiting for chainmoves").await?;
-                }
-            }
+            // A failed deposit/withdrawal write propagates out (cursor not advanced) so the
+            // supervisor reconnects and reprocesses from the un-advanced CreatedIndex.
+            let max_index = self.handle_chainmoves(created_index).await?;
+            next_index = max_index.saturating_add(1);
+            self.services
+                .system
+                .set_onchain_cursor(OnchainSyncCursor::CreatedIndex(next_index))
+                .await
+                .map_err(|e| LightningError::Listener(e.to_string()))?;
         }
     }
 
@@ -374,14 +316,13 @@ impl ClnGrpcListener {
                         }
                     };
 
-                    if let Err(err) = self
-                        .services
+                    // Propagate write failures so the cursor isn't advanced past a deposit we
+                    // failed to credit; the supervisor reconnects and reprocesses idempotently.
+                    self.services
                         .event
                         .onchain_deposit(output.into(), currency.clone())
                         .await
-                    {
-                        warn!(%err, "Failed to process onchain deposit");
-                    }
+                        .map_err(|e| LightningError::EventProcessing(e.to_string()))?;
                 }
                 (ListchainmovesChainmovesPrimaryTag::Withdrawal, "wallet") => {
                     let Some(spending_txid) = chainmove.spending_txid else {
@@ -394,9 +335,11 @@ impl ClnGrpcListener {
                         block_height: Some(chainmove.blockheight),
                     };
 
-                    if let Err(err) = self.services.event.onchain_withdrawal(event).await {
-                        warn!(%err, "Failed to process onchain withdrawal");
-                    }
+                    self.services
+                        .event
+                        .onchain_withdrawal(event)
+                        .await
+                        .map_err(|e| LightningError::EventProcessing(e.to_string()))?;
                 }
                 _ => {}
             }

--- a/src/infra/lightning/cln/cln_websocket_listener.rs
+++ b/src/infra/lightning/cln/cln_websocket_listener.rs
@@ -162,31 +162,34 @@ impl ClnWebsocketListener {
 
                             match wallet.synchronize(cursor_guard.clone()).await {
                                 Ok(batch) => {
+                                    let mut processed_all = true;
                                     for transaction in batch.events {
-                                        match transaction {
+                                        let result = match transaction {
                                             OnchainTransaction::Deposit(output) => {
-                                                if let Err(err) = services
-                                                    .event
-                                                    .onchain_deposit(output.into(), currency.clone())
-                                                    .await
-                                                {
-                                                    error!(%err, "Failed to process onchain deposit");
-                                                }
+                                                services.event.onchain_deposit(output.into(), currency.clone()).await
                                             }
                                             OnchainTransaction::Withdrawal(event) => {
-                                                if let Err(err) = services.event.onchain_withdrawal(event).await {
-                                                    error!(%err, "Failed to process onchain withdrawal");
-                                                }
+                                                services.event.onchain_withdrawal(event).await
                                             }
+                                        };
+
+                                        // Don't advance the cursor past a write we couldn't persist, or the
+                                        // deposit is lost. socket.io keeps the connection alive and re-syncs
+                                        // on the next chain event, reprocessing from the un-advanced cursor.
+                                        if let Err(err) = result {
+                                            error!(%err, "Failed to process onchain transaction; cursor not advanced");
+                                            processed_all = false;
+                                            break;
                                         }
                                     }
 
-                                    if let Some(next_cursor) = batch.next_cursor {
-                                        if let Err(err) = services.system.set_onchain_cursor(next_cursor.clone()).await
-                                        {
-                                            warn!(%err, "Failed to persist chainmoves cursor");
+                                    if processed_all {
+                                        if let Some(next_cursor) = batch.next_cursor {
+                                            match services.system.set_onchain_cursor(next_cursor.clone()).await {
+                                                Ok(()) => *cursor_guard = Some(next_cursor),
+                                                Err(err) => warn!(%err, "Failed to persist chainmoves cursor"),
+                                            }
                                         }
-                                        *cursor_guard = Some(next_cursor);
                                     }
                                 }
                                 Err(err) => {
@@ -234,10 +237,16 @@ impl EventsListener for ClnWebsocketListener {
             Self::on_message(services.clone(), wallet.clone(), cursor.clone(), payload)
         });
 
-        client_builder
+        // Hold the connected client: rust_socketio reconnects internally
+        // (reconnect_on_disconnect), so this listener owns its own recovery. Park the task
+        // for the process lifetime — returning would let the supervisor re-enter listen() on
+        // a builder already consumed by take() above, failing with "Listener already started".
+        let _client = client_builder
             .connect()
             .await
             .map_err(|e| LightningError::ConnectWebsocket(e.to_string()))?;
+
+        std::future::pending::<()>().await;
 
         Ok(())
     }

--- a/src/infra/lightning/lnd/lnd_grpc_client.rs
+++ b/src/infra/lightning/lnd/lnd_grpc_client.rs
@@ -101,8 +101,6 @@ pub struct LndGrpcClientConfig {
     pub fee_limit_msat: u64,
     #[serde(deserialize_with = "deserialize_duration")]
     pub payment_timeout: Duration,
-    #[serde(deserialize_with = "deserialize_duration")]
-    pub retry_delay: Duration,
     pub reorg_buffer_blocks: u32,
 }
 

--- a/src/infra/lightning/lnd/lnd_grpc_listener.rs
+++ b/src/infra/lightning/lnd/lnd_grpc_listener.rs
@@ -1,10 +1,8 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
-use tokio::time::sleep;
-use tonic::{Code, Status};
-use tracing::{error, warn};
+use tracing::warn;
 
 use crate::{
     application::{composition::AppServices, errors::LightningError},
@@ -27,7 +25,6 @@ pub struct LndGrpcListener {
     client: LightningClient<LndChannel>,
     services: Arc<AppServices>,
     network: crate::domains::bitcoin::BtcNetwork,
-    retry_delay: Duration,
 }
 
 impl LndGrpcListener {
@@ -42,49 +39,30 @@ impl LndGrpcListener {
             client: LightningClient::new(channel),
             services,
             network: wallet.network(),
-            retry_delay: config.retry_delay,
         })
     }
 
-    async fn handle_grpc_error(&self, err: Status, context: &str) -> Result<(), LightningError> {
-        match err.code() {
-            Code::Aborted
-            | Code::Cancelled
-            | Code::DeadlineExceeded
-            | Code::Internal
-            | Code::FailedPrecondition
-            | Code::Unavailable => {
-                error!(err = err.message(), "{}. Retrying...", context);
-                sleep(self.retry_delay).await;
-                Ok(())
-            }
-            _ => Err(LightningError::Listener(err.to_string())),
-        }
-    }
-
+    // Both streams propagate every error out of `listen()`; the `EventListener` supervisor
+    // owns reconnection (re-running `sync()` from the un-advanced cursor). A clean stream
+    // close is also surfaced as an error so it triggers the same reconnect path (issue #267).
     async fn listen_invoices(&self) -> Result<(), LightningError> {
-        loop {
-            let result = {
-                let mut client = self.client.clone();
-                client.subscribe_invoices(lnrpc::InvoiceSubscription::default()).await
-            };
+        let response = self
+            .client
+            .clone()
+            .subscribe_invoices(lnrpc::InvoiceSubscription::default())
+            .await
+            .map_err(|e| LightningError::Listener(e.to_string()))?;
 
-            match result {
-                Ok(response) => {
-                    let mut stream = response.into_inner();
-                    while let Some(invoice) = stream
-                        .message()
-                        .await
-                        .map_err(|e| LightningError::Listener(format!("Failed to read invoice stream: {}", e)))?
-                    {
-                        self.handle_invoice(invoice).await;
-                    }
-                }
-                Err(err) => {
-                    self.handle_grpc_error(err, "Error subscribing to invoices").await?;
-                }
-            }
+        let mut stream = response.into_inner();
+        while let Some(invoice) = stream
+            .message()
+            .await
+            .map_err(|e| LightningError::Listener(format!("Failed to read invoice stream: {}", e)))?
+        {
+            self.handle_invoice(invoice).await;
         }
+
+        Err(LightningError::Listener("LND invoice stream closed".to_string()))
     }
 
     async fn listen_transactions(&self) -> Result<(), LightningError> {
@@ -94,31 +72,24 @@ impl LndGrpcListener {
             .await
             .map_err(|e| LightningError::Listener(e.to_string()))?;
 
-        loop {
-            let result = {
-                let mut client = self.client.clone();
-                client
-                    .subscribe_transactions(lnrpc::GetTransactionsRequest::default())
-                    .await
-            };
+        let response = self
+            .client
+            .clone()
+            .subscribe_transactions(lnrpc::GetTransactionsRequest::default())
+            .await
+            .map_err(|e| LightningError::Listener(e.to_string()))?;
 
-            match result {
-                Ok(response) => {
-                    let mut stream = response.into_inner();
-                    while let Some(transaction) = stream
-                        .message()
-                        .await
-                        .map_err(|e| LightningError::Listener(format!("Failed to read transaction stream: {}", e)))?
-                    {
-                        let transaction = Self::map_transaction(transaction);
-                        self.handle_transaction(transaction).await;
-                    }
-                }
-                Err(err) => {
-                    self.handle_grpc_error(err, "Error subscribing to transactions").await?;
-                }
-            }
+        let mut stream = response.into_inner();
+        while let Some(transaction) = stream
+            .message()
+            .await
+            .map_err(|e| LightningError::Listener(format!("Failed to read transaction stream: {}", e)))?
+        {
+            let transaction = Self::map_transaction(transaction);
+            self.handle_transaction(transaction).await?;
         }
+
+        Err(LightningError::Listener("LND transaction stream closed".to_string()))
     }
 
     async fn handle_invoice(&self, invoice: lnrpc::Invoice) {
@@ -179,7 +150,7 @@ impl LndGrpcListener {
         }
     }
 
-    async fn handle_transaction(&self, transaction: BtcTransaction) {
+    async fn handle_transaction(&self, transaction: BtcTransaction) -> Result<(), LightningError> {
         let relevant_outputs = transaction.outputs.iter().filter(|output| {
             if transaction.is_outgoing {
                 !output.is_ours
@@ -201,21 +172,22 @@ impl LndGrpcListener {
                     .await
             };
 
-            if let Err(err) = result {
-                error!(%err, "Failed to process onchain transaction");
-            }
+            // Propagate write failures instead of swallowing them. The cursor must not
+            // advance past an event we failed to persist or the deposit is lost; bubbling
+            // the error exits the listener so the supervisor reconnects and `sync()` reruns
+            // from the un-advanced cursor, reprocessing idempotently.
+            result.map_err(|e| LightningError::EventProcessing(e.to_string()))?;
         }
 
         if let Some(block_height) = transaction.block_height.filter(|&h| h > 0) {
-            if let Err(err) = self
-                .services
+            self.services
                 .system
                 .set_onchain_cursor(OnchainSyncCursor::BlockHeight(block_height))
                 .await
-            {
-                warn!(%err, "Failed to persist onchain cursor");
-            }
+                .map_err(|e| LightningError::Listener(e.to_string()))?;
         }
+
+        Ok(())
     }
 }
 

--- a/src/infra/lightning/lnd/lnd_rest_client.rs
+++ b/src/infra/lightning/lnd/lnd_rest_client.rs
@@ -47,10 +47,6 @@ pub struct LndRestClientConfig {
     pub fee_limit_msat: u64,
     #[serde(deserialize_with = "deserialize_duration")]
     pub payment_timeout: Duration,
-    #[serde(deserialize_with = "deserialize_duration")]
-    pub ws_min_reconnect_delay: Duration,
-    #[serde(deserialize_with = "deserialize_duration")]
-    pub ws_max_reconnect_delay: Duration,
     pub ca_cert_path: Option<String>,
     pub macaroon_path: String,
     pub reorg_buffer_blocks: u32,

--- a/src/infra/lightning/lnd/lnd_websocket_listener.rs
+++ b/src/infra/lightning/lnd/lnd_websocket_listener.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -8,8 +7,8 @@ use futures_util::StreamExt;
 use http::Uri;
 use native_tls::{Certificate, TlsConnector};
 use serde_json::Value;
+use tokio::fs;
 use tokio::net::TcpStream;
-use tokio::{fs, time::sleep};
 use tokio_tungstenite::tungstenite::ClientRequestBuilder;
 use tokio_tungstenite::{connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream};
 use tracing::{debug, error, warn};
@@ -50,29 +49,14 @@ impl LndWebsocketListener {
         })
     }
 
+    // Every error propagates out of `listen()`; the `EventListener` supervisor owns
+    // reconnection (re-running `sync()` from the un-advanced cursor). A clean disconnect
+    // is surfaced as an error so it takes the same reconnect path.
     async fn listen_invoices(&self) -> Result<(), LightningError> {
-        let max_reconnect_delay = self.config.ws_max_reconnect_delay;
-        let mut reconnect_delay = self.config.ws_min_reconnect_delay;
-
-        loop {
-            let result = self.connect_and_handle_invoices().await;
-
-            if let Err(err) = result {
-                match err {
-                    LightningError::ParseConfig(msg)
-                    | LightningError::ConnectWebsocket(msg)
-                    | LightningError::TLSConfig(msg)
-                    | LightningError::ReadCertificates(msg) => {
-                        return Err(LightningError::Listener(msg));
-                    }
-                    _ => {
-                        error!(%err, "WebSocket connection error");
-                        sleep(reconnect_delay).await;
-                        reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay);
-                    }
-                }
-            }
-        }
+        self.connect_and_handle_invoices().await?;
+        Err(LightningError::ConnectWebsocket(
+            "LND invoice websocket disconnected".to_string(),
+        ))
     }
 
     async fn listen_transactions(&self) -> Result<(), LightningError> {
@@ -82,28 +66,10 @@ impl LndWebsocketListener {
             .await
             .map_err(|e| LightningError::Listener(e.to_string()))?;
 
-        let max_reconnect_delay = self.config.ws_max_reconnect_delay;
-        let mut reconnect_delay = self.config.ws_min_reconnect_delay;
-
-        loop {
-            let result = self.connect_and_handle_transactions().await;
-
-            if let Err(err) = result {
-                match err {
-                    LightningError::ParseConfig(msg)
-                    | LightningError::ConnectWebsocket(msg)
-                    | LightningError::TLSConfig(msg)
-                    | LightningError::ReadCertificates(msg) => {
-                        return Err(LightningError::Listener(msg));
-                    }
-                    _ => {
-                        error!(%err, "WebSocket connection error");
-                        sleep(reconnect_delay).await;
-                        reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay);
-                    }
-                }
-            }
-        }
+        self.connect_and_handle_transactions().await?;
+        Err(LightningError::ConnectWebsocket(
+            "LND transaction websocket disconnected".to_string(),
+        ))
     }
 
     async fn connect_and_handle_invoices(&self) -> Result<(), LightningError> {
@@ -119,7 +85,7 @@ impl LndWebsocketListener {
 
         debug!("Connected to LND WebSocket server");
 
-        self.handle_invoice_messages(ws_stream).await;
+        self.handle_invoice_messages(ws_stream).await?;
 
         debug!("Disconnected from LND WebSocket server");
 
@@ -139,7 +105,7 @@ impl LndWebsocketListener {
 
         debug!("Connected to LND WebSocket transaction server");
 
-        self.handle_transaction_messages(ws_stream).await;
+        self.handle_transaction_messages(ws_stream).await?;
 
         debug!("Disconnected from LND WebSocket transaction server");
 
@@ -170,48 +136,54 @@ impl LndWebsocketListener {
         }
     }
 
-    async fn handle_invoice_messages(&self, mut ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>) {
+    async fn handle_invoice_messages(
+        &self,
+        mut ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    ) -> Result<(), LightningError> {
         while let Some(message) = ws_stream.next().await {
             match message {
                 Ok(msg) => {
                     if msg.is_text() {
                         let text = msg.into_text().unwrap();
+                        // Invoice parse/settlement errors are skippable (idempotent and re-synced
+                        // by invoice.sync()), so log and keep reading rather than dropping the stream.
                         if let Err(e) = self.process_invoice_message(&text).await {
                             error!(%e, "Failed to process message");
                         }
                     } else if msg.is_close() {
                         debug!("WebSocket closed");
-                        break;
+                        return Ok(());
                     }
                 }
-                Err(err) => {
-                    error!(%err, "Error receiving message");
-                    break;
-                }
+                Err(err) => return Err(LightningError::ConnectWebsocket(err.to_string())),
             }
         }
+
+        Ok(())
     }
 
-    async fn handle_transaction_messages(&self, mut ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>) {
+    async fn handle_transaction_messages(
+        &self,
+        mut ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    ) -> Result<(), LightningError> {
         while let Some(message) = ws_stream.next().await {
             match message {
                 Ok(msg) => {
                     if msg.is_text() {
                         let text = msg.into_text().unwrap();
-                        if let Err(e) = self.process_transaction_message(&text).await {
-                            error!(%e, "Failed to process transaction message");
-                        }
+                        // A failed deposit/withdrawal write propagates so the supervisor
+                        // reconnects and re-syncs; parse errors are skipped inside.
+                        self.process_transaction_message(&text).await?;
                     } else if msg.is_close() {
                         debug!("WebSocket closed");
-                        break;
+                        return Ok(());
                     }
                 }
-                Err(err) => {
-                    error!(%err, "Error receiving message");
-                    break;
-                }
+                Err(err) => return Err(LightningError::ConnectWebsocket(err.to_string())),
             }
         }
+
+        Ok(())
     }
 
     async fn process_invoice_message(&self, text: &str) -> anyhow::Result<()> {
@@ -235,14 +207,20 @@ impl LndWebsocketListener {
         Ok(())
     }
 
-    async fn process_transaction_message(&self, text: &str) -> anyhow::Result<()> {
-        let value: Value = serde_json::from_str(text)?;
+    async fn process_transaction_message(&self, text: &str) -> Result<(), LightningError> {
+        let value: Value = match serde_json::from_str(text) {
+            Ok(value) => value,
+            Err(err) => {
+                error!(%err, "Failed to parse transaction message");
+                return Ok(());
+            }
+        };
 
         if let Some(event) = value.get("result") {
             match serde_json::from_value::<TransactionResponse>(event.clone()) {
                 Ok(transaction) => {
                     let transaction: BtcTransaction = transaction.into();
-                    self.handle_transaction(transaction).await;
+                    self.handle_transaction(transaction).await?;
                 }
                 Err(err) => {
                     error!(%err, "Failed to parse SubscribeTransactions event");
@@ -253,7 +231,7 @@ impl LndWebsocketListener {
         Ok(())
     }
 
-    async fn handle_transaction(&self, transaction: BtcTransaction) {
+    async fn handle_transaction(&self, transaction: BtcTransaction) -> Result<(), LightningError> {
         // Filter outputs based on transaction direction:
         // - Incoming tx (deposit): only process outputs that are ours
         // - Outgoing tx (withdrawal): only process outputs that are NOT ours (skip change)
@@ -278,21 +256,21 @@ impl LndWebsocketListener {
                     .await
             };
 
-            if let Err(err) = result {
-                error!(%err, "Failed to process onchain transaction");
-            }
+            // Don't swallow: a failed write must not advance the cursor, or the deposit is
+            // lost. Propagating exits the listener so the supervisor reconnects and `sync()`
+            // reruns from the un-advanced cursor, reprocessing idempotently.
+            result.map_err(|e| LightningError::EventProcessing(e.to_string()))?;
         }
 
         if let Some(block_height) = transaction.block_height.filter(|&h| h > 0) {
-            if let Err(err) = self
-                .services
+            self.services
                 .system
                 .set_onchain_cursor(OnchainSyncCursor::BlockHeight(block_height))
                 .await
-            {
-                warn!(%err, "Failed to persist onchain cursor");
-            }
+                .map_err(|e| LightningError::Listener(e.to_string()))?;
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #267. On SQLite, the on-chain deposit listener could **permanently drop a deposit credit** under concurrent writes: a write that lost the lock race failed immediately with `SQLITE_BUSY`, the error was only logged, and the cursor advanced anyway — so the deposit was never re-processed.

## Root cause

- **Trigger:** the SQLite connection had no `busy_timeout` and no WAL journal mode. sea-orm's `ConnectOptions` can't set SQLite pragmas and sqlx ignores them as URL query params, so a contended writer failed instantly instead of waiting for the lock.
- **The actual defect:** every listener (`LndGrpc`, `LndWebsocket`, `ClnGrpc`, `ClnWebsocket`) swallowed the write error and still advanced the on-chain sync cursor, so the dropped event was never revisited. There is no periodic re-sync and the reorg lookback is only ~2 blocks, so the loss was effectively permanent. Only SQLite deployments hit the trigger, but the cursor-advance defect was latent on Postgres too.

## Changes

- **SQLite connection** (`store.rs`): build the sqlx pool directly with `journal_mode(WAL)` + `busy_timeout` (new required `busy_timeout` config field) + `synchronous(FULL)`; Postgres keeps the standard sea-orm path. Writers stay serialized, so balance updates (atomic `SET x = x ± n` statements) are unaffected by WAL.
- **Single reconnect supervisor** (`event_listener.rs`): `start()` no longer `panic!`s — under `panic = "unwind"` that silently killed the detached listener task while the HTTP server kept serving. It now runs the listener in an exponential-backoff retry loop, the one source of truth for reconnection.
- **Listeners propagate instead of swallow:** a failed deposit/withdrawal write now bubbles out as `LightningError::EventProcessing`, so the cursor is never advanced past it; the supervisor reconnects and `sync()` re-runs from the un-advanced cursor (idempotent). Removed the per-adapter `handle_grpc_error` retries and the `match err` fatal/transient blocks. CLN websocket keeps its socket.io self-reconnect and gets the cursor rule only (it re-syncs on every chain event).
- Removed now-dead config: `retry_delay` (LND/CLN gRPC) and LND `ws_*_reconnect_delay`.

Net `-369 / +346` across 13 files — the consolidation removes more than it adds.

## Validation

- Unit: 210/210. Persistence/concurrency on a real SQLite DB: 11/11, including `concurrent_reserves_cannot_overdraw` and the idempotent-replay tests (also confirms WAL is safe for the read/modify/write balance paths).
- api suite run **in parallel** (the exact condition that previously hung funding tests for 180s): `sqlite + lnd_grpc` 104/104 in 2.96s, `sqlite + cln_grpc` 104/104, `sqlite + cln_rest` 104/104.
- `clippy -D warnings` and `rustfmt` clean.

## Note

The `sqlite + lnd_rest` cell can't be exercised end-to-end in the local regtest stack: the server fails at app-state creation reaching LND's REST `getinfo` (a pre-existing TLS/transport issue on the REST port — this PR doesn't touch that path; `git diff` for `lnd_rest_client.rs` is only the two removed config fields). The LND websocket listener change mirrors the validated LND gRPC pattern.
