### PR TITLE
fix(payments): LNURL success-action settlement race + coverage on main only

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -116,7 +116,13 @@ jobs:
   # Full-matrix merged coverage: unit + UoW (both DBs) + the integration suite
   # across every provider x DB cell, merged into one report (printed to the job
   # log and uploaded as lcov). This is the true total coverage.
+  #
+  # It re-runs the whole suite under instrumentation, which duplicates the
+  # integration + persistence jobs above. Those are the PR gates and already
+  # cover every cell, so coverage runs only on pushes to main (and manual
+  # dispatch), not on every pull-request push.
   coverage:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 90
 

--- a/src/domains/payment/payment_service.rs
+++ b/src/domains/payment/payment_service.rs
@@ -485,12 +485,19 @@ impl PaymentService {
                     _ => None,
                 };
 
-                if let Some(success_action) = success_action {
-                    let lightning = settled_payment.lightning.get_or_insert_with(Default::default);
-                    lightning.success_action = Some(success_action);
-                }
+                let mut payment = self.store.payment_uow.settle(settled_payment).await?;
 
-                let payment = self.store.payment_uow.settle(settled_payment).await?;
+                // The LNURL success action is known only on this synchronous path (it needs
+                // the callback action and the pay preimage). The async success listener can
+                // win the Settled transition and persist the row without it, so attach it and
+                // persist when the stored row is missing it — this path is its only source.
+                if let Some(success_action) = success_action {
+                    let lightning = payment.lightning.get_or_insert_with(Default::default);
+                    if lightning.success_action.is_none() {
+                        lightning.success_action = Some(success_action);
+                        payment = self.store.payment.update(payment).await?;
+                    }
+                }
 
                 Ok(payment)
             }

--- a/tests/common/lnurl_server.rs
+++ b/tests/common/lnurl_server.rs
@@ -81,6 +81,16 @@ impl MockLnurl {
             .await;
     }
 
+    /// Mount the callback so it returns `bolt11` plus a `message` success action.
+    /// Raw JSON: `LnURLPayInvoice`'s success-action field is private with no setter.
+    pub async fn mount_callback_invoice_with_message(&self, bolt11: &str, message: &str) {
+        self.mount_get(
+            CALLBACK_PATH.to_string(),
+            json!({ "pr": bolt11, "successAction": { "tag": "message", "message": message } }),
+        )
+        .await;
+    }
+
     /// Mount the callback so it returns the LNURL error contract `{status, reason}`.
     pub async fn mount_callback_error(&self, reason: &str) {
         self.mount_get(

--- a/tests/suites/lnurl_send.rs
+++ b/tests/suites/lnurl_send.rs
@@ -52,7 +52,8 @@ mod pay {
         let user = unique("payee");
         let mock = MockLnurl::start().await;
         mock.mount_pay_request(&user, 1_000, 250_000_000_000, 255).await;
-        mock.mount_callback_invoice(&bolt11).await;
+        mock.mount_callback_invoice_with_message(&bolt11, "Thanks for the sats!")
+            .await;
 
         let res = app
             .api()
@@ -72,10 +73,15 @@ mod pay {
         assert_eq!(payment.ledger, Ledger::Lightning);
         assert_eq!(payment.amount_msat, amount_msat);
 
-        // The callback's success action is intentionally not asserted: it is
-        // mapped onto the payment but can be raced away by the async settlement
-        // listener (bitcoin-numeraire/swissknife#269). The mapping is unit-tested
-        // in `lnurl::utils`.
+        // The callback's success action is mapped onto the payment and persisted by the
+        // synchronous pay path, which stays authoritative over the async settlement
+        // listener (the listener carries no action), so it is present deterministically.
+        let success_action = payment
+            .lightning
+            .as_ref()
+            .and_then(|ln| ln.success_action.as_ref())
+            .expect("LNURL success action present on the settled payment");
+        assert_eq!(success_action.message.as_deref(), Some("Thanks for the sats!"));
 
         // The wallet is debited by the amount plus the routing fee.
         let fee = payment.fee_msat.unwrap_or_default() as i64;

--- a/tests/suites/wallets.rs
+++ b/tests/suites/wallets.rs
@@ -3,7 +3,10 @@
 use reqwest::StatusCode;
 use serde_json::json;
 
-use swissknife_types::{RegisterWalletRequest, Wallet};
+use swissknife_types::{
+    Balance, Ledger, LnAddress, Payment, PaymentStatus, RegisterLnAddressRequest, RegisterWalletRequest,
+    SendPaymentRequest, Wallet, WalletOverview,
+};
 
 use crate::common::fixtures::unique;
 use crate::common::{app, assert_error, assert_status, Auth};
@@ -97,6 +100,107 @@ mod list {
         assert!(
             res.parse::<Vec<Wallet>>().iter().any(|w| w.id == wallet.id),
             "the registered wallet is listed"
+        );
+    }
+}
+
+mod list_overviews {
+    use super::*;
+
+    fn register_ln_address(wallet_id: uuid::Uuid, username: &str) -> RegisterLnAddressRequest {
+        RegisterLnAddressRequest {
+            wallet_id: Some(wallet_id),
+            username: username.to_string(),
+            allows_nostr: false,
+            nostr_pubkey: None,
+        }
+    }
+
+    fn internal_payment(wallet_id: uuid::Uuid, input: String, amount_msat: u64) -> SendPaymentRequest {
+        SendPaymentRequest {
+            wallet_id: Some(wallet_id),
+            input,
+            amount_msat: Some(amount_msat),
+            comment: None,
+        }
+    }
+
+    fn find_overview(overviews: &[WalletOverview], id: uuid::Uuid) -> &WalletOverview {
+        overviews
+            .iter()
+            .find(|overview| overview.id == id)
+            .expect("created wallet is present in overviews")
+    }
+
+    fn assert_balance(overview: &WalletOverview, balance: &Balance) {
+        assert_eq!(overview.balance.received_msat, balance.received_msat);
+        assert_eq!(overview.balance.sent_msat, balance.sent_msat);
+        assert_eq!(overview.balance.fees_paid_msat, balance.fees_paid_msat);
+        assert_eq!(overview.balance.reserved_msat, balance.reserved_msat);
+        assert_eq!(overview.balance.available_msat, balance.available_msat);
+    }
+
+    #[tokio::test]
+    async fn includes_aggregated_wallet_activity() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let payer = app.create_wallet(token, "wallet-overview-payer").await;
+        let payee = app.create_wallet(token, "wallet-overview-payee").await;
+        let username = unique("walletoverview");
+        let address_input = format!("{username}@localhost");
+        let amount_msat = 25_000_000u64;
+
+        app.fund_onchain(token, payer.id, 100_000).await;
+
+        let address = app
+            .api()
+            .post(
+                "/v1/lightning-addresses",
+                Auth::Bearer(token),
+                register_ln_address(payee.id, &username),
+            )
+            .await;
+        assert_status(&address, StatusCode::OK);
+        let address = address.parse::<LnAddress>();
+
+        let payment = app
+            .api()
+            .post(
+                "/v1/payments",
+                Auth::Bearer(token),
+                internal_payment(payer.id, address_input, amount_msat),
+            )
+            .await;
+        assert_status(&payment, StatusCode::OK);
+        let payment = payment.parse::<Payment>();
+        assert_eq!(payment.status, PaymentStatus::Settled);
+        assert_eq!(payment.ledger, Ledger::Internal);
+
+        let payer_balance = app.wallet_balance(token, payer.id).await;
+        let payee_balance = app.wallet_balance(token, payee.id).await;
+
+        let res = app.api().get("/v1/wallets/overviews", Auth::Bearer(token)).await;
+        assert_status(&res, StatusCode::OK);
+        let overviews = res.parse::<Vec<WalletOverview>>();
+
+        let payer_overview = find_overview(&overviews, payer.id);
+        assert_balance(payer_overview, &payer_balance);
+        assert_eq!(payer_overview.n_payments, 1);
+        assert_eq!(payer_overview.n_contacts, 1);
+        assert!(payer_overview.ln_address.is_none());
+
+        let payee_overview = find_overview(&overviews, payee.id);
+        assert_balance(payee_overview, &payee_balance);
+        assert_eq!(payee_overview.n_payments, 0);
+        assert_eq!(payee_overview.n_invoices, 1);
+        assert_eq!(payee_overview.n_contacts, 0);
+        assert_eq!(
+            payee_overview
+                .ln_address
+                .as_ref()
+                .expect("registered address is included")
+                .id,
+            address.id
         );
     }
 }


### PR DESCRIPTION
Two independent v0.2.0 cleanups, one commit each.

## `ci(coverage): run merged coverage only on main`

The `coverage` job in `integration.yml` runs `make coverage-matrix`, which re-runs unit + UoW + the full integration matrix under instrumentation — duplicating the `integration` and `persistence` jobs that are the actual PR gates. Gated it with `if: github.event_name != 'pull_request'`, so it runs on pushes to main (and manual dispatch) but not on every PR push. The PR gates are unchanged and still cover every cell.

Follow-up worth considering (left out to keep this focused): make coverage a byproduct of the existing matrix jobs — run them under `cargo llvm-cov --no-report` and merge in a final job — so even main doesn't re-run the suite.

## `fix(payments): persist LNURL success action past the settlement race`

Closes #269. The LNURL `successAction` from the remote callback is known only on the synchronous pay path (it needs the callback action plus the pay preimage). Settlement is single-winner via `try_transition`: whoever flips `Pending → Settled` first runs `update()`. If the async success listener (`outgoing_payment`) wins, it persists the row without the action (it never carries one) and the synchronous path loses the transition and never writes it — so the action was non-deterministically dropped (~1 in 3 on cln_rest).

Fix: the synchronous path now persists the action right after `settle()`, independent of who won the transition. The async winner commits its whole settle transaction atomically, so the loser always runs strictly after it — no residual race. Re-enabled the success-action assertion in the `lnurl_send` happy-path itest (reverting b9b1505's workaround).

## Validation

- Unit: 210/210. clippy `-D warnings` + fmt clean.
- `lnurl_send` settle test now deterministic across providers: cln_rest 5/5 (was ~1-in-3), lnd_grpc + cln_grpc green. (lnd_rest is CI-only locally — pre-existing LND REST connectivity quirk in the local regtest stack, unrelated to this change.)
