### PR TITLE
fix(migration): drop legacy lowercase invoice unique indexes

### DIFF
--- a/crates/migration/src/m20260113_222755_fix_invoice_payment_hash_unique.rs
+++ b/crates/migration/src/m20260113_222755_fix_invoice_payment_hash_unique.rs
@@ -26,6 +26,14 @@ impl MigrationTrait for Migration {
 
         db.execute_unprepared(r#"DROP INDEX IF EXISTS "UNIQUE_bolt11""#).await?;
 
+        // Some production databases also carry lowercase partial indexes created
+        // out-of-band (never by a migration). Drop them so the schema converges to
+        // the migration-defined indexes below instead of coexisting redundantly.
+        db.execute_unprepared(r#"DROP INDEX IF EXISTS "unique_payment_hash""#)
+            .await?;
+
+        db.execute_unprepared(r#"DROP INDEX IF EXISTS "unique_bolt11""#).await?;
+
         // Recreate as unique indexes without NULLS NOT DISTINCT
         // This allows multiple NULL values (needed for onchain invoices)
         db.execute_unprepared(r#"CREATE UNIQUE INDEX "UNIQUE_payment_hash" ON invoice (payment_hash)"#)


### PR DESCRIPTION
## Context

While testing the v0.2.0 migrations against a restore of the production database, I found that prod's `invoice` table carries lowercase **partial** unique indexes that were created out-of-band and are not produced by any migration: `unique_payment_hash ON (payment_hash) WHERE payment_hash IS NOT NULL` and `unique_bolt11 ON (bolt11) WHERE bolt11 IS NOT NULL`.

`m20260113_222755_fix_invoice_payment_hash_unique` only drops the **uppercase** names (`"UNIQUE_payment_hash"` / `"UNIQUE_bolt11"`) that fresh installs have, so on prod the `DROP INDEX IF EXISTS` calls are no-ops and the migration then *adds* the uppercase indexes alongside the surviving lowercase ones. The result is four redundant unique objects on `payment_hash`/`bolt11`, a schema that isn't reproducible from migrations, and a latent footgun: a future `DROP INDEX IF EXISTS "UNIQUE_payment_hash"` would silently leave the lowercase index still enforcing uniqueness.

## Change

Add two `DROP INDEX IF EXISTS` statements for the lowercase index names to the Postgres branch of `up()`, before the canonical indexes are recreated, so prod converges to the migration-defined schema.

The drops are inside the existing `backend != Postgres` guard and use `IF EXISTS`, so they are harmless no-ops on fresh Postgres installs and on SQLite. This migration has not yet run on production (prod is at `m20251021`), so it takes effect on the v0.2.0 upgrade.

## Verification

Re-ran the migration against a fresh restore of the production dump:

- Pre-migration `invoice` indexes: `invoice_pkey`, `unique_payment_hash`, `unique_bolt11`.
- Post-migration `invoice` indexes: `invoice_pkey`, `UNIQUE_payment_hash`, `UNIQUE_bolt11` — lowercase partial indexes dropped, schema converged.
- Wallet-balance backfill unaffected (49 rows, 0 negatives).
- `cargo fmt --all` and `cargo clippy -p migration -- -D warnings` clean.