### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@ This section is the source for the `v0.2.0` release notes.
 
 - Removed Breez Liquid/Spark support for now, keeping the current release focused
   on self-hosted CLN and LND providers ([#224]).
-- Removed right-to-left (RTL) layout support from the dashboard; it is now
-  left-to-right only ([#219]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ release notes when a tag is published.
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-18
+This section is the source for the `v0.2.0` release notes.
 
 ### Added
 
@@ -55,8 +55,7 @@ release notes when a tag is published.
 
 - Removed blink on the login page ([#175]).
 
-[Unreleased]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/bitcoin-numeraire/swissknife/releases/tag/v0.2.0
+[Unreleased]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.1.8...HEAD
 [0.1.8]: https://github.com/bitcoin-numeraire/swissknife/releases/tag/v0.1.8
 [#175]: https://github.com/bitcoin-numeraire/swissknife/pull/175
 [#176]: https://github.com/bitcoin-numeraire/swissknife/pull/176

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ release notes when a tag is published.
 
 ## [Unreleased]
 
-This section is the source for the `v0.2.0` release notes.
+## [0.2.0] - 2026-06-18
 
 ### Added
 
@@ -29,11 +29,18 @@ This section is the source for the `v0.2.0` release notes.
   payments, and wallet state are reconciled more reliably when SwissKnife starts
   ([#200], [#202]).
 - Refreshed the backend dependency baseline ([#210], [#212], [#226]).
+- Upgraded the dashboard to React 19, Next.js 16, MUI v9, and zod 4 on Node 24 /
+  Yarn 4.17, and refreshed its dependency baseline ([#219], [#276]).
+- Aligned the dashboard with the current backend API and regenerated its typed
+  client; added a `make openapi` workflow to keep the spec and client in sync
+  ([#221]).
 
 ### Removed
 
 - Removed Breez Liquid/Spark support for now, keeping the current release focused
   on self-hosted CLN and LND providers ([#224]).
+- Removed right-to-left (RTL) layout support from the dashboard; it is now
+  left-to-right only ([#219]).
 
 ### Fixed
 
@@ -48,7 +55,8 @@ This section is the source for the `v0.2.0` release notes.
 
 - Removed blink on the login page ([#175]).
 
-[Unreleased]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/bitcoin-numeraire/swissknife/releases/tag/v0.2.0
 [0.1.8]: https://github.com/bitcoin-numeraire/swissknife/releases/tag/v0.1.8
 [#175]: https://github.com/bitcoin-numeraire/swissknife/pull/175
 [#176]: https://github.com/bitcoin-numeraire/swissknife/pull/176
@@ -64,8 +72,11 @@ This section is the source for the `v0.2.0` release notes.
 [#209]: https://github.com/bitcoin-numeraire/swissknife/pull/209
 [#210]: https://github.com/bitcoin-numeraire/swissknife/pull/210
 [#212]: https://github.com/bitcoin-numeraire/swissknife/pull/212
+[#219]: https://github.com/bitcoin-numeraire/swissknife/issues/219
+[#221]: https://github.com/bitcoin-numeraire/swissknife/issues/221
 [#224]: https://github.com/bitcoin-numeraire/swissknife/pull/224
 [#226]: https://github.com/bitcoin-numeraire/swissknife/pull/226
 [#240]: https://github.com/bitcoin-numeraire/swissknife/issues/240
 [#267]: https://github.com/bitcoin-numeraire/swissknife/issues/267
+[#276]: https://github.com/bitcoin-numeraire/swissknife/pull/276
 [398e89f]: https://github.com/bitcoin-numeraire/swissknife/commit/398e89f

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "sea-orm-migration",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,7 +4666,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swissknife"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "swissknife-types"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "nostr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "swissknife"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["Dario Anongba Varela <dario.varela@numeraire.tech>"]
 rust-version = "1.96"

--- a/crates/migration/Cargo.toml
+++ b/crates/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "migration"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/swissknife-types/Cargo.toml
+++ b/crates/swissknife-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swissknife-types"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["Dario Anongba Varela <dario.varela@numeraire.tech>"]
 rust-version = "1.96"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swissknife-dashboard",
   "author": "Dario Anongba Varela",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "email": "dario.varela@numeraire.tech",
   "description": "Numeraire Bitcoin SwissKnife Dashboard",
   "private": true,

--- a/dashboard/src/lib/openapi.json
+++ b/dashboard/src/lib/openapi.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.1.7"
+    "version": "0.2.0"
   },
   "paths": {
     "/.well-known/lnurlp/{username}": {

--- a/dashboard/src/lib/swissknife/zod.gen.ts
+++ b/dashboard/src/lib/swissknife/zod.gen.ts
@@ -14,30 +14,18 @@ export const zBalance = z.object({
     .max(BigInt('9223372036854775807'), {
       error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
     }),
-  fees_paid_msat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
-  received_msat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
-  reserved_msat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
-  sent_msat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  fees_paid_msat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
+  received_msat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
+  reserved_msat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
+  sent_msat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
 });
 
 /**
@@ -80,12 +68,9 @@ export const zBtcOutputStatus = z.enum(['Unconfirmed', 'Confirmed', 'Spent', 'Im
  */
 export const zBtcOutput = z.object({
   address: z.string(),
-  amount_sat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  amount_sat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   block_height: z
     .int()
     .gte(0)
@@ -191,18 +176,12 @@ export const zLnInvoice = z.object({
   bolt11: z.string(),
   description_hash: z.string().nullish(),
   expires_at: z.iso.datetime(),
-  expiry: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
-  min_final_cltv_expiry_delta: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  expiry: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
+  min_final_cltv_expiry_delta: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   payee_pubkey: z.string(),
   payment_hash: z.string(),
   payment_secret: z.string(),
@@ -258,19 +237,13 @@ export const zLnUrlPayRequest = z.object({
     .int()
     .gte(0)
     .max(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
-  maxSendable: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  maxSendable: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   metadata: z.string(),
-  minSendable: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  minSendable: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   nostrPubkey: z.string().nullish(),
   tag: z.string(),
 });
@@ -319,12 +292,9 @@ export const zNewBtcAddressRequest = z.object({
  * New Invoice Request
  */
 export const zNewInvoiceRequest = z.object({
-  amount_msat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  amount_msat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   description: z.string().nullish(),
   expiry: z
     .int()
@@ -355,12 +325,9 @@ export const zPaymentStatus = z.enum(['Pending', 'Settled', 'Failed']);
  * An outgoing payment, over Lightning, on-chain, or internal to the instance.
  */
 export const zPayment = z.object({
-  amount_msat: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  amount_msat: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   bitcoin: zBtcPayment.nullish(),
   created_at: z.iso.datetime(),
   currency: zCurrency,
@@ -572,12 +539,9 @@ export const zCallbackPath = z.object({
 });
 
 export const zCallbackQuery = z.object({
-  amount: z.coerce
-    .bigint()
-    .gte(BigInt(0))
-    .max(BigInt('9223372036854775807'), {
-      error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
-    }),
+  amount: z.coerce.bigint().gte(BigInt(0)).max(BigInt('9223372036854775807'), {
+    error: 'Invalid value: Expected int64 to be <= 9223372036854775807',
+  }),
   comment: z.string().nullish(),
 });
 


### PR DESCRIPTION
## Summary

Cuts the **v0.2.0** release. Bumps every version surface to `0.2.0` and converts the curated `[Unreleased]` changelog (already authored as the v0.2.0 source) into the dated `[0.2.0]` entry.

## Version bumps

- **Backend:** `swissknife` and `swissknife-types` crates `0.1.7 → 0.2.0` (`Cargo.lock` synced). The `migration` crate is independently versioned (`publish = false`) and intentionally left at `0.1.4`.
- **Dashboard:** `package.json` `0.1.8 → 0.2.0` — drives the in-app version badge (account drawer) and the settings cache-bust key.
- **Generated OpenAPI spec** (`dashboard/src/lib/openapi.json`): `info.version → 0.2.0`.

## Docs

- `CHANGELOG.md`: `[Unreleased] → [0.2.0] - 2026-06-18`, opened a fresh empty `[Unreleased]`, refreshed the compare/tag link refs, and added the dashboard work — the React 19 / Next 16 / MUI v9 / zod 4 upgrade on Node 24 / Yarn 4.17 (#219, #276), the backend-API alignment + `make openapi` (#221), and the RTL removal (#219).

## Deliberately not touched

- `release.yml` derives image tags from the pushed git tag via `docker/metadata-action` (`type=semver`) — no version edits needed in CI.
- `README.md` references images by `:latest` — no hardcoded version.
- No Dockerfile `ARG`/`LABEL` version, and no test asserts the version literally (it flows from `CARGO_PKG_VERSION`).

## Release flow

After merge, tag `v0.2.0` on `main` → `release.yml` builds and pushes `bitcoinnumeraire/{swissknife, swissknife-server, swissknife-dashboard}` to Docker Hub for `linux/amd64` + `linux/arm64`.

Part of #222.
