### PR TITLE
chore(security): add cargo audit to CI; swap dotenv→dotenvy

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+# cargo-audit configuration (read automatically by `cargo audit`).
+# Docs: https://github.com/rustsec/rustsec/tree/main/cargo-audit
+
+[advisories]
+# RUSTSEC-2023-0071 (Marvin Attack, `rsa` crate) is pulled in transitively via
+# `jsonwebtoken`. No fixed `rsa` release exists yet, and our usage is JWT
+# signature verification — not the RSA private-key decryption the attack
+# targets — so practical exposure is low. Accepted/deferred until a patched
+# `rsa` (and a `jsonwebtoken` that depends on it) is published.
+ignore = ["RUSTSEC-2023-0071"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,18 @@ jobs:
 
       - name: Run build
         run: yarn build
+
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,12 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4680,7 +4674,7 @@ dependencies = [
  "chrono",
  "config",
  "ctor",
- "dotenv",
+ "dotenvy",
  "futures-util",
  "hex",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "signal", "
 bip21 = { version = "0.5.0", features = ["std"] }
 lnurl = { package = "lnurl-rs", version = "0.9.0", default-features = false, features = ["async"] }
 config = { version = "0.15.23", features = ["yaml", "json", "toml"] }
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["json", "env-filter"] }
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod infra;
 use std::{process::exit, sync::Arc};
 
 #[cfg(debug_assertions)]
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use tokio::signal::{
     ctrl_c,
     unix::{signal, SignalKind},


### PR DESCRIPTION
## Summary

Dependency hardening, following up on the v0.2.0 security audit (#222, Gate 4). Two changes:

### 1. Replace `dotenv` → `dotenvy`
`dotenv` is unmaintained (RUSTSEC-2021-0141). Swapped for the maintained `dotenvy` fork — a drop-in; only used under `#[cfg(debug_assertions)]` to load `.env` in development.

### 2. Add `cargo audit` to CI
New `audit` job runs `cargo audit` on every PR/push (installed via `taiki-e/install-action`, a fast prebuilt binary — no compile).

`RUSTSEC-2023-0071` (Marvin Attack in `rsa`, pulled in transitively via `jsonwebtoken`) is **accepted/deferred** in `.cargo/audit.toml` with a documented rationale: there is no fixed `rsa` release, and our usage is JWT signature verification — not the RSA private-key decryption the attack targets.

## Verification
- `cargo check` ✅ compiles with `dotenvy`
- `cargo audit` ✅ exit 0 — the one vulnerability is ignored; the 4 remaining are informational **unmaintained-crate** warnings (`async-std`, `backoff`, `instant`, `proc-macro-error2`), all transitive and non-failing.

## Merge note
The `dashboard` CI check is currently red on `main` (a pre-existing Prettier issue on the generated `zod.gen.ts`) — it's fixed by the v0.2.0 release PR #278. Merge #278 first (or rebase this branch afterward) and the dashboard check clears.
