### PR TITLE
fix(docker): copy crates/ after migration crate move

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM chef AS builder
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
 COPY --from=planner /app/recipe.json recipe.json
-COPY ./migration ./migration
+COPY ./crates ./crates
 
 # Fetch dependencies with cargo cache mount
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
## Problem

The `v0.2.0` release build failed: https://github.com/bitcoin-numeraire/swissknife/actions/runs/27770502058/job/82168853608

Both server images (`swissknife` and `swissknife-server`, which share `./Dockerfile`) failed at:

```
ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref ...: "/migration": not found
```

The `swissknife-dashboard` image builds from a separate Dockerfile and was unaffected.

## Root cause

Commit `9f52f1d` (`chore(migration): move crate under crates/`) moved the `migration` crate to `crates/migration`, and `swissknife-types` also lives under `crates/`. The Dockerfile still copied the old path before the `cargo chef cook` step:

```dockerfile
COPY ./migration ./migration
```

That path no longer exists, so the build aborted before compiling anything.

## Fix

Copy the whole `crates/` directory, which covers both workspace member crates (`migration` and `swissknife-types`):

```dockerfile
COPY ./crates ./crates
```

The `Makefile` was already updated to `crates/migration` in the move commit — the Dockerfile was the only stale reference.

## Validation

Built the `builder` stage locally (`docker buildx build --target builder --platform linux/arm64`). The `COPY ./crates ./crates` step resolves, `cargo chef cook` and `cargo build --release` complete successfully — the build proceeds well past the point where it previously failed.

## Recovery

The `v0.2.0` tag points at `dc64065`, which still has the broken Dockerfile, so re-running the failed jobs alone will not help. After this merges, the `v0.2.0` tag needs to be re-pointed at the fixed commit and re-pushed to retrigger the Release workflow.
