### PR TITLE
refactor(cln): refresh Lightning protos and migrate pay → xpay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ This section is the source for the `v0.2.0` release notes.
 - Aligned the dashboard with the current backend API and regenerated its typed
   client; added a `make openapi` workflow to keep the spec and client in sync
   ([#221]).
+- Migrated CLN Lightning payments from the deprecated `pay` RPC to `xpay`, and
+  refreshed the vendored CLN and LND gRPC protos to CLN v26.06 and LND v0.21
+  ([#282]).
+- Replaced the CLN `maxfeepercent` and `payment_exemptfee` settings with a single
+  absolute `maxfee` (msat); when left unset, the node applies its own default
+  ([#282]).
 
 ### Removed
 
@@ -46,6 +52,8 @@ This section is the source for the `v0.2.0` release notes.
 - Fixed LNURL payment callback encoding and error handling ([#224]).
 - Fixed on-chain deposit event handling so transient database write failures do
   not silently drop credits ([#267]).
+- Fixed CLN REST Lightning payments charging the routing fee twice for payments
+  that incur a non-zero fee ([#282]).
 
 ## [0.1.8] - 2025-11-03
 
@@ -76,4 +84,5 @@ This section is the source for the `v0.2.0` release notes.
 [#240]: https://github.com/bitcoin-numeraire/swissknife/issues/240
 [#267]: https://github.com/bitcoin-numeraire/swissknife/issues/267
 [#276]: https://github.com/bitcoin-numeraire/swissknife/pull/276
+[#282]: https://github.com/bitcoin-numeraire/swissknife/pull/282
 [398e89f]: https://github.com/bitcoin-numeraire/swissknife/commit/398e89f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,7 @@ release notes when a tag is published.
 - Aligned the dashboard with the current backend API and regenerated its typed
   client; added a `make openapi` workflow to keep the spec and client in sync
   ([#221]).
-
-### Removed
-
-- Removed Breez Liquid/Spark support for now, keeping the current release focused
+- Dropped Breez Liquid/Spark support for now, keeping the current release focused
   on self-hosted CLN and LND providers ([#224]).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ release notes when a tag is published.
 
 ## [Unreleased]
 
-This section is the source for the `v0.2.0` release notes.
+### Changed
+
+- Migrated CLN Lightning payments from the deprecated `pay` RPC to `xpay`, and
+  refreshed the vendored CLN and LND gRPC protos to CLN v26.06 and LND v0.21
+  ([#282]).
+- Replaced the CLN `maxfeepercent` and `payment_exemptfee` settings with a single
+  absolute `maxfee` (msat); when left unset, the node applies its own default
+  ([#282]).
+
+### Fixed
+
+- Fixed CLN REST Lightning payments charging the routing fee twice for payments
+  that incur a non-zero fee ([#282]).
+
+## [0.2.0] - 2026-06-18
 
 ### Added
 
@@ -34,12 +48,6 @@ This section is the source for the `v0.2.0` release notes.
 - Aligned the dashboard with the current backend API and regenerated its typed
   client; added a `make openapi` workflow to keep the spec and client in sync
   ([#221]).
-- Migrated CLN Lightning payments from the deprecated `pay` RPC to `xpay`, and
-  refreshed the vendored CLN and LND gRPC protos to CLN v26.06 and LND v0.21
-  ([#282]).
-- Replaced the CLN `maxfeepercent` and `payment_exemptfee` settings with a single
-  absolute `maxfee` (msat); when left unset, the node applies its own default
-  ([#282]).
 
 ### Removed
 
@@ -52,8 +60,6 @@ This section is the source for the `v0.2.0` release notes.
 - Fixed LNURL payment callback encoding and error handling ([#224]).
 - Fixed on-chain deposit event handling so transient database write failures do
   not silently drop credits ([#267]).
-- Fixed CLN REST Lightning payments charging the routing fee twice for payments
-  that incur a non-zero fee ([#282]).
 
 ## [0.1.8] - 2025-11-03
 
@@ -61,7 +67,8 @@ This section is the source for the `v0.2.0` release notes.
 
 - Removed blink on the login page ([#175]).
 
-[Unreleased]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/bitcoin-numeraire/swissknife/compare/v0.1.8...v0.2.0
 [0.1.8]: https://github.com/bitcoin-numeraire/swissknife/releases/tag/v0.1.8
 [#175]: https://github.com/bitcoin-numeraire/swissknife/pull/175
 [#176]: https://github.com/bitcoin-numeraire/swissknife/pull/176

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ITEST_ENV = SWISSKNIFE_ITEST_COMPOSE_PROJECT=$(ITEST_PROJECT) \
 	SWISSKNIFE_ITEST_DATABASE=$(ITEST_DATABASE) \
 	SWISSKNIFE_ITEST_PROVIDER=$(ITEST_PROVIDER)
 
-.PHONY: watch up up-swissknife up-server up-postgres up-pgadmin shutdown down generate-certs build build-docker build-docker-server build-docker-dashboard run-docker lint fmt fmt-fix test test-unit test-integration test-persistence itest-up itest-down itest-shutdown itest-logs coverage coverage-html coverage-lcov coverage-matrix clean check deps-upgrade deps-outdated install-tools generate-models new-migration run-migrations fresh-migrations
+.PHONY: watch up up-swissknife up-server up-postgres up-pgadmin shutdown down generate-certs build protos build-docker build-docker-server build-docker-dashboard run-docker lint fmt fmt-fix test test-unit test-integration test-persistence itest-up itest-down itest-shutdown itest-logs coverage coverage-html coverage-lcov coverage-matrix clean check deps-upgrade deps-outdated install-tools generate-models new-migration run-migrations fresh-migrations
 
 watch:
 	@cargo watch -x run
@@ -98,6 +98,11 @@ fmt-fix:
 
 build:
 	@cargo build --workspace --all-targets --features itest
+
+# Refresh the vendored Lightning gRPC protos (logic in scripts/update-protos.sh).
+# Override versions: `CLN_VERSION=... LND_VERSION=... make protos`.
+protos:
+	@./scripts/update-protos.sh
 
 test:
 	@cargo test --workspace --all-targets

--- a/config/default.toml
+++ b/config/default.toml
@@ -17,9 +17,8 @@ request_timeout = "60s"
 [cln_grpc_config]
 endpoint = "https://localhost:11002"
 certs_dir = "certs/lightningd"
-maxfeepercent = 0.5
 payment_timeout = "60s"
-payment_exemptfee = 5000
+# maxfee = 50000 # Optional absolute routing fee cap in msat. Unset: xpay uses max(1%, 5000 msat).
 
 [cln_rest_config]
 endpoint = "http://localhost:3010"
@@ -30,9 +29,8 @@ timeout = "90s"
 connection_verbose = true
 accept_invalid_certs = false
 accept_invalid_hostnames = false
-maxfeepercent = 0.5
 payment_timeout = "60s"
-payment_exemptfee = 5000
+# maxfee = 50000 # Optional absolute routing fee cap in msat. Unset: xpay uses max(1%, 5000 msat).
 ws_min_reconnect_delay = "1s"
 ws_max_reconnect_delay = "30s"
 

--- a/config/itest.toml
+++ b/config/itest.toml
@@ -56,9 +56,7 @@ reorg_buffer_blocks = 2
 [cln_grpc_config]
 endpoint = "https://localhost:11002"
 certs_dir = "tests/itest/runtime/cln/regtest"
-maxfeepercent = 0.5
 payment_timeout = "10s"
-payment_exemptfee = 5000
 
 [cln_rest_config]
 endpoint = "https://127.0.0.1:3010"
@@ -68,8 +66,6 @@ timeout = "30s"
 connection_verbose = false
 accept_invalid_certs = true
 accept_invalid_hostnames = true
-maxfeepercent = 0.5
 payment_timeout = "10s"
-payment_exemptfee = 5000
 ws_min_reconnect_delay = "1s"
 ws_max_reconnect_delay = "5s"

--- a/scripts/update-protos.sh
+++ b/scripts/update-protos.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Refresh the vendored Lightning gRPC proto definitions, pinned to the deployed
+# node versions. Run via `make protos`. After running, review the diff and run
+# `make build` to regenerate the tonic bindings.
+#
+# Override the versions:
+#   CLN_VERSION=v26.06.1 LND_VERSION=v0.21.0-beta make protos
+#
+set -euo pipefail
+
+# Run from the repo root regardless of where the script is invoked.
+cd "$(dirname "$0")/.."
+
+CLN_VERSION="${CLN_VERSION:-v26.06.1}"
+LND_VERSION="${LND_VERSION:-v0.21.0-beta}"
+
+cln_url="https://raw.githubusercontent.com/ElementsProject/lightning/${CLN_VERSION}/cln-grpc/proto"
+lnd_url="https://raw.githubusercontent.com/lightningnetwork/lnd/${LND_VERSION}/lnrpc"
+cln_dir="src/infra/lightning/cln/proto"
+lnd_dir="src/infra/lightning/lnd/proto"
+
+fetch() { echo "  -> $2"; curl -sSfL "$1" -o "$2"; }
+
+echo ">>> CLN ${CLN_VERSION}"
+fetch "${cln_url}/node.proto"       "${cln_dir}/node.proto"
+fetch "${cln_url}/primitives.proto" "${cln_dir}/primitives.proto"
+
+echo ">>> LND ${LND_VERSION}"
+mkdir -p "${lnd_dir}/signrpc"
+fetch "${lnd_url}/lightning.proto"            "${lnd_dir}/lightning.proto"
+fetch "${lnd_url}/invoicesrpc/invoices.proto" "${lnd_dir}/invoices.proto"
+fetch "${lnd_url}/routerrpc/router.proto"     "${lnd_dir}/router.proto"
+fetch "${lnd_url}/walletrpc/walletkit.proto"  "${lnd_dir}/walletkit.proto"
+fetch "${lnd_url}/signrpc/signer.proto"       "${lnd_dir}/signrpc/signer.proto"
+
+echo ">>> Done. Review the diff, then run 'make build' to regenerate the bindings."

--- a/src/infra/lightning/cln/cln_grpc_client.rs
+++ b/src/infra/lightning/cln/cln_grpc_client.rs
@@ -55,10 +55,11 @@ pub mod cln {
 pub struct ClnClientConfig {
     pub endpoint: String,
     pub certs_dir: String,
-    pub maxfeepercent: Option<f64>,
     #[serde(deserialize_with = "deserialize_duration")]
     pub payment_timeout: Duration,
-    pub payment_exemptfee: Option<u64>,
+    /// Absolute max routing fee per payment, in msat. When unset, `xpay` applies
+    /// its own default of `max(1%, 5000 msat)`.
+    pub maxfee: Option<u64>,
 }
 
 const DEFAULT_CLIENT_CERT_FILENAME: &str = "client.pem";
@@ -67,9 +68,8 @@ const DEFAULT_CA_CRT_FILENAME: &str = "ca.pem";
 
 pub struct ClnGrpcClient {
     client: NodeClient<Channel>,
-    maxfeepercent: Option<f64>,
+    maxfee: Option<u64>,
     retry_for: Option<u32>,
-    payment_exemptfee: Option<Amount>,
     network: BtcNetwork,
 }
 
@@ -79,9 +79,8 @@ impl ClnGrpcClient {
 
         let mut cln_client = Self {
             client: client.clone(),
-            maxfeepercent: config.maxfeepercent,
+            maxfee: config.maxfee,
             retry_for: Some(config.payment_timeout.as_secs() as u32),
-            payment_exemptfee: config.payment_exemptfee.map(|fee| Amount { msat: fee }),
             network: BtcNetwork::default(),
         };
 
@@ -201,26 +200,11 @@ impl LnClient for ClnGrpcClient {
     async fn pay(&self, bolt11: String, amount_msat: Option<u64>, label: String) -> Result<Payment, LightningError> {
         let mut client = self.client.clone();
 
-        // `xpay` takes an absolute `maxfee` rather than `pay`'s deprecated
-        // `maxfeepercent`/`exemptfee`. Derive it from the configured percentage
-        // and the payment amount (explicit override or the invoice's amount).
-        let amount = amount_msat.or_else(|| {
-            Bolt11Invoice::from_str(&bolt11)
-                .ok()
-                .and_then(|inv| inv.amount_milli_satoshis())
-        });
-        let maxfee = self.maxfeepercent.zip(amount).map(|(pct, amt)| {
-            let exempt = self.payment_exemptfee.map(|a| a.msat).unwrap_or(0);
-            cln::Amount {
-                msat: ((amt as f64 * pct / 100.0) as u64).max(exempt),
-            }
-        });
-
         let response = client
             .xpay(XpayRequest {
                 invstring: bolt11,
                 amount_msat: amount_msat.map(|msat| cln::Amount { msat }),
-                maxfee,
+                maxfee: self.maxfee.map(|msat| cln::Amount { msat }),
                 retry_for: self.retry_for,
                 label: Some(label),
                 ..Default::default()

--- a/src/infra/lightning/cln/cln_grpc_client.rs
+++ b/src/infra/lightning/cln/cln_grpc_client.rs
@@ -5,7 +5,7 @@ use bitcoin::{Address, Network, ScriptBuf};
 use chrono::{TimeZone, Utc};
 use cln::{
     node_client::NodeClient, Amount, Feerate, GetinfoRequest, ListinvoicesRequest, NewaddrRequest, OutputDesc,
-    PayRequest, SetpsbtversionRequest, TxdiscardRequest, TxprepareRequest, TxsendRequest,
+    SetpsbtversionRequest, TxdiscardRequest, TxprepareRequest, TxsendRequest, XpayRequest,
 };
 use hex::decode;
 use lightning_invoice::Bolt11Invoice;
@@ -201,14 +201,28 @@ impl LnClient for ClnGrpcClient {
     async fn pay(&self, bolt11: String, amount_msat: Option<u64>, label: String) -> Result<Payment, LightningError> {
         let mut client = self.client.clone();
 
+        // `xpay` takes an absolute `maxfee` rather than `pay`'s deprecated
+        // `maxfeepercent`/`exemptfee`. Derive it from the configured percentage
+        // and the payment amount (explicit override or the invoice's amount).
+        let amount = amount_msat.or_else(|| {
+            Bolt11Invoice::from_str(&bolt11)
+                .ok()
+                .and_then(|inv| inv.amount_milli_satoshis())
+        });
+        let maxfee = self.maxfeepercent.zip(amount).map(|(pct, amt)| {
+            let exempt = self.payment_exemptfee.map(|a| a.msat).unwrap_or(0);
+            cln::Amount {
+                msat: ((amt as f64 * pct / 100.0) as u64).max(exempt),
+            }
+        });
+
         let response = client
-            .pay(PayRequest {
-                bolt11,
+            .xpay(XpayRequest {
+                invstring: bolt11,
                 amount_msat: amount_msat.map(|msat| cln::Amount { msat }),
-                label: Some(label),
-                maxfeepercent: self.maxfeepercent,
+                maxfee,
                 retry_for: self.retry_for,
-                exemptfee: self.payment_exemptfee,
+                label: Some(label),
                 ..Default::default()
             })
             .await

--- a/src/infra/lightning/cln/cln_grpc_types.rs
+++ b/src/infra/lightning/cln/cln_grpc_types.rs
@@ -1,5 +1,6 @@
 use chrono::{TimeZone, Utc};
 use lightning_invoice::Bolt11Invoice;
+use serde_bolt::bitcoin::hashes::{sha256, Hash};
 use std::str::FromStr;
 
 use crate::{
@@ -14,31 +15,26 @@ use crate::{
 };
 
 use super::cln::{
-    listinvoices_invoices::ListinvoicesInvoicesStatus, pay_response::PayStatus, ListinvoicesInvoices, PayResponse,
-    WaitinvoiceResponse,
+    listinvoices_invoices::ListinvoicesInvoicesStatus, ListinvoicesInvoices, WaitinvoiceResponse, XpayResponse,
 };
 
-impl From<PayResponse> for Payment {
-    fn from(val: PayResponse) -> Self {
-        let error = match val.status() {
-            PayStatus::Complete => None,
-            _ => Some(format!(
-                "Unexpected error. Payment returned successfully but with status {}",
-                val.status().as_str_name()
-            )),
-        };
-
-        let seconds = val.created_at as i64;
-        let nanoseconds = ((val.created_at - seconds as f64) * 1e9) as u32;
+impl From<XpayResponse> for Payment {
+    fn from(val: XpayResponse) -> Self {
+        // `xpay` returns no payment_hash; it is the SHA-256 of the preimage.
+        let payment_hash = hex::encode(sha256::Hash::hash(&val.payment_preimage).to_byte_array());
+        let amount_msat = val.amount_msat.map(|a| a.msat).unwrap_or_default();
+        let amount_sent_msat = val.amount_sent_msat.map(|a| a.msat).unwrap_or(amount_msat);
 
         Payment {
             ledger: Ledger::Lightning,
-            amount_msat: val.amount_msat.unwrap().msat,
-            fee_msat: Some(val.amount_sent_msat.unwrap().msat - val.amount_msat.unwrap().msat),
-            payment_time: Some(Utc.timestamp_opt(seconds, nanoseconds).unwrap()),
-            error,
+            amount_msat,
+            fee_msat: Some(amount_sent_msat.saturating_sub(amount_msat)),
+            // A returned XpayResponse means the payment completed; xpay surfaces
+            // failures as a gRPC error. No created_at is returned, so stamp now.
+            payment_time: Some(Utc::now()),
+            error: None,
             lightning: Some(LnPayment {
-                payment_hash: hex::encode(&val.payment_hash),
+                payment_hash,
                 payment_preimage: Some(hex::encode(val.payment_preimage)),
                 ..Default::default()
             }),

--- a/src/infra/lightning/cln/cln_grpc_types.rs
+++ b/src/infra/lightning/cln/cln_grpc_types.rs
@@ -88,3 +88,30 @@ impl From<ListfundsOutputsStatus> for BtcOutputStatus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::lightning::cln::cln::Amount;
+
+    /// `amount_msat` must be the delivered amount and `fee_msat` the routing fee, so
+    /// the settlement debit (`amount_msat + fee_msat`) equals `amount_sent_msat` once.
+    /// Mirrors the REST converter test; together they pin the semantics the single-hop
+    /// integration topology (zero routing fee) cannot exercise.
+    #[test]
+    fn xpay_response_separates_delivered_amount_from_routing_fee() {
+        let resp = XpayResponse {
+            payment_preimage: vec![1u8; 32],
+            failed_parts: 0,
+            successful_parts: 1,
+            amount_msat: Some(Amount { msat: 100_000 }), // delivered to the recipient
+            amount_sent_msat: Some(Amount { msat: 100_500 }), // delivered + 500 msat fee
+        };
+
+        let payment: Payment = resp.into();
+
+        assert_eq!(payment.amount_msat, 100_000);
+        assert_eq!(payment.fee_msat, Some(500));
+        assert_eq!(payment.amount_msat + payment.fee_msat.unwrap(), 100_500);
+    }
+}

--- a/src/infra/lightning/cln/cln_rest_client.rs
+++ b/src/infra/lightning/cln/cln_rest_client.rs
@@ -52,10 +52,11 @@ pub struct ClnRestClientConfig {
     pub timeout: Duration,
     pub accept_invalid_certs: bool,
     pub accept_invalid_hostnames: bool,
-    pub maxfeepercent: Option<f64>,
     #[serde(deserialize_with = "deserialize_duration")]
     pub payment_timeout: Duration,
-    pub payment_exemptfee: Option<u64>,
+    /// Absolute max routing fee per payment, in msat. When unset, `xpay` applies
+    /// its own default of `max(1%, 5000 msat)`.
+    pub maxfee: Option<u64>,
     #[serde(deserialize_with = "deserialize_duration")]
     pub ws_min_reconnect_delay: Duration,
     #[serde(deserialize_with = "deserialize_duration")]
@@ -66,9 +67,8 @@ pub struct ClnRestClientConfig {
 pub struct ClnRestClient {
     client: Client,
     base_url: String,
-    maxfeepercent: Option<f64>,
+    maxfee: Option<u64>,
     retry_for: Option<u32>,
-    payment_exemptfee: Option<u64>,
     network: BtcNetwork,
 }
 
@@ -106,9 +106,8 @@ impl ClnRestClient {
         let mut cln_client = Self {
             client,
             base_url: config.endpoint.clone(),
-            maxfeepercent: config.maxfeepercent,
+            maxfee: config.maxfee,
             retry_for: Some(config.payment_timeout.as_secs() as u32),
-            payment_exemptfee: config.payment_exemptfee,
             network: BtcNetwork::default(),
         };
 
@@ -191,26 +190,13 @@ impl LnClient for ClnRestClient {
     }
 
     async fn pay(&self, bolt11: String, amount_msat: Option<u64>, label: String) -> Result<Payment, LightningError> {
-        // `xpay` takes an absolute `maxfee` rather than `pay`'s deprecated
-        // `maxfeepercent`/`exemptfee`. Derive it from the configured percentage
-        // and the payment amount (explicit override or the invoice's amount).
-        let amount = amount_msat.or_else(|| {
-            Bolt11Invoice::from_str(&bolt11)
-                .ok()
-                .and_then(|inv| inv.amount_milli_satoshis())
-        });
-        let maxfee = self
-            .maxfeepercent
-            .zip(amount)
-            .map(|(pct, amt)| ((amt as f64 * pct / 100.0) as u64).max(self.payment_exemptfee.unwrap_or(0)));
-
         let response: XpayResponse = self
             .post_request(
                 "xpay",
                 &XpayRequest {
                     invstring: bolt11,
                     amount_msat,
-                    maxfee,
+                    maxfee: self.maxfee,
                     retry_for: self.retry_for,
                     label: Some(label),
                 },

--- a/src/infra/lightning/cln/cln_rest_client.rs
+++ b/src/infra/lightning/cln/cln_rest_client.rs
@@ -36,9 +36,9 @@ use super::{
     DelInvoiceRequest, DelInvoiceResponse, ErrorResponse, GetinfoRequest, GetinfoResponse, InvoiceRequest,
     InvoiceResponse, ListChainMovesRequest, ListChainMovesResponse, ListFundsRequest, ListInvoicesRequest,
     ListInvoicesResponse, ListPaysRequest, ListPaysResponse, ListTransactionsRequest, ListTransactionsResponse,
-    NewAddrRequest, NewAddrResponse, PayRequest, PayResponse, SetPsbtVersionRequest, SetPsbtVersionResponse,
-    TxDiscardRequest, TxDiscardResponse, TxPrepareOutput, TxPrepareRequest, TxPrepareResponse, TxSendRequest,
-    TxSendResponse,
+    NewAddrRequest, NewAddrResponse, SetPsbtVersionRequest, SetPsbtVersionResponse, TxDiscardRequest,
+    TxDiscardResponse, TxPrepareOutput, TxPrepareRequest, TxPrepareResponse, TxSendRequest, TxSendResponse,
+    XpayRequest, XpayResponse,
 };
 
 #[derive(Clone, Debug, Deserialize)]
@@ -191,16 +191,28 @@ impl LnClient for ClnRestClient {
     }
 
     async fn pay(&self, bolt11: String, amount_msat: Option<u64>, label: String) -> Result<Payment, LightningError> {
-        let response: PayResponse = self
+        // `xpay` takes an absolute `maxfee` rather than `pay`'s deprecated
+        // `maxfeepercent`/`exemptfee`. Derive it from the configured percentage
+        // and the payment amount (explicit override or the invoice's amount).
+        let amount = amount_msat.or_else(|| {
+            Bolt11Invoice::from_str(&bolt11)
+                .ok()
+                .and_then(|inv| inv.amount_milli_satoshis())
+        });
+        let maxfee = self
+            .maxfeepercent
+            .zip(amount)
+            .map(|(pct, amt)| ((amt as f64 * pct / 100.0) as u64).max(self.payment_exemptfee.unwrap_or(0)));
+
+        let response: XpayResponse = self
             .post_request(
-                "pay",
-                &PayRequest {
-                    bolt11,
+                "xpay",
+                &XpayRequest {
+                    invstring: bolt11,
                     amount_msat,
-                    label: Some(label),
-                    maxfeepercent: self.maxfeepercent,
+                    maxfee,
                     retry_for: self.retry_for,
-                    exemptfee: self.payment_exemptfee,
+                    label: Some(label),
                 },
             )
             .await

--- a/src/infra/lightning/cln/cln_rest_types.rs
+++ b/src/infra/lightning/cln/cln_rest_types.rs
@@ -248,7 +248,11 @@ impl From<XpayResponse> for Payment {
 
         Payment {
             ledger: Ledger::Lightning,
-            amount_msat: val.amount_sent_msat,
+            // `amount_msat` is the amount delivered to the recipient; `amount_sent_msat`
+            // includes the routing fee. Settlement debits `amount_msat + fee_msat`, so
+            // storing the delivered amount (not the fee-inclusive total) avoids charging
+            // the fee twice. Matches the gRPC converter.
+            amount_msat: val.amount_msat,
             fee_msat: Some(val.amount_sent_msat.saturating_sub(val.amount_msat)),
             // A returned XpayResponse means the payment completed; xpay surfaces
             // failures as an error response. No created_at is returned, so stamp now.
@@ -292,4 +296,32 @@ impl From<ListInvoicesInvoice> for Invoice {
 #[derive(Debug, Deserialize)]
 pub struct ErrorResponse {
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards against debiting the routing fee twice. The settlement path debits
+    /// `amount_msat + fee_msat`, so `amount_msat` must be the delivered amount, not
+    /// the fee-inclusive `amount_sent_msat`. The integration suite cannot catch this
+    /// because its single-hop regtest topology always has a zero routing fee.
+    #[test]
+    fn xpay_response_separates_delivered_amount_from_routing_fee() {
+        let resp = XpayResponse {
+            payment_preimage: "01".repeat(32),
+            amount_msat: 100_000,      // delivered to the recipient
+            amount_sent_msat: 100_500, // delivered + 500 msat routing fee
+        };
+
+        let payment: Payment = resp.into();
+
+        assert_eq!(payment.amount_msat, 100_000);
+        assert_eq!(payment.fee_msat, Some(500));
+        assert_eq!(
+            payment.amount_msat + payment.fee_msat.unwrap(),
+            100_500,
+            "wallet debit (amount + fee) must equal amount_sent_msat, not amount + 2*fee"
+        );
+    }
 }

--- a/src/infra/lightning/cln/cln_rest_types.rs
+++ b/src/infra/lightning/cln/cln_rest_types.rs
@@ -1,6 +1,7 @@
 use chrono::{TimeZone, Utc};
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
+use serde_bolt::bitcoin::hashes::{sha256, Hash};
 use std::str::FromStr;
 
 use crate::{
@@ -26,23 +27,19 @@ pub struct InvoiceResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub struct PayRequest {
-    pub bolt11: String,
-    pub label: Option<String>,
-    pub maxfeepercent: Option<f64>,
-    pub retry_for: Option<u32>,
-    pub exemptfee: Option<u64>,
+pub struct XpayRequest {
+    pub invstring: String,
     pub amount_msat: Option<u64>,
+    pub maxfee: Option<u64>,
+    pub retry_for: Option<u32>,
+    pub label: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct PayResponse {
+pub struct XpayResponse {
     pub payment_preimage: String,
-    pub payment_hash: String,
-    pub created_at: f64,
     pub amount_msat: u64,
     pub amount_sent_msat: u64,
-    pub status: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -243,27 +240,22 @@ pub struct ListInvoicesInvoice {
     amount_received_msat: Option<u64>,
 }
 
-impl From<PayResponse> for Payment {
-    fn from(val: PayResponse) -> Self {
-        let error = match val.status.as_str() {
-            "complete" => None,
-            _ => Some(format!(
-                "Unexpected error. Payment returned successfully but with status {}",
-                val.status
-            )),
-        };
-
-        let seconds = val.created_at as i64;
-        let nanoseconds = ((val.created_at - seconds as f64) * 1e9) as u32;
+impl From<XpayResponse> for Payment {
+    fn from(val: XpayResponse) -> Self {
+        // `xpay` returns no payment_hash; it is the SHA-256 of the preimage.
+        let preimage_bytes = hex::decode(&val.payment_preimage).unwrap_or_default();
+        let payment_hash = hex::encode(sha256::Hash::hash(&preimage_bytes).to_byte_array());
 
         Payment {
             ledger: Ledger::Lightning,
             amount_msat: val.amount_sent_msat,
-            fee_msat: Some(val.amount_sent_msat - val.amount_msat),
-            payment_time: Some(Utc.timestamp_opt(seconds, nanoseconds).unwrap()),
-            error,
+            fee_msat: Some(val.amount_sent_msat.saturating_sub(val.amount_msat)),
+            // A returned XpayResponse means the payment completed; xpay surfaces
+            // failures as an error response. No created_at is returned, so stamp now.
+            payment_time: Some(Utc::now()),
+            error: None,
             lightning: Some(LnPayment {
-                payment_hash: val.payment_hash,
+                payment_hash,
                 payment_preimage: Some(val.payment_preimage),
                 ..Default::default()
             }),

--- a/src/infra/lightning/cln/proto/node.proto
+++ b/src/infra/lightning/cln/proto/node.proto
@@ -104,6 +104,8 @@ service Node {
 	rpc SpliceInit(SpliceInitRequest) returns (SpliceInitResponse) {}
 	rpc SpliceSigned(SpliceSignedRequest) returns (SpliceSignedResponse) {}
 	rpc SpliceUpdate(SpliceUpdateRequest) returns (SpliceUpdateResponse) {}
+	rpc SpliceIn(SpliceinRequest) returns (SpliceinResponse) {}
+	rpc SpliceOut(SpliceoutRequest) returns (SpliceoutResponse) {}
 	rpc DevSplice(DevspliceRequest) returns (DevspliceResponse) {}
 	rpc UnreserveInputs(UnreserveinputsRequest) returns (UnreserveinputsResponse) {}
 	rpc UpgradeWallet(UpgradewalletRequest) returns (UpgradewalletResponse) {}
@@ -123,6 +125,7 @@ service Node {
 	rpc BkprListIncome(BkprlistincomeRequest) returns (BkprlistincomeResponse) {}
 	rpc BkprEditDescriptionByPaymentId(BkpreditdescriptionbypaymentidRequest) returns (BkpreditdescriptionbypaymentidResponse) {}
 	rpc BkprEditDescriptionByOutpoint(BkpreditdescriptionbyoutpointRequest) returns (BkpreditdescriptionbyoutpointResponse) {}
+	rpc BkprReport(BkprreportRequest) returns (BkprreportResponse) {}
 	rpc BlacklistRune(BlacklistruneRequest) returns (BlacklistruneResponse) {}
 	rpc CheckRune(CheckruneRequest) returns (CheckruneResponse) {}
 	rpc CreateRune(CreateruneRequest) returns (CreateruneResponse) {}
@@ -131,6 +134,7 @@ service Node {
 	rpc AskReneListLayers(AskrenelistlayersRequest) returns (AskrenelistlayersResponse) {}
 	rpc AskReneCreateLayer(AskrenecreatelayerRequest) returns (AskrenecreatelayerResponse) {}
 	rpc AskReneRemoveLayer(AskreneremovelayerRequest) returns (AskreneremovelayerResponse) {}
+	rpc AskReneRemoveChannelUpdate(AskreneremovechannelupdateRequest) returns (AskreneremovechannelupdateResponse) {}
 	rpc AskReneReserve(AskrenereserveRequest) returns (AskrenereserveResponse) {}
 	rpc AskReneAge(AskreneageRequest) returns (AskreneageResponse) {}
 	rpc GetRoutes(GetroutesRequest) returns (GetroutesResponse) {}
@@ -150,13 +154,38 @@ service Node {
 	rpc ListNetworkEvents(ListnetworkeventsRequest) returns (ListnetworkeventsResponse) {}
 	rpc DelNetworkEvent(DelnetworkeventRequest) returns (DelnetworkeventResponse) {}
 	rpc ClnrestRegisterPath(ClnrestregisterpathRequest) returns (ClnrestregisterpathResponse) {}
+	rpc ListCurrencyRates(ListcurrencyratesRequest) returns (ListcurrencyratesResponse) {}
+	rpc CurrencyConvert(CurrencyconvertRequest) returns (CurrencyconvertResponse) {}
+	rpc CurrencyRate(CurrencyrateRequest) returns (CurrencyrateResponse) {}
+	rpc SendAmount(SendamountRequest) returns (SendamountResponse) {}
+	rpc CreateProof(CreateproofRequest) returns (CreateproofResponse) {}
+	rpc Xkeysend(XkeysendRequest) returns (XkeysendResponse) {}
+	rpc Graceful(GracefulRequest) returns (GracefulResponse) {}
 
+	rpc SubscribeBalanceSnapshot(StreamBalanceSnapshotRequest) returns (stream BalanceSnapshotNotification) {}
 	rpc SubscribeBlockAdded(StreamBlockAddedRequest) returns (stream BlockAddedNotification) {}
 	rpc SubscribeChannelOpenFailed(StreamChannelOpenFailedRequest) returns (stream ChannelOpenFailedNotification) {}
 	rpc SubscribeChannelOpened(StreamChannelOpenedRequest) returns (stream ChannelOpenedNotification) {}
-	rpc SubscribeConnect(StreamConnectRequest) returns (stream PeerConnectNotification) {}
-	rpc SubscribeCustomMsg(StreamCustomMsgRequest) returns (stream CustomMsgNotification) {}
 	rpc SubscribeChannelStateChanged(StreamChannelStateChangedRequest) returns (stream ChannelStateChangedNotification) {}
+	rpc SubscribeConnect(StreamConnectRequest) returns (stream PeerConnectNotification) {}
+	rpc SubscribeCoinMovement(StreamCoinMovementRequest) returns (stream CoinMovementNotification) {}
+	rpc SubscribeCustomMsg(StreamCustomMsgRequest) returns (stream CustomMsgNotification) {}
+	rpc SubscribeDeprecatedOneshot(StreamDeprecatedOneshotRequest) returns (stream DeprecatedOneshotNotification) {}
+	rpc SubscribeDisconnect(StreamDisconnectRequest) returns (stream DisconnectNotification) {}
+	rpc SubscribeForwardEvent(StreamForwardEventRequest) returns (stream ForwardEventNotification) {}
+	rpc SubscribeInvoiceCreation(StreamInvoiceCreationRequest) returns (stream InvoiceCreationNotification) {}
+	rpc SubscribeInvoicePayment(StreamInvoicePaymentRequest) returns (stream InvoicePaymentNotification) {}
+	rpc SubscribeLog(StreamLogRequest) returns (stream LogNotification) {}
+	rpc SubscribeOnionMessageForwardFail(StreamOnionMessageForwardFailRequest) returns (stream OnionMessageForwardFailNotification) {}
+	rpc SubscribeOpenChannelPeerSigs(StreamOpenChannelPeerSigsRequest) returns (stream OpenChannelPeerSigsNotification) {}
+	rpc SubscribePluginStarted(StreamPluginStartedRequest) returns (stream PluginStartedNotification) {}
+	rpc SubscribePluginStopped(StreamPluginStoppedRequest) returns (stream PluginStoppedNotification) {}
+	rpc SubscribeSendPayFailure(StreamSendPayFailureRequest) returns (stream SendPayFailureNotification) {}
+	rpc SubscribeSendPaySuccess(StreamSendPaySuccessRequest) returns (stream SendPaySuccessNotification) {}
+	rpc SubscribeShutdown(StreamShutdownRequest) returns (stream ShutdownNotification) {}
+	rpc SubscribeWarning(StreamWarningRequest) returns (stream WarningNotification) {}
+	rpc SubscribePayPartEnd(StreamPayPartEndRequest) returns (stream PayPartEndNotification) {}
+	rpc SubscribePayPartStart(StreamPayPartStartRequest) returns (stream PayPartStartNotification) {}
 }
 
 message GetinfoRequest {
@@ -164,7 +193,7 @@ message GetinfoRequest {
 
 message GetinfoResponse {
 	bytes id = 1;
-	optional string alias = 2;
+	string alias = 2;
 	bytes color = 3;
 	uint32 num_peers = 4;
 	uint32 num_pending_channels = 5;
@@ -180,13 +209,6 @@ message GetinfoResponse {
 	repeated GetinfoBinding binding = 15;
 	optional string warning_bitcoind_sync = 16;
 	optional string warning_lightningd_sync = 17;
-}
-
-message GetinfoOurFeatures {
-	bytes init = 1;
-	bytes node = 2;
-	bytes channel = 3;
-	bytes invoice = 4;
 }
 
 message GetinfoAddress {
@@ -220,6 +242,13 @@ message GetinfoBinding {
 	optional string subtype = 5;
 }
 
+message GetinfoOurFeatures {
+	bytes init = 1;
+	bytes node = 2;
+	bytes channel = 3;
+	bytes invoice = 4;
+}
+
 message ListpeersRequest {
 	// ListPeers.level
 	enum ListpeersLevel {
@@ -244,7 +273,7 @@ message ListpeersPeers {
 	repeated string netaddr = 5;
 	optional bytes features = 6;
 	optional string remote_addr = 7;
-	optional uint32 num_channels = 8;
+	uint32 num_channels = 8;
 }
 
 message ListpeersPeersLog {
@@ -277,6 +306,18 @@ message ListfundsResponse {
 	repeated ListfundsChannels channels = 2;
 }
 
+message ListfundsChannels {
+	bytes peer_id = 1;
+	Amount our_amount_msat = 2;
+	Amount amount_msat = 3;
+	bytes funding_txid = 4;
+	uint32 funding_output = 5;
+	bool connected = 6;
+	ChannelState state = 7;
+	optional string short_channel_id = 8;
+	bytes channel_id = 9;
+}
+
 message ListfundsOutputs {
 	// ListFunds.outputs[].status
 	enum ListfundsOutputsStatus {
@@ -295,18 +336,6 @@ message ListfundsOutputs {
 	optional uint32 blockheight = 8;
 	bool reserved = 9;
 	optional uint32 reserved_to_block = 10;
-}
-
-message ListfundsChannels {
-	bytes peer_id = 1;
-	Amount our_amount_msat = 2;
-	Amount amount_msat = 3;
-	bytes funding_txid = 4;
-	uint32 funding_output = 5;
-	bool connected = 6;
-	ChannelState state = 7;
-	optional string short_channel_id = 8;
-	optional bytes channel_id = 9;
 }
 
 message SendpayRequest {
@@ -344,15 +373,19 @@ message SendpayResponse {
 	optional bytes payment_preimage = 13;
 	optional string message = 14;
 	optional uint64 completed_at = 15;
-	optional uint64 created_index = 16;
+	uint64 created_index = 16;
 	optional uint64 updated_index = 17;
 }
 
 message SendpayRoute {
-	bytes id = 2;
-	uint32 delay = 3;
-	string channel = 4;
-	Amount amount_msat = 5;
+	optional bytes id = 2;
+	optional uint32 delay = 3;
+	optional string channel = 4;
+	optional Amount amount_msat = 5;
+	optional string short_channel_id_dir = 6;
+	optional bytes node_id_out = 7;
+	optional Amount amount_out_msat = 8;
+	optional uint32 cltv_out = 9;
 }
 
 message ListchannelsRequest {
@@ -423,7 +456,7 @@ message AutocleanonceAutoclean {
 	optional AutocleanonceAutocleanNetworkevents networkevents = 7;
 }
 
-message AutocleanonceAutocleanSucceededforwards {
+message AutocleanonceAutocleanExpiredinvoices {
 	uint64 cleaned = 1;
 	uint64 uncleaned = 2;
 }
@@ -433,12 +466,12 @@ message AutocleanonceAutocleanFailedforwards {
 	uint64 uncleaned = 2;
 }
 
-message AutocleanonceAutocleanSucceededpays {
+message AutocleanonceAutocleanFailedpays {
 	uint64 cleaned = 1;
 	uint64 uncleaned = 2;
 }
 
-message AutocleanonceAutocleanFailedpays {
+message AutocleanonceAutocleanNetworkevents {
 	uint64 cleaned = 1;
 	uint64 uncleaned = 2;
 }
@@ -448,12 +481,12 @@ message AutocleanonceAutocleanPaidinvoices {
 	uint64 uncleaned = 2;
 }
 
-message AutocleanonceAutocleanExpiredinvoices {
+message AutocleanonceAutocleanSucceededforwards {
 	uint64 cleaned = 1;
 	uint64 uncleaned = 2;
 }
 
-message AutocleanonceAutocleanNetworkevents {
+message AutocleanonceAutocleanSucceededpays {
 	uint64 cleaned = 1;
 	uint64 uncleaned = 2;
 }
@@ -476,7 +509,7 @@ message AutocleanstatusAutoclean {
 	optional AutocleanstatusAutocleanNetworkevents networkevents = 7;
 }
 
-message AutocleanstatusAutocleanSucceededforwards {
+message AutocleanstatusAutocleanExpiredinvoices {
 	bool enabled = 1;
 	uint64 cleaned = 2;
 	optional uint64 age = 3;
@@ -488,13 +521,13 @@ message AutocleanstatusAutocleanFailedforwards {
 	optional uint64 age = 3;
 }
 
-message AutocleanstatusAutocleanSucceededpays {
+message AutocleanstatusAutocleanFailedpays {
 	bool enabled = 1;
 	uint64 cleaned = 2;
 	optional uint64 age = 3;
 }
 
-message AutocleanstatusAutocleanFailedpays {
+message AutocleanstatusAutocleanNetworkevents {
 	bool enabled = 1;
 	uint64 cleaned = 2;
 	optional uint64 age = 3;
@@ -506,13 +539,13 @@ message AutocleanstatusAutocleanPaidinvoices {
 	optional uint64 age = 3;
 }
 
-message AutocleanstatusAutocleanExpiredinvoices {
+message AutocleanstatusAutocleanSucceededforwards {
 	bool enabled = 1;
 	uint64 cleaned = 2;
 	optional uint64 age = 3;
 }
 
-message AutocleanstatusAutocleanNetworkevents {
+message AutocleanstatusAutocleanSucceededpays {
 	bool enabled = 1;
 	uint64 cleaned = 2;
 	optional uint64 age = 3;
@@ -611,7 +644,7 @@ message CreateinvoiceResponse {
 	optional bytes payment_preimage = 12;
 	optional bytes local_offer_id = 13;
 	optional string invreq_payer_note = 15;
-	optional uint64 created_index = 16;
+	uint64 created_index = 16;
 	optional CreateinvoicePaidOutpoint paid_outpoint = 17;
 }
 
@@ -714,7 +747,7 @@ message DelinvoiceResponse {
 	uint64 expires_at = 8;
 	optional bytes local_offer_id = 9;
 	optional string invreq_payer_note = 11;
-	optional uint64 created_index = 12;
+	uint64 created_index = 12;
 	optional uint64 updated_index = 13;
 	optional uint64 pay_index = 14;
 	optional Amount amount_received_msat = 15;
@@ -747,6 +780,8 @@ message GetemergencyrecoverdataRequest {
 
 message GetemergencyrecoverdataResponse {
 	bytes filedata = 1;
+	optional bool can_create_penalty = 2;
+	repeated bytes backed_up_channel_ids = 3;
 }
 
 message ExposesecretRequest {
@@ -769,7 +804,7 @@ message RecoverResponse {
 	enum RecoverResult {
 		RECOVERY_RESTART_IN_PROGRESS = 0;
 	}
-	optional RecoverResult result = 1;
+	RecoverResult result = 1;
 }
 
 message RecoverchannelRequest {
@@ -802,7 +837,7 @@ message InvoiceResponse {
 	optional string warning_deadends = 7;
 	optional string warning_private_unused = 8;
 	optional string warning_mpp = 9;
-	optional uint64 created_index = 10;
+	uint64 created_index = 10;
 }
 
 message InvoicerequestRequest {
@@ -909,7 +944,7 @@ message ListinvoicesInvoices {
 	optional uint64 paid_at = 13;
 	optional bytes payment_preimage = 14;
 	optional string invreq_payer_note = 15;
-	optional uint64 created_index = 16;
+	uint64 created_index = 16;
 	optional uint64 updated_index = 17;
 	optional ListinvoicesInvoicesPaidOutpoint paid_outpoint = 18;
 }
@@ -954,7 +989,7 @@ message SendonionResponse {
 	optional bytes payment_preimage = 11;
 	optional string message = 12;
 	optional uint64 partid = 13;
-	optional uint64 created_index = 14;
+	uint64 created_index = 14;
 	optional uint64 updated_index = 15;
 }
 
@@ -965,16 +1000,16 @@ message SendonionFirstHop {
 }
 
 message ListsendpaysRequest {
+	// ListSendPays.index
+	enum ListsendpaysIndex {
+		CREATED = 0;
+		UPDATED = 1;
+	}
 	// ListSendPays.status
 	enum ListsendpaysStatus {
 		PENDING = 0;
 		COMPLETE = 1;
 		FAILED = 2;
-	}
-	// ListSendPays.index
-	enum ListsendpaysIndex {
-		CREATED = 0;
-		UPDATED = 1;
 	}
 	optional string bolt11 = 1;
 	optional bytes payment_hash = 2;
@@ -1010,7 +1045,7 @@ message ListsendpaysPayments {
 	optional bytes erroronion = 13;
 	optional string description = 14;
 	optional uint64 partid = 15;
-	optional uint64 created_index = 16;
+	uint64 created_index = 16;
 	optional uint64 updated_index = 17;
 	optional uint64 completed_at = 18;
 }
@@ -1055,37 +1090,37 @@ message MakesecretResponse {
 }
 
 message PayRequest {
-	string bolt11 = 1;
-	optional string label = 3;
-	optional double maxfeepercent = 4;
-	optional uint32 retry_for = 5;
-	optional uint32 maxdelay = 6;
-	optional Amount exemptfee = 7;
-	optional double riskfactor = 8;
-	repeated string exclude = 10;
-	optional Amount maxfee = 11;
-	optional string description = 12;
-	optional Amount amount_msat = 13;
-	optional bytes localinvreqid = 14;
-	optional Amount partial_msat = 15;
+	string bolt11 = 1 [deprecated = true];
+	optional string label = 3 [deprecated = true];
+	optional double maxfeepercent = 4 [deprecated = true];
+	optional uint32 retry_for = 5 [deprecated = true];
+	optional uint32 maxdelay = 6 [deprecated = true];
+	optional Amount exemptfee = 7 [deprecated = true];
+	optional double riskfactor = 8 [deprecated = true];
+	repeated string exclude = 10 [deprecated = true];
+	optional Amount maxfee = 11 [deprecated = true];
+	optional string description = 12 [deprecated = true];
+	optional Amount amount_msat = 13 [deprecated = true];
+	optional bytes localinvreqid = 14 [deprecated = true];
+	optional Amount partial_msat = 15 [deprecated = true];
 }
 
 message PayResponse {
 	// Pay.status
 	enum PayStatus {
-		COMPLETE = 0;
-		PENDING = 1;
-		FAILED = 2;
+		COMPLETE = 0 [deprecated = true];
+		PENDING = 1 [deprecated = true];
+		FAILED = 2 [deprecated = true];
 	}
-	bytes payment_preimage = 1;
-	optional bytes destination = 2;
-	bytes payment_hash = 3;
-	double created_at = 4;
-	uint32 parts = 5;
-	Amount amount_msat = 6;
-	Amount amount_sent_msat = 7;
-	optional string warning_partial_completion = 8;
-	PayStatus status = 9;
+	bytes payment_preimage = 1 [deprecated = true];
+	optional bytes destination = 2 [deprecated = true];
+	bytes payment_hash = 3 [deprecated = true];
+	double created_at = 4 [deprecated = true];
+	uint32 parts = 5 [deprecated = true];
+	Amount amount_msat = 6 [deprecated = true];
+	Amount amount_sent_msat = 7 [deprecated = true];
+	optional string warning_partial_completion = 8 [deprecated = true];
+	PayStatus status = 9 [deprecated = true];
 }
 
 message ListnodesRequest {
@@ -1106,15 +1141,6 @@ message ListnodesNodes {
 	optional ListnodesNodesOptionWillFund option_will_fund = 7;
 }
 
-message ListnodesNodesOptionWillFund {
-	Amount lease_fee_base_msat = 1;
-	uint32 lease_fee_basis = 2;
-	uint32 funding_weight = 3;
-	Amount channel_fee_max_base_msat = 4;
-	uint32 channel_fee_max_proportional_thousandths = 5;
-	bytes compact_lease = 6;
-}
-
 message ListnodesNodesAddresses {
 	// ListNodes.nodes[].addresses[].type
 	enum ListnodesNodesAddressesType {
@@ -1127,6 +1153,15 @@ message ListnodesNodesAddresses {
 	ListnodesNodesAddressesType item_type = 1;
 	uint32 port = 2;
 	optional string address = 3;
+}
+
+message ListnodesNodesOptionWillFund {
+	Amount lease_fee_base_msat = 1;
+	uint32 lease_fee_basis = 2;
+	uint32 funding_weight = 3;
+	Amount channel_fee_max_base_msat = 4;
+	uint32 channel_fee_max_proportional_thousandths = 5;
+	bytes compact_lease = 6;
 }
 
 message WaitanyinvoiceRequest {
@@ -1152,7 +1187,7 @@ message WaitanyinvoiceResponse {
 	optional Amount amount_received_msat = 10;
 	optional uint64 paid_at = 11;
 	optional bytes payment_preimage = 12;
-	optional uint64 created_index = 13;
+	uint64 created_index = 13;
 	optional uint64 updated_index = 14;
 	optional WaitanyinvoicePaidOutpoint paid_outpoint = 15;
 }
@@ -1184,7 +1219,7 @@ message WaitinvoiceResponse {
 	optional Amount amount_received_msat = 10;
 	optional uint64 paid_at = 11;
 	optional bytes payment_preimage = 12;
-	optional uint64 created_index = 13;
+	uint64 created_index = 13;
 	optional uint64 updated_index = 14;
 	optional WaitinvoicePaidOutpoint paid_outpoint = 15;
 }
@@ -1220,7 +1255,7 @@ message WaitsendpayResponse {
 	optional string bolt12 = 12;
 	optional bytes payment_preimage = 13;
 	optional double completed_at = 14;
-	optional uint64 created_index = 15;
+	uint64 created_index = 15;
 	optional uint64 updated_index = 16;
 }
 
@@ -1254,32 +1289,32 @@ message WithdrawResponse {
 }
 
 message KeysendRequest {
-	bytes destination = 1;
-	optional string label = 3;
-	optional double maxfeepercent = 4;
-	optional uint32 retry_for = 5;
-	optional uint32 maxdelay = 6;
-	optional Amount exemptfee = 7;
-	optional RoutehintList routehints = 8;
-	optional TlvStream extratlvs = 9;
-	Amount amount_msat = 10;
-	optional Amount maxfee = 11;
+	bytes destination = 1 [deprecated = true];
+	optional string label = 3 [deprecated = true];
+	optional double maxfeepercent = 4 [deprecated = true];
+	optional uint32 retry_for = 5 [deprecated = true];
+	optional uint32 maxdelay = 6 [deprecated = true];
+	optional Amount exemptfee = 7 [deprecated = true];
+	optional RoutehintList routehints = 8 [deprecated = true];
+	optional TlvStream extratlvs = 9 [deprecated = true];
+	Amount amount_msat = 10 [deprecated = true];
+	optional Amount maxfee = 11 [deprecated = true];
 }
 
 message KeysendResponse {
 	// KeySend.status
 	enum KeysendStatus {
-		COMPLETE = 0;
+		COMPLETE = 0 [deprecated = true];
 	}
-	bytes payment_preimage = 1;
-	optional bytes destination = 2;
-	bytes payment_hash = 3;
-	double created_at = 4;
-	uint32 parts = 5;
-	Amount amount_msat = 6;
-	Amount amount_sent_msat = 7;
-	optional string warning_partial_completion = 8;
-	KeysendStatus status = 9;
+	bytes payment_preimage = 1 [deprecated = true];
+	optional bytes destination = 2 [deprecated = true];
+	bytes payment_hash = 3 [deprecated = true];
+	double created_at = 4 [deprecated = true];
+	uint32 parts = 5 [deprecated = true];
+	Amount amount_msat = 6 [deprecated = true];
+	Amount amount_sent_msat = 7 [deprecated = true];
+	optional string warning_partial_completion = 8 [deprecated = true];
+	KeysendStatus status = 9 [deprecated = true];
 }
 
 message FundpsbtRequest {
@@ -1396,6 +1431,7 @@ message TxsendResponse {
 message ListpeerchannelsRequest {
 	optional bytes id = 1;
 	optional string short_channel_id = 2;
+	optional bytes channel_id = 3;
 }
 
 message ListpeerchannelsResponse {
@@ -1407,6 +1443,7 @@ message ListpeerchannelsChannels {
 	bool peer_connected = 2;
 	ChannelState state = 3;
 	optional bytes scratch_txid = 4;
+	optional ListpeerchannelsChannelsChannelType channel_type = 5;
 	optional ListpeerchannelsChannelsFeerate feerate = 6;
 	optional string owner = 7;
 	optional string short_channel_id = 8;
@@ -1430,7 +1467,6 @@ message ListpeerchannelsChannels {
 	optional Amount fee_base_msat = 27;
 	optional uint32 fee_proportional_millionths = 28;
 	optional Amount dust_limit_msat = 29;
-	optional Amount max_total_htlc_in_msat = 30;
 	optional Amount their_reserve_msat = 31;
 	optional Amount our_reserve_msat = 32;
 	optional Amount spendable_msat = 33;
@@ -1442,6 +1478,7 @@ message ListpeerchannelsChannels {
 	optional uint32 our_to_self_delay = 39;
 	optional uint32 max_accepted_htlcs = 40;
 	optional ListpeerchannelsChannelsAlias alias = 41;
+	repeated ListpeerchannelsChannelsStateChanges state_changes = 42;
 	repeated string status = 43;
 	optional uint64 in_payments_offered = 44;
 	optional Amount in_offered_msat = 45;
@@ -1459,9 +1496,78 @@ message ListpeerchannelsChannels {
 	optional bool lost_state = 57;
 	optional bool reestablished = 58;
 	optional Amount last_tx_fee_msat = 59;
-	optional sint64 direction = 60;
+	optional uint32 direction = 60;
 	optional Amount their_max_htlc_value_in_flight_msat = 61;
 	optional Amount our_max_htlc_value_in_flight_msat = 62;
+	repeated string features = 63;
+}
+
+message ListpeerchannelsChannelsAlias {
+	optional string local = 1;
+	optional string remote = 2;
+}
+
+message ListpeerchannelsChannelsChannelType {
+	repeated uint32 bits = 1;
+	repeated ChannelTypeName names = 2;
+}
+
+message ListpeerchannelsChannelsFeerate {
+	uint32 perkw = 1;
+	uint32 perkb = 2;
+}
+
+message ListpeerchannelsChannelsFunding {
+	optional Amount pushed_msat = 1;
+	Amount local_funds_msat = 2;
+	Amount remote_funds_msat = 3;
+	optional Amount fee_paid_msat = 4;
+	optional Amount fee_rcvd_msat = 5;
+	optional string psbt = 6;
+	optional bool withheld = 7;
+}
+
+message ListpeerchannelsChannelsHtlcs {
+	// ListPeerChannels.channels[].htlcs[].direction
+	enum ListpeerchannelsChannelsHtlcsDirection {
+		IN = 0;
+		OUT = 1;
+	}
+	ListpeerchannelsChannelsHtlcsDirection direction = 1;
+	uint64 id = 2;
+	Amount amount_msat = 3;
+	uint32 expiry = 4;
+	bytes payment_hash = 5;
+	optional bool local_trimmed = 6;
+	optional string status = 7;
+	HtlcState state = 8;
+}
+
+message ListpeerchannelsChannelsInflight {
+	bytes funding_txid = 1;
+	uint32 funding_outnum = 2;
+	string feerate = 3;
+	Amount total_funding_msat = 4;
+	Amount our_funding_msat = 5;
+	optional bytes scratch_txid = 6;
+	sint64 splice_amount = 7;
+}
+
+message ListpeerchannelsChannelsStateChanges {
+	// ListPeerChannels.channels[].state_changes[].cause
+	enum ListpeerchannelsChannelsStateChangesCause {
+		UNKNOWN = 0;
+		LOCAL = 1;
+		USER = 2;
+		REMOTE = 3;
+		PROTOCOL = 4;
+		ONCHAIN = 5;
+	}
+	string timestamp = 1;
+	ChannelState old_state = 2;
+	ChannelState new_state = 3;
+	ListpeerchannelsChannelsStateChangesCause cause = 4;
+	string message = 5;
 }
 
 message ListpeerchannelsChannelsUpdates {
@@ -1483,52 +1589,6 @@ message ListpeerchannelsChannelsUpdatesRemote {
 	uint32 cltv_expiry_delta = 3;
 	Amount fee_base_msat = 4;
 	uint32 fee_proportional_millionths = 5;
-}
-
-message ListpeerchannelsChannelsFeerate {
-	uint32 perkw = 1;
-	uint32 perkb = 2;
-}
-
-message ListpeerchannelsChannelsInflight {
-	bytes funding_txid = 1;
-	uint32 funding_outnum = 2;
-	string feerate = 3;
-	Amount total_funding_msat = 4;
-	Amount our_funding_msat = 5;
-	optional bytes scratch_txid = 6;
-	optional sint64 splice_amount = 7;
-}
-
-message ListpeerchannelsChannelsFunding {
-	optional Amount pushed_msat = 1;
-	Amount local_funds_msat = 2;
-	Amount remote_funds_msat = 3;
-	optional Amount fee_paid_msat = 4;
-	optional Amount fee_rcvd_msat = 5;
-	optional string psbt = 6;
-	optional bool withheld = 7;
-}
-
-message ListpeerchannelsChannelsAlias {
-	optional string local = 1;
-	optional string remote = 2;
-}
-
-message ListpeerchannelsChannelsHtlcs {
-	// ListPeerChannels.channels[].htlcs[].direction
-	enum ListpeerchannelsChannelsHtlcsDirection {
-		IN = 0;
-		OUT = 1;
-	}
-	ListpeerchannelsChannelsHtlcsDirection direction = 1;
-	uint64 id = 2;
-	Amount amount_msat = 3;
-	uint32 expiry = 4;
-	bytes payment_hash = 5;
-	optional bool local_trimmed = 6;
-	optional string status = 7;
-	HtlcState state = 8;
 }
 
 message ListclosedchannelsRequest {
@@ -1556,6 +1616,7 @@ message ListclosedchannelsClosedchannels {
 	ChannelSide opener = 5;
 	optional ChannelSide closer = 6;
 	bool private = 7;
+	optional ListclosedchannelsClosedchannelsChannelType channel_type = 8;
 	uint64 total_local_commitments = 9;
 	uint64 total_remote_commitments = 10;
 	uint64 total_htlcs_sent = 11;
@@ -1582,6 +1643,11 @@ message ListclosedchannelsClosedchannelsAlias {
 	optional string remote = 2;
 }
 
+message ListclosedchannelsClosedchannelsChannelType {
+	repeated uint32 bits = 1;
+	repeated ChannelTypeName names = 2;
+}
+
 message DecodeRequest {
 	string string = 1;
 }
@@ -1595,6 +1661,7 @@ message DecodeResponse {
 		BOLT11_INVOICE = 3;
 		RUNE = 4;
 		EMERGENCY_RECOVER = 5;
+		BOLT12_PAYER_PROOF = 6;
 	}
 	DecodeType item_type = 1;
 	bool valid = 2;
@@ -1612,8 +1679,8 @@ message DecodeResponse {
 	optional uint64 offer_absolute_expiry = 14;
 	optional uint64 offer_quantity_max = 15;
 	repeated DecodeOfferPaths offer_paths = 16;
-	optional bytes offer_node_id = 17;
-	optional string warning_missing_offer_node_id = 20;
+	optional DecodeOfferRecurrence offer_recurrence = 18;
+	repeated DecodeUnknownOfferTlvs unknown_offer_tlvs = 19;
 	optional string warning_invalid_offer_description = 21;
 	optional string warning_missing_offer_description = 22;
 	optional string warning_invalid_offer_currency = 23;
@@ -1627,11 +1694,13 @@ message DecodeResponse {
 	optional string invreq_payer_note = 31;
 	optional uint32 invreq_recurrence_counter = 32;
 	optional uint32 invreq_recurrence_start = 33;
+	repeated DecodeUnknownInvoiceRequestTlvs unknown_invoice_request_tlvs = 34;
 	optional string warning_missing_invreq_metadata = 35;
 	optional string warning_missing_invreq_payer_id = 36;
 	optional string warning_invalid_invreq_payer_note = 37;
 	optional string warning_missing_invoice_request_signature = 38;
 	optional string warning_invalid_invoice_request_signature = 39;
+	repeated DecodeInvoicePaths invoice_paths = 40;
 	optional uint64 invoice_created_at = 41;
 	optional uint32 invoice_relative_expiry = 42;
 	optional bytes invoice_payment_hash = 43;
@@ -1640,6 +1709,7 @@ message DecodeResponse {
 	optional bytes invoice_features = 46;
 	optional bytes invoice_node_id = 47;
 	optional uint64 invoice_recurrence_basetime = 48;
+	repeated DecodeUnknownInvoiceTlvs unknown_invoice_tlvs = 49;
 	optional string warning_missing_invoice_paths = 50;
 	optional string warning_missing_invoice_blindedpay = 51;
 	optional string warning_missing_invoice_created_at = 52;
@@ -1679,50 +1749,21 @@ message DecodeResponse {
 	optional DecodeInvreqBip353Name invreq_bip_353_name = 87;
 	optional string warning_invreq_bip_353_name_name_invalid = 88;
 	optional string warning_invreq_bip_353_name_domain_invalid = 89;
+	optional bool invreq_recurrence_cancel = 90;
+	optional string warning_invreq_recurrence_cancel_without_counter = 91;
+	optional string warning_invreq_recurrence_cancel_with_zero_counter = 92;
+	optional bytes proof_preimage = 93;
+	repeated uint64 proof_omitted_tlvs = 94;
+	repeated bytes proof_missing_hashes = 95;
+	repeated bytes proof_leaf_hashes = 96;
+	optional string proof_note = 97;
+	optional string proof_signature = 98;
+	repeated DecodeUnknownPayerProofTlvs unknown_payer_proof_tlvs = 99;
 }
 
-message DecodeOfferPaths {
-	optional bytes first_node_id = 1;
-	optional bytes blinding = 2;
-	optional uint32 first_scid_dir = 4;
-	optional string first_scid = 5;
-	optional bytes first_path_key = 6;
-}
-
-message DecodeOfferRecurrencePaywindow {
-	uint32 seconds_before = 1;
-	uint32 seconds_after = 2;
-	optional bool proportional_amount = 3;
-}
-
-message DecodeInvreqPaths {
-	optional uint32 first_scid_dir = 1;
-	optional bytes blinding = 2;
-	optional bytes first_node_id = 3;
-	optional string first_scid = 4;
-	repeated DecodeInvreqPathsPath path = 5;
-	optional bytes first_path_key = 6;
-}
-
-message DecodeInvreqPathsPath {
-	bytes blinded_node_id = 1;
-	bytes encrypted_recipient_data = 2;
-}
-
-message DecodeInvreqBip353Name {
-	optional string name = 1;
-	optional string domain = 2;
-}
-
-message DecodeInvoicePathsPath {
-	bytes blinded_node_id = 1;
-	bytes encrypted_recipient_data = 2;
-}
-
-message DecodeInvoiceFallbacks {
-	uint32 version = 1;
-	bytes hex = 2;
-	optional string address = 3;
+message DecodeExtra {
+	string tag = 1;
+	string data = 2;
 }
 
 message DecodeFallbacks {
@@ -1734,20 +1775,114 @@ message DecodeFallbacks {
 		P2WSH = 3;
 		P2TR = 4;
 	}
-	optional string warning_invoice_fallbacks_version_invalid = 1;
 	DecodeFallbacksType item_type = 2;
 	optional string addr = 3;
 	bytes hex = 4;
 }
 
-message DecodeExtra {
-	string tag = 1;
-	string data = 2;
+message DecodeInvoiceFallbacks {
+	uint32 version = 1;
+	bytes hex = 2;
+	optional string address = 3;
+}
+
+message DecodeInvoicePaths {
+	repeated DecodeInvoicePathsPath path = 1;
+	DecodeInvoicePathsPayinfo payinfo = 2;
+	optional bytes first_node_id = 3;
+	optional bytes first_path_key = 4;
+	optional uint32 first_scid_dir = 5;
+	optional string first_scid = 6;
+}
+
+message DecodeInvoicePathsPath {
+	bytes blinded_node_id = 1;
+	bytes encrypted_recipient_data = 2;
+}
+
+message DecodeInvoicePathsPayinfo {
+	optional Amount htlc_minimum_msat = 1;
+	bytes features = 2;
+	Amount fee_base_msat = 3;
+	uint32 fee_proportional_millionths = 4;
+	optional Amount htlc_maximum_msat = 5;
+	uint32 cltv_expiry_delta = 6;
+}
+
+message DecodeInvreqBip353Name {
+	optional string name = 1;
+	optional string domain = 2;
+}
+
+message DecodeInvreqPaths {
+	optional uint32 first_scid_dir = 1;
+	optional bytes first_node_id = 3;
+	optional string first_scid = 4;
+	repeated DecodeInvreqPathsPath path = 5;
+	optional bytes first_path_key = 6;
+}
+
+message DecodeInvreqPathsPath {
+	bytes blinded_node_id = 1;
+	bytes encrypted_recipient_data = 2;
+}
+
+message DecodeOfferPaths {
+	optional bytes first_node_id = 1;
+	repeated DecodeOfferPathsPath path = 3;
+	optional uint32 first_scid_dir = 4;
+	optional string first_scid = 5;
+	optional bytes first_path_key = 6;
+}
+
+message DecodeOfferPathsPath {
+	bytes blinded_node_id = 1;
+	bytes encrypted_recipient_data = 2;
+}
+
+message DecodeOfferRecurrence {
+	uint32 time_unit = 1;
+	optional bool compulsory_field = 2;
+	optional string time_unit_name = 3;
+	uint32 period = 4;
+	optional uint64 basetime = 5;
+	optional DecodeOfferRecurrencePaywindow paywindow = 6;
+	optional uint32 limit = 7;
+}
+
+message DecodeOfferRecurrencePaywindow {
+	uint32 seconds_before = 1;
+	uint32 seconds_after = 2;
+	optional bool proportional_amount = 3;
 }
 
 message DecodeRestrictions {
 	repeated string alternatives = 1;
 	string summary = 2;
+}
+
+message DecodeUnknownInvoiceRequestTlvs {
+	uint64 item_type = 1;
+	uint64 length = 2;
+	bytes value = 3;
+}
+
+message DecodeUnknownInvoiceTlvs {
+	uint64 item_type = 1;
+	uint64 length = 2;
+	bytes value = 3;
+}
+
+message DecodeUnknownOfferTlvs {
+	uint64 item_type = 1;
+	uint64 length = 2;
+	bytes value = 3;
+}
+
+message DecodeUnknownPayerProofTlvs {
+	uint64 item_type = 1;
+	uint64 length = 2;
+	bytes value = 3;
 }
 
 message DelpayRequest {
@@ -1773,7 +1908,7 @@ message DelpayPayments {
 		FAILED = 1;
 		COMPLETE = 2;
 	}
-	optional uint64 created_index = 1;
+	uint64 created_index = 1;
 	uint64 id = 2;
 	bytes payment_hash = 3;
 	DelpayPaymentsStatus status = 4;
@@ -1819,6 +1954,7 @@ message DisableofferResponse {
 	bool used = 5;
 	optional string label = 6;
 	optional string description = 7;
+	optional bool force_paths = 8;
 }
 
 message EnableofferRequest {
@@ -1833,6 +1969,7 @@ message EnableofferResponse {
 	bool used = 5;
 	optional string label = 6;
 	optional string description = 7;
+	optional bool force_paths = 8;
 }
 
 message DisconnectRequest {
@@ -1859,18 +1996,26 @@ message FeeratesResponse {
 	optional FeeratesOnchainFeeEstimates onchain_fee_estimates = 4;
 }
 
+message FeeratesOnchainFeeEstimates {
+	uint64 opening_channel_satoshis = 1;
+	uint64 mutual_close_satoshis = 2;
+	uint64 unilateral_close_satoshis = 3;
+	uint64 htlc_timeout_satoshis = 4;
+	uint64 htlc_success_satoshis = 5;
+	optional uint64 unilateral_close_nonanchor_satoshis = 6;
+}
+
 message FeeratesPerkb {
 	uint32 min_acceptable = 1;
 	uint32 max_acceptable = 2;
 	optional uint32 opening = 3;
 	optional uint32 mutual_close = 4;
 	optional uint32 unilateral_close = 5;
-	optional uint32 delayed_to_us = 6;
-	optional uint32 htlc_resolution = 7;
 	optional uint32 penalty = 8;
 	repeated FeeratesPerkbEstimates estimates = 9;
-	optional uint32 floor = 10;
+	uint32 floor = 10;
 	optional uint32 unilateral_anchor_close = 11;
+	optional uint32 splice = 12;
 }
 
 message FeeratesPerkbEstimates {
@@ -1885,27 +2030,17 @@ message FeeratesPerkw {
 	optional uint32 opening = 3;
 	optional uint32 mutual_close = 4;
 	optional uint32 unilateral_close = 5;
-	optional uint32 delayed_to_us = 6;
-	optional uint32 htlc_resolution = 7;
 	optional uint32 penalty = 8;
 	repeated FeeratesPerkwEstimates estimates = 9;
-	optional uint32 floor = 10;
+	uint32 floor = 10;
 	optional uint32 unilateral_anchor_close = 11;
+	optional uint32 splice = 12;
 }
 
 message FeeratesPerkwEstimates {
 	uint32 blockcount = 1;
 	uint32 feerate = 2;
 	uint32 smoothed_feerate = 3;
-}
-
-message FeeratesOnchainFeeEstimates {
-	uint64 opening_channel_satoshis = 1;
-	uint64 mutual_close_satoshis = 2;
-	uint64 unilateral_close_satoshis = 3;
-	uint64 htlc_timeout_satoshis = 4;
-	uint64 htlc_success_satoshis = 5;
-	optional uint64 unilateral_close_nonanchor_satoshis = 6;
 }
 
 message Fetchbip353Request {
@@ -2015,7 +2150,7 @@ message FundchannelResponse {
 	bytes channel_id = 4;
 	optional bytes close_to = 5;
 	optional uint32 mindepth = 6;
-	optional FundchannelChannelType channel_type = 7;
+	FundchannelChannelType channel_type = 7;
 }
 
 message FundchannelChannelType {
@@ -2142,31 +2277,31 @@ message FunderupdateResponse {
 }
 
 message GetrouteRequest {
-	bytes id = 1;
-	uint64 riskfactor = 3;
-	optional uint32 cltv = 4;
-	optional bytes fromid = 5;
-	optional uint32 fuzzpercent = 6;
-	repeated string exclude = 7;
-	optional uint32 maxhops = 8;
-	Amount amount_msat = 9;
+	bytes id = 1 [deprecated = true];
+	uint64 riskfactor = 3 [deprecated = true];
+	optional uint32 cltv = 4 [deprecated = true];
+	optional bytes fromid = 5 [deprecated = true];
+	optional uint32 fuzzpercent = 6 [deprecated = true];
+	repeated string exclude = 7 [deprecated = true];
+	optional uint32 maxhops = 8 [deprecated = true];
+	Amount amount_msat = 9 [deprecated = true];
 }
 
 message GetrouteResponse {
-	repeated GetrouteRoute route = 1;
+	repeated GetrouteRoute route = 1 [deprecated = true];
 }
 
 message GetrouteRoute {
 	// GetRoute.route[].style
 	enum GetrouteRouteStyle {
-		TLV = 0;
+		TLV = 0 [deprecated = true];
 	}
-	bytes id = 1;
-	string channel = 2;
-	uint32 direction = 3;
-	Amount amount_msat = 4;
-	uint32 delay = 5;
-	GetrouteRouteStyle style = 6;
+	bytes id = 1 [deprecated = true];
+	string channel = 2 [deprecated = true];
+	uint32 direction = 3 [deprecated = true];
+	Amount amount_msat = 4 [deprecated = true];
+	uint32 delay = 5 [deprecated = true];
+	GetrouteRouteStyle style = 6 [deprecated = true];
 }
 
 message ListaddressesRequest {
@@ -2186,17 +2321,17 @@ message ListaddressesAddresses {
 }
 
 message ListforwardsRequest {
+	// ListForwards.index
+	enum ListforwardsIndex {
+		CREATED = 0;
+		UPDATED = 1;
+	}
 	// ListForwards.status
 	enum ListforwardsStatus {
 		OFFERED = 0;
 		SETTLED = 1;
 		LOCAL_FAILED = 2;
 		FAILED = 3;
-	}
-	// ListForwards.index
-	enum ListforwardsIndex {
-		CREATED = 0;
-		UPDATED = 1;
 	}
 	optional ListforwardsStatus status = 1;
 	optional string in_channel = 2;
@@ -2233,7 +2368,7 @@ message ListforwardsForwards {
 	optional ListforwardsForwardsStyle style = 9;
 	optional uint64 in_htlc_id = 10;
 	optional uint64 out_htlc_id = 11;
-	optional uint64 created_index = 12;
+	uint64 created_index = 12;
 	optional uint64 updated_index = 13;
 	optional double resolved_time = 14;
 	optional uint32 failcode = 15;
@@ -2257,19 +2392,20 @@ message ListoffersOffers {
 	bool used = 5;
 	optional string label = 6;
 	optional string description = 7;
+	optional bool force_paths = 8;
 }
 
 message ListpaysRequest {
+	// ListPays.index
+	enum ListpaysIndex {
+		CREATED = 0;
+		UPDATED = 1;
+	}
 	// ListPays.status
 	enum ListpaysStatus {
 		PENDING = 0;
 		COMPLETE = 1;
 		FAILED = 2;
-	}
-	// ListPays.index
-	enum ListpaysIndex {
-		CREATED = 0;
-		UPDATED = 1;
 	}
 	optional string bolt11 = 1;
 	optional bytes payment_hash = 2;
@@ -2373,7 +2509,7 @@ message MultifundchannelChannelIds {
 	bytes id = 1;
 	uint32 outnum = 2;
 	bytes channel_id = 3;
-	optional MultifundchannelChannelIdsChannelType channel_type = 4;
+	MultifundchannelChannelIdsChannelType channel_type = 4;
 	optional bytes close_to = 5;
 }
 
@@ -2426,6 +2562,7 @@ message OfferRequest {
 	optional bool single_use = 11;
 	optional bool proportional_amount = 13;
 	optional bool optional_recurrence = 14;
+	repeated bytes fronting_nodes = 15;
 }
 
 message OfferResponse {
@@ -2436,6 +2573,7 @@ message OfferResponse {
 	bool used = 5;
 	bool created = 6;
 	optional string label = 7;
+	optional bool force_paths = 8;
 }
 
 message OpenchannelAbortRequest {
@@ -2457,7 +2595,7 @@ message OpenchannelBumpRequest {
 
 message OpenchannelBumpResponse {
 	bytes channel_id = 1;
-	optional OpenchannelBumpChannelType channel_type = 2;
+	OpenchannelBumpChannelType channel_type = 2;
 	string psbt = 3;
 	bool commitments_secured = 4;
 	uint64 funding_serial = 5;
@@ -2485,7 +2623,7 @@ message OpenchannelInitRequest {
 message OpenchannelInitResponse {
 	bytes channel_id = 1;
 	string psbt = 2;
-	optional OpenchannelInitChannelType channel_type = 3;
+	OpenchannelInitChannelType channel_type = 3;
 	bool commitments_secured = 4;
 	uint64 funding_serial = 5;
 	optional bool requires_confirmed_inputs = 6;
@@ -2514,7 +2652,7 @@ message OpenchannelUpdateRequest {
 
 message OpenchannelUpdateResponse {
 	bytes channel_id = 1;
-	optional OpenchannelUpdateChannelType channel_type = 2;
+	OpenchannelUpdateChannelType channel_type = 2;
 	string psbt = 3;
 	bool commitments_secured = 4;
 	uint32 funding_outnum = 5;
@@ -2557,63 +2695,63 @@ message PluginPlugins {
 }
 
 message RenepaystatusRequest {
-	optional string invstring = 1;
+	optional string invstring = 1 [deprecated = true];
 }
 
 message RenepaystatusResponse {
-	repeated RenepaystatusPaystatus paystatus = 1;
+	repeated RenepaystatusPaystatus paystatus = 1 [deprecated = true];
 }
 
 message RenepaystatusPaystatus {
 	// RenePayStatus.paystatus[].status
 	enum RenepaystatusPaystatusStatus {
-		COMPLETE = 0;
-		PENDING = 1;
-		FAILED = 2;
+		COMPLETE = 0 [deprecated = true];
+		PENDING = 1 [deprecated = true];
+		FAILED = 2 [deprecated = true];
 	}
-	string bolt11 = 1;
-	optional bytes payment_preimage = 2;
-	bytes payment_hash = 3;
-	double created_at = 4;
-	uint32 groupid = 5;
-	optional uint32 parts = 6;
-	Amount amount_msat = 7;
-	optional Amount amount_sent_msat = 8;
-	RenepaystatusPaystatusStatus status = 9;
-	optional bytes destination = 10;
-	repeated string notes = 11;
+	string bolt11 = 1 [deprecated = true];
+	optional bytes payment_preimage = 2 [deprecated = true];
+	bytes payment_hash = 3 [deprecated = true];
+	double created_at = 4 [deprecated = true];
+	uint32 groupid = 5 [deprecated = true];
+	optional uint32 parts = 6 [deprecated = true];
+	Amount amount_msat = 7 [deprecated = true];
+	optional Amount amount_sent_msat = 8 [deprecated = true];
+	RenepaystatusPaystatusStatus status = 9 [deprecated = true];
+	optional bytes destination = 10 [deprecated = true];
+	repeated string notes = 11 [deprecated = true];
 }
 
 message RenepayRequest {
-	string invstring = 1;
-	optional Amount amount_msat = 2;
-	optional Amount maxfee = 3;
-	optional uint32 maxdelay = 4;
-	optional uint32 retry_for = 5;
-	optional string description = 6;
-	optional string label = 7;
-	optional bool dev_use_shadow = 8;
-	repeated string exclude = 9;
+	string invstring = 1 [deprecated = true];
+	optional Amount amount_msat = 2 [deprecated = true];
+	optional Amount maxfee = 3 [deprecated = true];
+	optional uint32 maxdelay = 4 [deprecated = true];
+	optional uint32 retry_for = 5 [deprecated = true];
+	optional string description = 6 [deprecated = true];
+	optional string label = 7 [deprecated = true];
+	optional bool dev_use_shadow = 8 [deprecated = true];
+	repeated string exclude = 9 [deprecated = true];
 }
 
 message RenepayResponse {
 	// RenePay.status
 	enum RenepayStatus {
-		COMPLETE = 0;
-		PENDING = 1;
-		FAILED = 2;
+		COMPLETE = 0 [deprecated = true];
+		PENDING = 1 [deprecated = true];
+		FAILED = 2 [deprecated = true];
 	}
-	bytes payment_preimage = 1;
-	bytes payment_hash = 2;
-	double created_at = 3;
-	uint32 parts = 4;
-	Amount amount_msat = 5;
-	Amount amount_sent_msat = 6;
-	RenepayStatus status = 7;
-	optional bytes destination = 8;
-	optional string bolt11 = 9;
-	optional string bolt12 = 10;
-	optional uint64 groupid = 11;
+	bytes payment_preimage = 1 [deprecated = true];
+	bytes payment_hash = 2 [deprecated = true];
+	double created_at = 3 [deprecated = true];
+	uint32 parts = 4 [deprecated = true];
+	Amount amount_msat = 5 [deprecated = true];
+	Amount amount_sent_msat = 6 [deprecated = true];
+	RenepayStatus status = 7 [deprecated = true];
+	optional bytes destination = 8 [deprecated = true];
+	optional string bolt11 = 9 [deprecated = true];
+	optional string bolt12 = 10 [deprecated = true];
+	optional uint64 groupid = 11 [deprecated = true];
 }
 
 message ReserveinputsRequest {
@@ -2665,7 +2803,7 @@ message SendinvoiceResponse {
 	uint64 expires_at = 5;
 	optional Amount amount_msat = 6;
 	optional string bolt12 = 7;
-	optional uint64 created_index = 8;
+	uint64 created_index = 8;
 	optional uint64 updated_index = 9;
 	optional uint64 pay_index = 10;
 	optional Amount amount_received_msat = 11;
@@ -2697,7 +2835,7 @@ message SetchannelChannels {
 	optional string warning_htlcmin_too_low = 7;
 	Amount maximum_htlc_out_msat = 8;
 	optional string warning_htlcmax_too_high = 9;
-	optional bool ignore_fee_limits = 10;
+	bool ignore_fee_limits = 10;
 }
 
 message SetconfigRequest {
@@ -2712,7 +2850,7 @@ message SetconfigResponse {
 
 message SetconfigConfig {
 	string config = 1;
-	string source = 2;
+	optional string source = 2;
 	optional string plugin = 3;
 	bool dynamic = 4;
 	optional bool set = 5;
@@ -2720,6 +2858,8 @@ message SetconfigConfig {
 	optional Amount value_msat = 7;
 	optional sint64 value_int = 8;
 	optional bool value_bool = 9;
+	repeated string sources = 10;
+	repeated string values_str = 11;
 }
 
 message SetpsbtversionRequest {
@@ -2785,6 +2925,30 @@ message SpliceUpdateResponse {
 	optional bool signatures_secured = 3;
 }
 
+message SpliceinRequest {
+	string channel = 1;
+	string amount = 2;
+}
+
+message SpliceinResponse {
+	optional string psbt = 1;
+	optional string tx = 2;
+	optional string txid = 3;
+}
+
+message SpliceoutRequest {
+	string channel = 1;
+	string amount = 2;
+	optional string destination = 3;
+	optional bool force_feerate = 4;
+}
+
+message SpliceoutResponse {
+	optional string psbt = 1;
+	optional string tx = 2;
+	optional string txid = 3;
+}
+
 message DevspliceRequest {
 	string script_or_json = 1;
 	optional bool dryrun = 2;
@@ -2824,7 +2988,7 @@ message UpgradewalletRequest {
 }
 
 message UpgradewalletResponse {
-	optional uint64 upgraded_outs = 1;
+	uint64 upgraded_outs = 1;
 	optional string psbt = 2;
 	optional bytes tx = 3;
 	optional bytes txid = 4;
@@ -2840,6 +3004,12 @@ message WaitblockheightResponse {
 }
 
 message WaitRequest {
+	// Wait.indexname
+	enum WaitIndexname {
+		CREATED = 0;
+		UPDATED = 1;
+		DELETED = 2;
+	}
 	// Wait.subsystem
 	enum WaitSubsystem {
 		INVOICES = 0;
@@ -2849,12 +3019,6 @@ message WaitRequest {
 		CHAINMOVES = 4;
 		CHANNELMOVES = 5;
 		NETWORKEVENTS = 6;
-	}
-	// Wait.indexname
-	enum WaitIndexname {
-		CREATED = 0;
-		UPDATED = 1;
-		DELETED = 2;
 	}
 	WaitSubsystem subsystem = 1;
 	WaitIndexname indexname = 2;
@@ -2876,7 +3040,7 @@ message WaitResponse {
 	optional uint64 created = 2;
 	optional uint64 updated = 3;
 	optional uint64 deleted = 4;
-	optional WaitDetails details = 5;
+	optional WaitDetails details = 5 [deprecated = true];
 	optional WaitForwards forwards = 6;
 	optional WaitInvoices invoices = 7;
 	optional WaitSendpays sendpays = 8;
@@ -2884,6 +3048,45 @@ message WaitResponse {
 	optional WaitChainmoves chainmoves = 10;
 	optional WaitChannelmoves channelmoves = 11;
 	optional WaitNetworkevents networkevents = 12;
+}
+
+message WaitChainmoves {
+	string account = 1;
+	Amount credit_msat = 2;
+	Amount debit_msat = 3;
+}
+
+message WaitChannelmoves {
+	string account = 1;
+	Amount credit_msat = 2;
+	Amount debit_msat = 3;
+}
+
+message WaitDetails {
+	// Wait.details.status
+	enum WaitDetailsStatus {
+		UNPAID = 0 [deprecated = true];
+		PAID = 1 [deprecated = true];
+		EXPIRED = 2 [deprecated = true];
+		PENDING = 3 [deprecated = true];
+		FAILED = 4 [deprecated = true];
+		COMPLETE = 5 [deprecated = true];
+		OFFERED = 6 [deprecated = true];
+		SETTLED = 7 [deprecated = true];
+		LOCAL_FAILED = 8 [deprecated = true];
+	}
+	optional WaitDetailsStatus status = 1 [deprecated = true];
+	optional string label = 2 [deprecated = true];
+	optional string description = 3 [deprecated = true];
+	optional string bolt11 = 4 [deprecated = true];
+	optional string bolt12 = 5 [deprecated = true];
+	optional uint64 partid = 6 [deprecated = true];
+	optional uint64 groupid = 7 [deprecated = true];
+	optional bytes payment_hash = 8 [deprecated = true];
+	optional string in_channel = 9 [deprecated = true];
+	optional uint64 in_htlc_id = 10 [deprecated = true];
+	optional Amount in_msat = 11 [deprecated = true];
+	optional string out_channel = 12 [deprecated = true];
 }
 
 message WaitForwards {
@@ -2901,33 +3104,6 @@ message WaitForwards {
 	optional string out_channel = 5;
 }
 
-message WaitInvoices {
-	// Wait.invoices.status
-	enum WaitInvoicesStatus {
-		UNPAID = 0;
-		PAID = 1;
-		EXPIRED = 2;
-	}
-	optional WaitInvoicesStatus status = 1;
-	optional string label = 2;
-	optional string description = 3;
-	optional string bolt11 = 4;
-	optional string bolt12 = 5;
-}
-
-message WaitSendpays {
-	// Wait.sendpays.status
-	enum WaitSendpaysStatus {
-		PENDING = 0;
-		FAILED = 1;
-		COMPLETE = 2;
-	}
-	optional WaitSendpaysStatus status = 1;
-	optional uint64 partid = 2;
-	optional uint64 groupid = 3;
-	optional bytes payment_hash = 4;
-}
-
 message WaitHtlcs {
 	// Wait.htlcs.direction
 	enum WaitHtlcsDirection {
@@ -2943,16 +3119,18 @@ message WaitHtlcs {
 	optional bytes payment_hash = 7;
 }
 
-message WaitChainmoves {
-	string account = 1;
-	Amount credit_msat = 2;
-	Amount debit_msat = 3;
-}
-
-message WaitChannelmoves {
-	string account = 1;
-	Amount credit_msat = 2;
-	Amount debit_msat = 3;
+message WaitInvoices {
+	// Wait.invoices.status
+	enum WaitInvoicesStatus {
+		UNPAID = 0;
+		PAID = 1;
+		EXPIRED = 2;
+	}
+	optional WaitInvoicesStatus status = 1;
+	optional string label = 2;
+	optional string description = 3;
+	optional string bolt11 = 4;
+	optional string bolt12 = 5;
 }
 
 message WaitNetworkevents {
@@ -2968,31 +3146,17 @@ message WaitNetworkevents {
 	optional bytes peer_id = 3;
 }
 
-message WaitDetails {
-	// Wait.details.status
-	enum WaitDetailsStatus {
-		UNPAID = 0;
-		PAID = 1;
-		EXPIRED = 2;
-		PENDING = 3;
-		FAILED = 4;
-		COMPLETE = 5;
-		OFFERED = 6;
-		SETTLED = 7;
-		LOCAL_FAILED = 8;
+message WaitSendpays {
+	// Wait.sendpays.status
+	enum WaitSendpaysStatus {
+		PENDING = 0;
+		FAILED = 1;
+		COMPLETE = 2;
 	}
-	optional WaitDetailsStatus status = 1;
-	optional string label = 2;
-	optional string description = 3;
-	optional string bolt11 = 4;
-	optional string bolt12 = 5;
-	optional uint64 partid = 6;
-	optional uint64 groupid = 7;
-	optional bytes payment_hash = 8;
-	optional string in_channel = 9;
-	optional uint64 in_htlc_id = 10;
-	optional Amount in_msat = 11;
-	optional string out_channel = 12;
+	optional WaitSendpaysStatus status = 1;
+	optional uint64 partid = 2;
+	optional uint64 groupid = 3;
+	optional bytes payment_hash = 4;
 }
 
 message ListconfigsRequest {
@@ -3025,9 +3189,7 @@ message ListconfigsConfigs {
 	optional ListconfigsConfigsWallet wallet = 19;
 	optional ListconfigsConfigsLargechannels large_channels = 20;
 	optional ListconfigsConfigsExperimentaldualfund experimental_dual_fund = 21;
-	optional ListconfigsConfigsExperimentalsplicing experimental_splicing = 22;
-	optional ListconfigsConfigsExperimentalonionmessages experimental_onion_messages = 23;
-	optional ListconfigsConfigsExperimentaloffers experimental_offers = 24;
+	optional ListconfigsConfigsExperimentalsplicing experimental_splicing = 22 [deprecated = true];
 	optional ListconfigsConfigsExperimentalshutdownwrongfunding experimental_shutdown_wrong_funding = 25;
 	optional ListconfigsConfigsExperimentalpeerstorage experimental_peer_storage = 26;
 	optional ListconfigsConfigsExperimentalanchors experimental_anchors = 27;
@@ -3037,7 +3199,6 @@ message ListconfigsConfigs {
 	optional ListconfigsConfigsPidfile pid_file = 31;
 	optional ListconfigsConfigsIgnorefeelimits ignore_fee_limits = 32;
 	optional ListconfigsConfigsWatchtimeblocks watchtime_blocks = 33;
-	optional ListconfigsConfigsMaxlocktimeblocks max_locktime_blocks = 34;
 	optional ListconfigsConfigsFundingconfirms funding_confirms = 35;
 	optional ListconfigsConfigsCltvdelta cltv_delta = 36;
 	optional ListconfigsConfigsCltvfinal cltv_final = 37;
@@ -3074,74 +3235,16 @@ message ListconfigsConfigs {
 	optional ListconfigsConfigsCommitfee commit_fee = 69;
 	optional ListconfigsConfigsCommitfeerateoffset commit_feerate_offset = 70;
 	optional ListconfigsConfigsAutoconnectseekerpeers autoconnect_seeker_peers = 71;
+	optional ListconfigsConfigsCurrencyrateaddsource currencyrate_add_source = 74;
+	optional ListconfigsConfigsCurrencyratedisablesource currencyrate_disable_source = 75;
 }
 
-message ListconfigsConfigsConf {
-	// ListConfigs.configs.conf.source
-	enum ListconfigsConfigsConfSource {
-		CMDLINE = 0;
-	}
-	string value_str = 1;
-	ListconfigsConfigsConfSource source = 2;
-}
-
-message ListconfigsConfigsDeveloper {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsClearplugins {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsDisablempp {
-	bool set = 1;
-	string source = 2;
-	optional string plugin = 3;
-}
-
-message ListconfigsConfigsMainnet {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsRegtest {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsSignet {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsTestnet {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsImportantplugin {
+message ListconfigsConfigsAddr {
 	repeated string values_str = 1;
 	repeated string sources = 2;
 }
 
-message ListconfigsConfigsPlugin {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
-message ListconfigsConfigsPlugindir {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
-message ListconfigsConfigsLightningdir {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsNetwork {
+message ListconfigsConfigsAlias {
 	string value_str = 1;
 	string source = 2;
 }
@@ -3151,200 +3254,14 @@ message ListconfigsConfigsAllowdeprecatedapis {
 	string source = 2;
 }
 
-message ListconfigsConfigsRpcfile {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsDisableplugin {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
 message ListconfigsConfigsAlwaysuseproxy {
 	bool value_bool = 1;
 	string source = 2;
 }
 
-message ListconfigsConfigsDaemon {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsWallet {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsLargechannels {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentaldualfund {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentalsplicing {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentalonionmessages {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentaloffers {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentalshutdownwrongfunding {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentalpeerstorage {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsExperimentalanchors {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsDatabaseupgrade {
-	bool value_bool = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsRgb {
-	bytes value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsAlias {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsPidfile {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsIgnorefeelimits {
-	bool value_bool = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsWatchtimeblocks {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsMaxlocktimeblocks {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsFundingconfirms {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsCltvdelta {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsCltvfinal {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsCommittime {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsFeebase {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsRescan {
-	sint64 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsFeepersatoshi {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsMaxconcurrenthtlcs {
-	uint32 value_int = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsHtlcminimummsat {
-	Amount value_msat = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsHtlcmaximummsat {
-	Amount value_msat = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsMaxdusthtlcexposuremsat {
-	Amount value_msat = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsMincapacitysat {
-	uint64 value_int = 1;
-	string source = 2;
-	optional bool dynamic = 3;
-}
-
-message ListconfigsConfigsAddr {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
 message ListconfigsConfigsAnnounceaddr {
 	repeated string values_str = 1;
 	repeated string sources = 2;
-}
-
-message ListconfigsConfigsBindaddr {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
-message ListconfigsConfigsOffline {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsAutolisten {
-	bool value_bool = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsProxy {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsDisabledns {
-	bool set = 1;
-	string source = 2;
 }
 
 message ListconfigsConfigsAnnounceaddrdiscovered {
@@ -3363,64 +3280,38 @@ message ListconfigsConfigsAnnounceaddrdiscoveredport {
 	string source = 2;
 }
 
-message ListconfigsConfigsEncryptedhsm {
-	bool set = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsRpcfilemode {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsLoglevel {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsLogprefix {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsLogfile {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
-message ListconfigsConfigsLogtimestamps {
-	bool value_bool = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsForcefeerates {
-	string value_str = 1;
-	string source = 2;
-}
-
-message ListconfigsConfigsSubdaemon {
-	repeated string values_str = 1;
-	repeated string sources = 2;
-}
-
-message ListconfigsConfigsFetchinvoicenoconnect {
-	bool set = 1;
-	string source = 2;
-	optional string plugin = 3;
-}
-
-message ListconfigsConfigsTorservicepassword {
-	string value_str = 1;
-	string source = 2;
-}
-
 message ListconfigsConfigsAnnounceaddrdns {
 	bool value_bool = 1;
 	string source = 2;
 }
 
-message ListconfigsConfigsRequireconfirmedinputs {
+message ListconfigsConfigsAutoconnectseekerpeers {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsAutolisten {
 	bool value_bool = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsBindaddr {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsClearplugins {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsCltvdelta {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsCltvfinal {
+	uint32 value_int = 1;
 	string source = 2;
 }
 
@@ -3434,7 +3325,276 @@ message ListconfigsConfigsCommitfeerateoffset {
 	string source = 2;
 }
 
-message ListconfigsConfigsAutoconnectseekerpeers {
+message ListconfigsConfigsCommittime {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsConf {
+	// ListConfigs.configs.conf.source
+	enum ListconfigsConfigsConfSource {
+		CMDLINE = 0;
+	}
+	string value_str = 1;
+	ListconfigsConfigsConfSource source = 2;
+}
+
+message ListconfigsConfigsCurrencyrateaddsource {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+	optional string plugin = 3;
+}
+
+message ListconfigsConfigsCurrencyratedisablesource {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+	optional string plugin = 3;
+}
+
+message ListconfigsConfigsDaemon {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsDatabaseupgrade {
+	bool value_bool = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsDeveloper {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsDisabledns {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsDisablempp {
+	bool set = 1;
+	string source = 2;
+	optional string plugin = 3;
+}
+
+message ListconfigsConfigsDisableplugin {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsEncryptedhsm {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsExperimentalanchors {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsExperimentaldualfund {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsExperimentalpeerstorage {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsExperimentalshutdownwrongfunding {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsExperimentalsplicing {
+	bool set = 1 [deprecated = true];
+	string source = 2 [deprecated = true];
+}
+
+message ListconfigsConfigsFeebase {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsFeepersatoshi {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsFetchinvoicenoconnect {
+	bool set = 1;
+	string source = 2;
+	optional string plugin = 3;
+}
+
+message ListconfigsConfigsForcefeerates {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsFundingconfirms {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsHtlcmaximummsat {
+	Amount value_msat = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsHtlcminimummsat {
+	Amount value_msat = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsIgnorefeelimits {
+	bool value_bool = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsImportantplugin {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsLargechannels {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsLightningdir {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsLogfile {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsLoglevel {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsLogprefix {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsLogtimestamps {
+	bool value_bool = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsMainnet {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsMaxconcurrenthtlcs {
+	uint32 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsMaxdusthtlcexposuremsat {
+	Amount value_msat = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsMincapacitysat {
+	uint64 value_int = 1;
+	string source = 2;
+	optional bool dynamic = 3;
+}
+
+message ListconfigsConfigsNetwork {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsOffline {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsPidfile {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsPlugin {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsPlugindir {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsProxy {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsRegtest {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsRequireconfirmedinputs {
+	bool value_bool = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsRescan {
+	sint64 value_int = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsRgb {
+	bytes value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsRpcfile {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsRpcfilemode {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsSignet {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsSubdaemon {
+	repeated string values_str = 1;
+	repeated string sources = 2;
+}
+
+message ListconfigsConfigsTestnet {
+	bool set = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsTorservicepassword {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsWallet {
+	string value_str = 1;
+	string source = 2;
+}
+
+message ListconfigsConfigsWatchtimeblocks {
 	uint32 value_int = 1;
 	string source = 2;
 }
@@ -3447,7 +3607,7 @@ message StopResponse {
 	enum StopResult {
 		SHUTDOWN_COMPLETE = 0;
 	}
-	optional StopResult result = 1;
+	StopResult result = 1;
 }
 
 message HelpRequest {
@@ -3605,6 +3765,7 @@ message BkprlistaccounteventsEvents {
 	optional Amount fees_msat = 14;
 	optional bool is_rebalance = 15;
 	optional uint32 part_id = 16;
+	optional double currencyrate = 17;
 }
 
 message BkprlistbalancesRequest {
@@ -3718,6 +3879,18 @@ message BkpreditdescriptionbyoutpointUpdated {
 	optional uint32 part_id = 16;
 }
 
+message BkprreportRequest {
+	optional string format = 1;
+	repeated string headers = 2;
+	optional string escape = 3;
+	optional uint32 start_time = 4;
+	optional uint32 end_time = 5;
+}
+
+message BkprreportResponse {
+	repeated string report = 1;
+}
+
 message BlacklistruneRequest {
 	optional uint64 start = 1;
 	optional uint64 end = 2;
@@ -3788,6 +3961,7 @@ message ShowrunesRunesRestrictionsAlternatives {
 
 message AskreneunreserveRequest {
 	repeated AskreneunreservePath path = 1;
+	optional bool dev_remove_all = 2;
 }
 
 message AskreneunreserveResponse {
@@ -3795,7 +3969,7 @@ message AskreneunreserveResponse {
 
 message AskreneunreservePath {
 	Amount amount_msat = 3;
-	optional string short_channel_id_dir = 4;
+	string short_channel_id_dir = 4;
 	optional string layer = 5;
 }
 
@@ -3812,18 +3986,18 @@ message AskrenelistlayersLayers {
 	repeated bytes disabled_nodes = 2;
 	repeated AskrenelistlayersLayersCreatedChannels created_channels = 3;
 	repeated AskrenelistlayersLayersConstraints constraints = 4;
-	optional bool persistent = 5;
+	bool persistent = 5;
 	repeated string disabled_channels = 6;
 	repeated AskrenelistlayersLayersChannelUpdates channel_updates = 7;
 	repeated AskrenelistlayersLayersBiases biases = 8;
 	repeated AskrenelistlayersLayersNodeBiases node_biases = 9;
 }
 
-message AskrenelistlayersLayersCreatedChannels {
-	bytes source = 1;
-	bytes destination = 2;
-	string short_channel_id = 3;
-	Amount capacity_msat = 4;
+message AskrenelistlayersLayersBiases {
+	string short_channel_id_dir = 1;
+	sint64 bias = 2;
+	optional string description = 3;
+	optional uint64 timestamp = 4;
 }
 
 message AskrenelistlayersLayersChannelUpdates {
@@ -3839,15 +4013,15 @@ message AskrenelistlayersLayersChannelUpdates {
 message AskrenelistlayersLayersConstraints {
 	optional Amount maximum_msat = 3;
 	optional Amount minimum_msat = 4;
-	optional string short_channel_id_dir = 5;
+	string short_channel_id_dir = 5;
 	optional uint64 timestamp = 6;
 }
 
-message AskrenelistlayersLayersBiases {
-	string short_channel_id_dir = 1;
-	sint64 bias = 2;
-	optional string description = 3;
-	optional uint64 timestamp = 4;
+message AskrenelistlayersLayersCreatedChannels {
+	bytes source = 1;
+	bytes destination = 2;
+	string short_channel_id = 3;
+	Amount capacity_msat = 4;
 }
 
 message AskrenelistlayersLayersNodeBiases {
@@ -3879,11 +4053,11 @@ message AskrenecreatelayerLayers {
 	repeated AskrenecreatelayerLayersNodeBiases node_biases = 9;
 }
 
-message AskrenecreatelayerLayersCreatedChannels {
-	bytes source = 1;
-	bytes destination = 2;
-	string short_channel_id = 3;
-	Amount capacity_msat = 4;
+message AskrenecreatelayerLayersBiases {
+	string short_channel_id_dir = 1;
+	sint64 bias = 2;
+	optional string description = 3;
+	optional uint64 timestamp = 4;
 }
 
 message AskrenecreatelayerLayersChannelUpdates {
@@ -3901,11 +4075,11 @@ message AskrenecreatelayerLayersConstraints {
 	optional Amount minimum_msat = 4;
 }
 
-message AskrenecreatelayerLayersBiases {
-	string short_channel_id_dir = 1;
-	sint64 bias = 2;
-	optional string description = 3;
-	optional uint64 timestamp = 4;
+message AskrenecreatelayerLayersCreatedChannels {
+	bytes source = 1;
+	bytes destination = 2;
+	string short_channel_id = 3;
+	Amount capacity_msat = 4;
 }
 
 message AskrenecreatelayerLayersNodeBiases {
@@ -3923,6 +4097,14 @@ message AskreneremovelayerRequest {
 message AskreneremovelayerResponse {
 }
 
+message AskreneremovechannelupdateRequest {
+	string layer = 1;
+	string short_channel_id_dir = 2;
+}
+
+message AskreneremovechannelupdateResponse {
+}
+
 message AskrenereserveRequest {
 	repeated AskrenereservePath path = 1;
 }
@@ -3932,7 +4114,7 @@ message AskrenereserveResponse {
 
 message AskrenereservePath {
 	Amount amount_msat = 3;
-	optional string short_channel_id_dir = 4;
+	string short_channel_id_dir = 4;
 	optional string layer = 5;
 }
 
@@ -3952,7 +4134,7 @@ message GetroutesRequest {
 	Amount amount_msat = 3;
 	repeated string layers = 4;
 	Amount maxfee_msat = 5;
-	optional uint32 final_cltv = 7;
+	uint32 final_cltv = 7;
 	optional uint32 maxdelay = 8;
 	optional uint32 maxparts = 9;
 }
@@ -3966,14 +4148,20 @@ message GetroutesRoutes {
 	uint64 probability_ppm = 1;
 	Amount amount_msat = 2;
 	repeated GetroutesRoutesPath path = 3;
-	optional uint32 final_cltv = 4;
+	uint32 final_cltv = 4;
 }
 
 message GetroutesRoutesPath {
-	Amount amount_msat = 3;
-	bytes next_node_id = 4;
-	uint32 delay = 5;
-	optional string short_channel_id_dir = 6;
+	optional Amount amount_msat = 3 [deprecated = true];
+	optional bytes next_node_id = 4 [deprecated = true];
+	optional uint32 delay = 5 [deprecated = true];
+	string short_channel_id_dir = 6;
+	optional Amount amount_in_msat = 7;
+	optional Amount amount_out_msat = 8;
+	optional bytes node_id_in = 9;
+	optional bytes node_id_out = 10;
+	optional uint32 cltv_in = 11;
+	optional uint32 cltv_out = 12;
 }
 
 message AskrenedisablenodeRequest {
@@ -3992,9 +4180,9 @@ message AskreneinformchannelRequest {
 		SUCCEEDED = 2;
 	}
 	string layer = 1;
-	optional string short_channel_id_dir = 6;
-	optional Amount amount_msat = 7;
-	optional AskreneinformchannelInform inform = 8;
+	string short_channel_id_dir = 6;
+	Amount amount_msat = 7;
+	AskreneinformchannelInform inform = 8;
 }
 
 message AskreneinformchannelResponse {
@@ -4101,6 +4289,7 @@ message InjectpaymentonionRequest {
 	optional string invstring = 8;
 	optional bytes localinvreqid = 9;
 	optional Amount destination_msat = 10;
+	optional bytes destination = 11;
 }
 
 message InjectpaymentonionResponse {
@@ -4127,6 +4316,9 @@ message XpayRequest {
 	optional Amount partial_msat = 6;
 	optional uint32 maxdelay = 7;
 	optional string payer_note = 8;
+	optional string label = 9;
+	optional bytes localinvreqid = 10;
+	optional bool dev_use_shadow = 11;
 }
 
 message XpayResponse {
@@ -4286,6 +4478,117 @@ message ClnrestregisterpathRuneRestrictions {
 	map<string, string> params = 3;
 }
 
+message ListcurrencyratesRequest {
+	string currency = 1;
+}
+
+message ListcurrencyratesResponse {
+	repeated ListcurrencyratesCurrencyrates currencyrates = 1;
+}
+
+message ListcurrencyratesCurrencyrates {
+	string source = 1;
+	double amount = 2;
+}
+
+message CurrencyconvertRequest {
+	double amount = 1;
+	string currency = 2;
+}
+
+message CurrencyconvertResponse {
+	Amount msat = 1;
+}
+
+message CurrencyrateRequest {
+	string currency = 1;
+	optional string source = 2;
+}
+
+message CurrencyrateResponse {
+	double rate = 1;
+}
+
+message SendamountRequest {
+	string invstring = 1;
+	Amount amount_msat = 2;
+	optional Amount maxfee = 3;
+	repeated string layers = 4;
+	optional uint32 retry_for = 5;
+	optional uint32 maxdelay = 6;
+	optional string payer_note = 7;
+	optional string label = 8;
+}
+
+message SendamountResponse {
+	bytes payment_preimage = 1;
+	uint64 failed_parts = 2;
+	uint64 successful_parts = 3;
+	Amount amount_msat = 4;
+	Amount amount_sent_msat = 5;
+}
+
+message CreateproofRequest {
+	string invstring = 1;
+	optional string note = 2;
+	repeated ProofField include = 3;
+}
+
+message CreateproofResponse {
+	repeated CreateproofProofs proofs = 1;
+}
+
+message CreateproofProofs {
+	string bolt12 = 1;
+	repeated ProofField offer_fields_included = 2;
+	repeated ProofField invreq_fields_included = 3;
+	repeated ProofField invoice_fields_included = 4;
+}
+
+message XkeysendRequest {
+	bytes destination = 1;
+	Amount amount_msat = 2;
+	optional string label = 3;
+	optional Amount maxfee = 4;
+	repeated string layers = 5;
+	optional uint32 retry_for = 6;
+	optional uint32 maxdelay = 7;
+	map<string, string> extratlvs = 8;
+}
+
+message XkeysendResponse {
+	bytes payment_preimage = 1;
+	uint64 failed_parts = 2;
+	uint64 successful_parts = 3;
+	Amount amount_msat = 4;
+	Amount amount_sent_msat = 5;
+}
+
+message GracefulRequest {
+	optional uint32 timeout = 1;
+}
+
+message GracefulResponse {
+	repeated uint32 pending_htlc_expiries = 1;
+	repeated bytes pending_peers = 2;
+}
+
+message StreamBalanceSnapshotRequest {
+}
+
+message BalanceSnapshotNotification {
+	bytes node_id = 1;
+	uint32 blockheight = 2;
+	uint32 timestamp = 3;
+	repeated BalanceSnapshotAccounts accounts = 4;
+}
+
+message BalanceSnapshotAccounts {
+	string account_id = 1;
+	Amount balance_msat = 2;
+	string coin_type = 3;
+}
+
 message StreamBlockAddedRequest {
 }
 
@@ -4309,6 +4612,29 @@ message ChannelOpenedNotification {
 	Amount funding_msat = 2;
 	bytes funding_txid = 3;
 	bool channel_ready = 4;
+}
+
+message StreamChannelStateChangedRequest {
+}
+
+message ChannelStateChangedNotification {
+	// channel_state_changed.cause
+	enum ChannelStateChangedCause {
+		UNKNOWN = 0;
+		LOCAL = 1;
+		USER = 2;
+		REMOTE = 3;
+		PROTOCOL = 4;
+		ONCHAIN = 5;
+	}
+	bytes peer_id = 1;
+	bytes channel_id = 2;
+	optional string short_channel_id = 3;
+	string timestamp = 4;
+	optional ChannelState old_state = 5;
+	ChannelState new_state = 6;
+	ChannelStateChangedCause cause = 7;
+	optional string message = 8;
 }
 
 message StreamConnectRequest {
@@ -4341,6 +4667,69 @@ message PeerConnectAddress {
 	optional uint32 port = 4;
 }
 
+message StreamCoinMovementRequest {
+}
+
+message CoinMovementNotification {
+	// coin_movement.primary_tag
+	enum CoinMovementPrimaryTag {
+		DEPOSIT = 0;
+		WITHDRAWAL = 1;
+		PENALTY = 2;
+		CHANNEL_OPEN = 3;
+		CHANNEL_CLOSE = 4;
+		DELAYED_TO_US = 5;
+		HTLC_TX = 6;
+		HTLC_TIMEOUT = 7;
+		HTLC_FULFILL = 8;
+		TO_WALLET = 9;
+		ANCHOR = 10;
+		TO_THEM = 11;
+		PENALIZED = 12;
+		STOLEN = 13;
+		IGNORED = 14;
+		TO_MINER = 15;
+		INVOICE = 16;
+		ROUTED = 17;
+		PUSHED = 18;
+		LEASE_FEE = 19;
+		CHANNEL_PROPOSED = 20;
+		PENALTY_ADJ = 21;
+		JOURNAL_ENTRY = 22;
+	}
+	// coin_movement.type
+	enum CoinMovementType {
+		CHANNEL_MVT = 0;
+		CHAIN_MVT = 1;
+	}
+	uint32 version = 1;
+	string coin_type = 2;
+	bytes node_id = 3;
+	CoinMovementType item_type = 4;
+	optional uint64 created_index = 5;
+	string account_id = 6;
+	Amount credit_msat = 7;
+	Amount debit_msat = 8;
+	uint64 timestamp = 9;
+	repeated string tags = 10 [deprecated = true];
+	optional CoinMovementPrimaryTag primary_tag = 11;
+	repeated string extra_tags = 12;
+	optional bytes payment_hash = 13;
+	optional uint64 part_id = 14;
+	optional uint64 group_id = 15;
+	optional Amount fees_msat = 16;
+	optional Outpoint utxo = 17;
+	optional bytes peer_id = 18;
+	optional string originating_account = 19;
+	optional bytes txid = 20 [deprecated = true];
+	optional bytes spending_txid = 21;
+	optional bytes utxo_txid = 22 [deprecated = true];
+	optional uint32 vout = 23 [deprecated = true];
+	optional Amount output_msat = 24;
+	optional uint32 output_count = 25;
+	optional uint32 blockheight = 26;
+}
+
 message StreamCustomMsgRequest {
 }
 
@@ -4349,25 +4738,259 @@ message CustomMsgNotification {
 	bytes payload = 2;
 }
 
-message StreamChannelStateChangedRequest {
+message StreamDeprecatedOneshotRequest {
 }
 
-message ChannelStateChangedNotification {
-	// channel_state_changed.cause
-	enum ChannelStateChangedCause {
-		UNKNOWN = 0;
-		LOCAL = 1;
-		USER = 2;
-		REMOTE = 3;
-		PROTOCOL = 4;
-		ONCHAIN = 5;
+message DeprecatedOneshotNotification {
+	bool deprecated_ok = 1;
+}
+
+message StreamDisconnectRequest {
+}
+
+message DisconnectNotification {
+	bytes id = 1;
+}
+
+message StreamForwardEventRequest {
+}
+
+message ForwardEventNotification {
+	// forward_event.status
+	enum ForwardEventStatus {
+		OFFERED = 0;
+		SETTLED = 1;
+		LOCAL_FAILED = 2;
+		FAILED = 3;
 	}
-	bytes peer_id = 1;
-	bytes channel_id = 2;
-	optional string short_channel_id = 3;
-	string timestamp = 4;
-	optional ChannelState old_state = 5;
-	ChannelState new_state = 6;
-	ChannelStateChangedCause cause = 7;
-	optional string message = 8;
+	// forward_event.style
+	enum ForwardEventStyle {
+		LEGACY = 0;
+		TLV = 1;
+	}
+	bytes payment_hash = 1;
+	string in_channel = 2;
+	optional string out_channel = 3;
+	Amount in_msat = 4;
+	optional Amount out_msat = 5;
+	optional Amount fee_msat = 6;
+	ForwardEventStatus status = 7;
+	optional uint32 failcode = 8;
+	optional string failreason = 9;
+	optional ForwardEventStyle style = 10;
+	double received_time = 11;
+	optional double resolved_time = 12;
+}
+
+message StreamInvoiceCreationRequest {
+}
+
+message InvoiceCreationNotification {
+	optional Amount msat = 1;
+	bytes preimage = 2;
+	string label = 3;
+}
+
+message StreamInvoicePaymentRequest {
+}
+
+message InvoicePaymentNotification {
+	Amount msat = 1;
+	bytes preimage = 2;
+	optional Outpoint outpoint = 3;
+	string label = 4;
+}
+
+message StreamLogRequest {
+}
+
+message LogNotification {
+	// log.level
+	enum LogLevel {
+		IO = 0;
+		TRACE = 1;
+		DEBUG = 2;
+		INFO = 3;
+		UNUSUAL = 4;
+		BROKEN = 5;
+	}
+	LogLevel level = 1;
+	string time = 2;
+	string timestamp = 3;
+	string source = 4;
+	string log = 5;
+}
+
+message StreamOnionMessageForwardFailRequest {
+}
+
+message OnionMessageForwardFailNotification {
+	bytes source = 1;
+	bytes incoming = 2;
+	bytes path_key = 3;
+	optional bytes outgoing = 4;
+	optional bytes next_node_id = 5;
+	optional string next_short_channel_id_dir = 6;
+}
+
+message StreamOpenChannelPeerSigsRequest {
+}
+
+message OpenChannelPeerSigsNotification {
+	bytes channel_id = 1;
+	string signed_psbt = 2;
+}
+
+message StreamPluginStartedRequest {
+}
+
+message PluginStartedNotification {
+	string plugin_name = 1;
+	string plugin_path = 2;
+	repeated string methods = 3;
+}
+
+message StreamPluginStoppedRequest {
+}
+
+message PluginStoppedNotification {
+	string plugin_name = 1;
+	string plugin_path = 2;
+	repeated string methods = 3;
+}
+
+message StreamSendPayFailureRequest {
+}
+
+message SendPayFailureNotification {
+	sint64 code = 1;
+	string message = 2;
+	SendpayFailureData data = 3;
+}
+
+message SendpayFailureData {
+	// sendpay_failure.data.status
+	enum SendpayFailureDataStatus {
+		FAILED = 0;
+		PENDING = 1;
+		COMPLETE = 2;
+	}
+	optional uint64 created_index = 1;
+	optional uint64 id = 2;
+	optional bytes payment_hash = 3;
+	optional uint64 groupid = 4;
+	optional uint64 updated_index = 5;
+	optional uint64 partid = 6;
+	optional bytes destination = 7;
+	optional Amount amount_msat = 8;
+	optional Amount amount_sent_msat = 9;
+	optional uint64 created_at = 10;
+	optional uint64 completed_at = 11;
+	optional SendpayFailureDataStatus status = 12;
+	optional bytes payment_preimage = 13;
+	optional string label = 14;
+	optional string bolt11 = 15;
+	optional string bolt12 = 16;
+	optional string description = 17;
+	optional bytes erroronion = 18;
+	optional bytes onionreply = 19;
+	optional uint32 erring_index = 20;
+	optional uint32 failcode = 21;
+	optional string failcodename = 22;
+	optional bytes erring_node = 23;
+	optional string erring_channel = 24;
+	optional uint32 erring_direction = 25;
+	optional bytes raw_message = 26;
+}
+
+message StreamSendPaySuccessRequest {
+}
+
+message SendPaySuccessNotification {
+	// sendpay_success.status
+	enum SendpaySuccessStatus {
+		COMPLETE = 0;
+	}
+	uint64 created_index = 1;
+	uint64 id = 2;
+	bytes payment_hash = 3;
+	uint64 groupid = 4;
+	optional uint64 updated_index = 5;
+	optional uint64 partid = 6;
+	optional bytes destination = 7;
+	optional Amount amount_msat = 8;
+	Amount amount_sent_msat = 9;
+	uint64 created_at = 10;
+	optional uint64 completed_at = 11;
+	SendpaySuccessStatus status = 12;
+	optional bytes payment_preimage = 13;
+	optional string label = 14;
+	optional string bolt11 = 15;
+	optional string bolt12 = 16;
+	optional string description = 17;
+	optional bytes erroronion = 18;
+}
+
+message StreamShutdownRequest {
+}
+
+message ShutdownNotification {
+}
+
+message StreamWarningRequest {
+}
+
+message WarningNotification {
+	// warning.level
+	enum WarningLevel {
+		WARN = 0;
+		ERROR = 1;
+	}
+	WarningLevel level = 1;
+	string time = 2;
+	string timestamp = 3;
+	string source = 4;
+	string log = 5;
+}
+
+message StreamPayPartEndRequest {
+}
+
+message PayPartEndNotification {
+	// pay_part_end.status
+	enum PayPartEndStatus {
+		SUCCESS = 0;
+		FAILURE = 1;
+	}
+	PayPartEndStatus status = 1;
+	double duration = 2;
+	bytes payment_hash = 3;
+	uint64 groupid = 4;
+	uint64 partid = 5;
+	optional bytes failed_msg = 6;
+	optional bytes failed_node_id = 7;
+	optional string failed_short_channel_id = 8;
+	optional uint32 failed_direction = 9;
+	optional uint32 error_code = 10;
+	optional string error_message = 11;
+}
+
+message StreamPayPartStartRequest {
+}
+
+message PayPartStartNotification {
+	bytes payment_hash = 1;
+	uint64 groupid = 2;
+	uint64 partid = 3;
+	Amount total_payment_msat = 4;
+	Amount attempt_msat = 5;
+	repeated PayPartStartHops hops = 6;
+}
+
+message PayPartStartHops {
+	bytes next_node = 1;
+	string short_channel_id = 2;
+	uint32 direction = 3;
+	Amount channel_in_msat = 4;
+	Amount channel_out_msat = 5;
 }

--- a/src/infra/lightning/cln/proto/primitives.proto
+++ b/src/infra/lightning/cln/proto/primitives.proto
@@ -39,6 +39,7 @@ enum ChannelState {
 	ChanneldAwaitingSplice = 11;
 	DualopendOpenCommitted = 12;
 	DualopendOpenCommittReady = 13;
+	Closed = 14;
 }
 
 enum HtlcState {
@@ -145,4 +146,48 @@ enum PluginSubcommand {
 	RESCAN = 2;
 	STARTDIR = 3;
 	LIST = 4;
+}
+
+message JsonObjectOrArray {
+	oneof structure {
+		JsonObject object = 1;
+		JsonArray array  = 2;
+	}
+}
+
+message JsonObject {
+	map<string, JsonValue> fields = 1;
+}
+
+message JsonArray {
+	repeated JsonValue values = 1;
+}
+
+message JsonValue {
+  	oneof kind {
+		bool   bool_value   = 1;
+		int64  int_value    = 2;
+		uint64 uint_value   = 3;
+		double double_value = 4;
+		string string_value = 5;
+		JsonArray  array    = 6;
+		JsonObject object   = 7;
+  }
+}
+
+message JsonScalar {
+	oneof scalar {
+		bool   bool_value   = 1;
+		int64  int_value    = 2;
+		uint64 uint_value   = 3;
+		double double_value = 4;
+		string string_value = 5;
+	}
+}
+
+message ProofField {
+	oneof ident {
+		string name   = 1;
+		uint64 number = 2;
+	}
 }

--- a/src/infra/lightning/lnd/proto/lightning.proto
+++ b/src/infra/lightning/lnd/proto/lightning.proto
@@ -262,47 +262,6 @@ service Lightning {
     */
     rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
 
-    /* lncli: `sendpayment`
-    Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
-    bi-directional streaming RPC for sending payments through the Lightning
-    Network. A single RPC invocation creates a persistent bi-directional
-    stream allowing clients to rapidly send payments through the Lightning
-    Network with a single persistent connection.
-    */
-    rpc SendPayment (stream SendRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use routerrpc.SendPaymentV2. SendPaymentSync is the synchronous
-    non-streaming version of SendPayment. This RPC is intended to be consumed by
-    clients of the REST proxy. Additionally, this RPC expects the destination's
-    public key and the payment hash (if any) to be encoded as hex strings.
-    */
-    rpc SendPaymentSync (SendRequest) returns (SendResponse) {
-        option deprecated = true;
-    }
-
-    /* lncli: `sendtoroute`
-    Deprecated, use routerrpc.SendToRouteV2. SendToRoute is a bi-directional
-    streaming RPC for sending payment through the Lightning Network. This
-    method differs from SendPayment in that it allows users to specify a full
-    route manually. This can be used for things like rebalancing, and atomic
-    swaps.
-    */
-    rpc SendToRoute (stream SendToRouteRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use routerrpc.SendToRouteV2. SendToRouteSync is a synchronous
-    version of SendToRoute. It Will block until the payment either fails or
-    succeeds.
-    */
-    rpc SendToRouteSync (SendToRouteRequest) returns (SendResponse) {
-        option deprecated = true;
-    }
-
     /* lncli: `addinvoice`
     AddInvoice attempts to add a new invoice to the invoice database. Any
     duplicated invoices are rejected, therefore all invoices *must* have a
@@ -607,7 +566,7 @@ service Lightning {
     SubscribeOnionMessages subscribes to a stream of incoming onion messages.
     */
     rpc SubscribeOnionMessages (SubscribeOnionMessagesRequest)
-        returns (stream OnionMessage);
+        returns (stream OnionMessageUpdate);
 
     /* lncli: `listaliases`
     ListAliases returns the set of all aliases that have ever existed with
@@ -676,7 +635,7 @@ message SendCustomMessageResponse {
 message SubscribeOnionMessagesRequest {
 }
 
-message OnionMessage {
+message OnionMessageUpdate {
     // Peer from which this message originates. Represented as a byte-encoded
     // public key.
     bytes peer = 1;
@@ -694,6 +653,20 @@ message OnionMessage {
     // encrypted payloads and routing instructions used to forward this message
     // along its designated path.
     bytes onion = 3;
+
+    // reply_path is the blinded path that should be used when replying to a
+    // received message.
+    BlindedPath reply_path = 4;
+
+    // encrypted_recipient_data is the encrypted data that contains the
+    // forwarding information for an onion message. It contains either
+    // next_node_id or short_channel_id for each non-final node. It MAY contain
+    // the path_id for the final node.
+    bytes encrypted_recipient_data = 5;
+
+    // Custom onion message tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
+    map<uint64, bytes> custom_records = 6;
 }
 
 message SendOnionMessageRequest {
@@ -880,139 +853,6 @@ message FeeLimit {
         // The fee limit expressed as a percentage of the payment amount.
         int64 percent = 2;
     }
-}
-
-message SendRequest {
-    /*
-    The identity pubkey of the payment recipient. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes dest = 1;
-
-    /*
-    The hex-encoded identity pubkey of the payment recipient. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string dest_string = 2 [deprecated = true];
-
-    /*
-    The amount to send expressed in satoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt = 3;
-
-    /*
-    The amount to send expressed in millisatoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt_msat = 12;
-
-    /*
-    The hash to use within the payment's HTLC. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes payment_hash = 4;
-
-    /*
-    The hex-encoded hash to use within the payment's HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 5 [deprecated = true];
-
-    /*
-    A bare-bones invoice for a payment within the Lightning Network. With the
-    details of the invoice, the sender has all the data necessary to send a
-    payment to the recipient.
-    */
-    string payment_request = 6;
-
-    /*
-    The CLTV delta from the current height that should be used to set the
-    timelock for the final hop.
-    */
-    int32 final_cltv_delta = 7;
-
-    /*
-    The maximum number of satoshis that will be paid as a fee of the payment.
-    This value can be represented either as a percentage of the amount being
-    sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment. If not specified, lnd will use a default value of 100%
-    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
-    */
-    FeeLimit fee_limit = 8;
-
-    /*
-    The channel id of the channel that must be taken to the first hop. If zero,
-    any channel may be used.
-    */
-    uint64 outgoing_chan_id = 9 [jstype = JS_STRING];
-
-    /*
-    The pubkey of the last hop of the route. If empty, any hop may be used.
-    */
-    bytes last_hop_pubkey = 13;
-
-    /*
-    An optional maximum total time lock for the route. This should not exceed
-    lnd's `--max-cltv-expiry` setting. If zero, then the value of
-    `--max-cltv-expiry` is enforced.
-    */
-    uint32 cltv_limit = 10;
-
-    /*
-    An optional field that can be used to pass an arbitrary set of TLV records
-    to a peer which understands the new records. This can be used to pass
-    application specific data during the payment attempt. Record types are
-    required to be in the custom range >= 65536. When using REST, the values
-    must be encoded as base64.
-    */
-    map<uint64, bytes> dest_custom_records = 11;
-
-    // If set, circular payments to self are permitted.
-    bool allow_self_payment = 14;
-
-    /*
-    Features assumed to be supported by the final node. All transitive feature
-    dependencies must also be set properly. For a given feature bit pair, either
-    optional or remote may be set, but not both. If this field is nil or empty,
-    the router will try to load destination features from the graph as a
-    fallback.
-    */
-    repeated FeatureBit dest_features = 15;
-
-    /*
-    The payment address of the generated invoice.  This is also called
-    payment secret in specifications (e.g. BOLT 11).
-    */
-    bytes payment_addr = 16;
-}
-
-message SendResponse {
-    string payment_error = 1;
-    bytes payment_preimage = 2;
-    Route payment_route = 3;
-    bytes payment_hash = 4;
-}
-
-message SendToRouteRequest {
-    /*
-    The payment hash to use for the HTLC. When using REST, this field must be
-    encoded as base64.
-    */
-    bytes payment_hash = 1;
-
-    /*
-    An optional hex-encoded payment hash to be used for the HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 2 [deprecated = true];
-
-    reserved 3;
-
-    // Route that should be used to attempt to complete the payment.
-    Route route = 4;
 }
 
 message ChannelAcceptRequest {
@@ -1465,6 +1305,11 @@ message HTLC {
 }
 
 enum CommitmentType {
+    // Allow multiple enum names to map to the same numeric value so the
+    // taproot channel types can expose short, canonical aliases without
+    // breaking on-wire compatibility with the historic names.
+    option allow_alias = true;
+
     /*
     Returned when the commitment type isn't known or unavailable.
     */
@@ -1501,8 +1346,25 @@ enum CommitmentType {
     SCRIPT_ENFORCED_LEASE = 4;
 
     /*
-    A channel that uses musig2 for the funding output, and the new tapscript
-    features where relevant.
+    The production taproot channel type that uses musig2 for the funding
+    output and the new tapscript features, with final scripts and feature
+    bits 80/81. This is the recommended taproot variant; new integrations
+    should select this enum value.
+    */
+    TAPROOT = 7;
+
+    /*
+    Deprecated alias for TAPROOT, preserved so existing clients that select
+    the production taproot channel type by its historic name continue to
+    compile and serialize against the same wire value.
+    */
+    SIMPLE_TAPROOT_FINAL = 7;
+
+    /*
+    A legacy taproot channel type that uses musig2 for the funding output and
+    the new tapscript features, but with development scripts and the staging
+    feature bits. Retained for compatibility with peers that have not upgraded
+    to TAPROOT; new integrations should prefer TAPROOT.
     */
     SIMPLE_TAPROOT = 5;
 
@@ -2044,6 +1906,13 @@ message PeerEvent {
 
 message GetInfoRequest {
 }
+enum GraphCacheStatus {
+    GRAPH_CACHE_STATUS_DISABLED = 0;
+    GRAPH_CACHE_STATUS_LOADING = 1;
+    GRAPH_CACHE_STATUS_LOADED = 2;
+    GRAPH_CACHE_STATUS_FAILED = 3;
+}
+
 message GetInfoResponse {
     // The version of the LND software that the node is running.
     string version = 14;
@@ -2122,9 +1991,15 @@ message GetInfoResponse {
     // Whether the wallet is fully synced to the best chain. This indicates the
     // wallet's internal sync state with the backing chain source.
     bool wallet_synced = 23;
+
+    // The current status of the in-memory graph cache.
+    GraphCacheStatus graph_cache_status = 24;
 }
 
 message GetDebugInfoRequest {
+    // If set to true, the log file content will be included in the response.
+    // By default, only the config information is returned.
+    bool include_log = 1;
 }
 
 message GetDebugInfoResponse {
@@ -2960,6 +2835,24 @@ message PendingChannelsResponse {
         // The raw hex encoded bytes of the closing transaction. Included if
         // include_raw_tx in the request is true.
         string closing_tx_hex = 5;
+
+        /*
+        Remaining number of confirmations until the channel closure is
+        considered final and removed from waiting close. Channel closes
+        require multiple confirmations for reorg protection — the exact
+        number scales with channel capacity. A closing transaction that
+        gets reorganized out of the chain resets this counter. When the
+        closing transaction is not yet confirmed, this value equals the
+        total number of confirmations required.
+        */
+        uint32 blocks_til_close_confirmed = 6;
+
+        /*
+        The block height at which the closing transaction was first confirmed.
+        This will be zero if the closing transaction has not yet confirmed, or
+        if this information is not available for older channels.
+        */
+        uint32 close_height = 7;
     }
 
     message Commitments {
@@ -3064,6 +2957,10 @@ message PendingChannelsResponse {
 message ChannelEventSubscription {
 }
 
+message ChannelCommitUpdate {
+    Channel channel = 1;
+}
+
 message ChannelEventUpdate {
     oneof channel {
         Channel open_channel = 1;
@@ -3073,6 +2970,7 @@ message ChannelEventUpdate {
         PendingUpdate pending_open_channel = 6;
         ChannelPoint fully_resolved_channel = 7;
         ChannelPoint channel_funding_timeout = 8;
+        ChannelCommitUpdate updated_channel = 9;
     }
 
     enum UpdateType {
@@ -3083,6 +2981,7 @@ message ChannelEventUpdate {
         PENDING_OPEN_CHANNEL = 4;
         FULLY_RESOLVED_CHANNEL = 5;
         CHANNEL_FUNDING_TIMEOUT = 6;
+        CHANNEL_UPDATE = 7;
     }
 
     UpdateType type = 5;
@@ -3256,11 +3155,7 @@ message QueryRoutesRequest {
     */
     map<uint64, bytes> dest_custom_records = 13;
 
-    /*
-    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
-    be taken to the first hop. If zero, any channel may be used.
-    */
-    uint64 outgoing_chan_id = 14 [jstype = JS_STRING, deprecated = true];
+    reserved 14;
 
     /*
     The pubkey of the last hop of the route. If empty, any hop may be used.
@@ -4531,6 +4426,10 @@ message ListPaymentsRequest {
     // If set, returns all payments with a creation date less than or equal to
     // it. Measured in seconds since the unix epoch.
     uint64 creation_date_end = 7;
+
+    // If set, omit hop-level route data for HTLC attempts to reduce query
+    // cost and response size.
+    bool omit_hops = 8;
 }
 
 message ListPaymentsResponse {

--- a/src/infra/lightning/lnd/proto/router.proto
+++ b/src/infra/lightning/lnd/proto/router.proto
@@ -27,7 +27,7 @@ option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
 // Router is a service that offers advanced interaction with the router
 // subsystem of the daemon.
 service Router {
-    /*
+    /* lncli: `sendpayment`
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
     payment updates. When using this RPC, make sure to set a fee limit, as the
@@ -53,24 +53,13 @@ service Router {
     */
     rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
 
-    /*
+    /* lncli: `estimateroutefee`
     EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
     may cost to send an HTLC to the target end destination.
     */
     rpc EstimateRouteFee (RouteFeeRequest) returns (RouteFeeResponse);
 
-    /*
-    Deprecated, use SendToRouteV2. SendToRoute attempts to make a payment via
-    the specified route. This method differs from SendPayment in that it
-    allows users to specify a full route manually. This can be used for
-    things like rebalancing, and atomic swaps. It differs from the newer
-    SendToRouteV2 in that it doesn't return the full HTLC information.
-    */
-    rpc SendToRoute (SendToRouteRequest) returns (SendToRouteResponse) {
-        option deprecated = true;
-    }
-
-    /*
+    /* lncli: `sendtoroute`
     SendToRouteV2 attempts to make a payment via the specified route. This
     method differs from SendPayment in that it allows users to specify a full
     route manually. This can be used for things like rebalancing, and atomic
@@ -141,23 +130,6 @@ service Router {
     rpc SubscribeHtlcEvents (SubscribeHtlcEventsRequest)
         returns (stream HtlcEvent);
 
-    /*
-    Deprecated, use SendPaymentV2. SendPayment attempts to route a payment
-    described by the passed PaymentRequest to the final destination. The call
-    returns a stream of payment status updates.
-    */
-    rpc SendPayment (SendPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use TrackPaymentV2. TrackPayment returns an update stream for
-    the payment identified by the payment hash.
-    */
-    rpc TrackPayment (TrackPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
     /**
     HtlcInterceptor dispatches a bi-directional streaming RPC in which
     Forwarded HTLC requests are sent to the client and the client responds with
@@ -202,6 +174,18 @@ service Router {
     */
     rpc XFindBaseLocalChanAlias (FindBaseAliasRequest)
         returns (FindBaseAliasResponse);
+
+    /* lncli: `deletefwdhistory`
+    DeleteForwardingHistory allows the caller to delete forwarding history
+    events with a timestamp at or before a specified time. This is useful
+    for implementing data retention policies for privacy purposes. The call
+    deletes events in batches and returns statistics including the total number
+    of events deleted and the aggregate fees earned from those events. The
+    deletion is performed in a transaction-safe manner with configurable batch
+    sizes to avoid holding large database locks.
+    */
+    rpc DeleteForwardingHistory (DeleteForwardingHistoryRequest)
+        returns (DeleteForwardingHistoryResponse);
 }
 
 message SendPaymentRequest {
@@ -252,12 +236,7 @@ message SendPaymentRequest {
     */
     int64 fee_limit_sat = 7;
 
-    /*
-    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
-    be taken to the first hop. If zero, any channel may be used (unless
-    outgoing_chan_ids are set).
-    */
-    uint64 outgoing_chan_id = 8 [jstype = JS_STRING, deprecated = true];
+    reserved 8;
 
     /*
     An optional maximum total time lock for the route. This should not
@@ -477,14 +456,6 @@ message SendToRouteRequest {
     base64.
     */
     map<uint64, bytes> first_hop_custom_records = 4;
-}
-
-message SendToRouteResponse {
-    // The preimage obtained by making the payment.
-    bytes preimage = 1;
-
-    // The failure message in case the payment failed.
-    lnrpc.Failure failure = 2;
 }
 
 message ResetMissionControlRequest {
@@ -918,62 +889,6 @@ enum FailureDetail {
     EXTERNAL_VALIDATION_FAILED = 27;
 }
 
-enum PaymentState {
-    /*
-    Payment is still in flight.
-    */
-    IN_FLIGHT = 0;
-
-    /*
-    Payment completed successfully.
-    */
-    SUCCEEDED = 1;
-
-    /*
-    There are more routes to try, but the payment timeout was exceeded.
-    */
-    FAILED_TIMEOUT = 2;
-
-    /*
-    All possible routes were tried and failed permanently. Or were no
-    routes to the destination at all.
-    */
-    FAILED_NO_ROUTE = 3;
-
-    /*
-    A non-recoverable error has occurred.
-    */
-    FAILED_ERROR = 4;
-
-    /*
-    Payment details incorrect (unknown hash, invalid amt or
-    invalid final cltv delta)
-    */
-    FAILED_INCORRECT_PAYMENT_DETAILS = 5;
-
-    /*
-    Insufficient local balance.
-    */
-    FAILED_INSUFFICIENT_BALANCE = 6;
-}
-
-message PaymentStatus {
-    // Current state the payment is in.
-    PaymentState state = 1;
-
-    /*
-    The pre-image of the payment when state is SUCCEEDED.
-    */
-    bytes preimage = 2;
-
-    reserved 3;
-
-    /*
-    The HTLCs made in attempt to settle the payment [EXPERIMENTAL].
-    */
-    repeated lnrpc.HTLCAttempt htlcs = 4;
-}
-
 message CircuitKey {
     /// The id of the channel that the is part of this circuit.
     uint64 chan_id = 1;
@@ -1138,4 +1053,36 @@ message FindBaseAliasRequest {
 message FindBaseAliasResponse {
     // The base scid that resulted from the base scid look up.
     uint64 base = 1;
+}
+
+message DeleteForwardingHistoryRequest {
+    // Specify the cutoff time for deletion using one of the following options.
+    // Events with a timestamp at or before the cutoff are deleted.
+    oneof time_spec {
+        // Absolute Unix timestamp (seconds). Events at or before this time
+        // are deleted.
+        uint64 delete_before_time = 1;
+
+        // Relative duration string indicating how far back to delete, e.g.
+        // "-30d" deletes events at or before 30 days ago.
+        // Standard Go: "-24h", "-1.5h"
+        // Custom units: "-1d", "-1w", "-1M", "-1y"
+        // Supported: ns, us/µs, ms, s, m, h, d (days), w (weeks),
+        // M (months=30.44d), y (years=365.25d).
+        // Use negative values to specify time in the past.
+        string delete_before_duration = 2;
+    }
+}
+
+message DeleteForwardingHistoryResponse {
+    // Number of forwarding events deleted.
+    uint64 events_deleted = 1;
+
+    // Total fees earned from deleted events (in millisatoshis).
+    // This is the sum of (amt_in - amt_out) for all deleted events, which
+    // can be used for accounting purposes.
+    int64 total_fee_msat = 2;
+
+    // Status message.
+    string status = 3;
 }

--- a/src/infra/lightning/lnd/proto/walletkit.proto
+++ b/src/infra/lightning/lnd/proto/walletkit.proto
@@ -328,7 +328,7 @@ service WalletKit {
     */
     rpc FundPsbt (FundPsbtRequest) returns (FundPsbtResponse);
 
-    /*
+    /* lncli: `wallet psbt sign`
     SignPsbt expects a partial transaction with all inputs and outputs fully
     declared and tries to sign all unsigned inputs that have all required fields
     (UTXO information, BIP32 derivation information, witness or sig scripts)
@@ -1098,6 +1098,56 @@ enum WitnessType {
     counterparty's who broadcasts a revoked taproot commitment transaction.
     */
     TAPROOT_COMMITMENT_REVOKE = 35;
+
+    /*
+    A witness type that allows us to spend our settled local commitment after a
+    CSV delay when we force close a production taproot channel.
+    */
+    TAPROOT_LOCAL_COMMIT_SPEND_FINAL = 36;
+
+    /*
+    A witness type that allows us to spend our settled local commitment after
+    a CSV delay when the remote party has force closed a production taproot
+    channel.
+    */
+    TAPROOT_REMOTE_COMMIT_SPEND_FINAL = 37;
+
+    /*
+    A witness that allows us to timeout an HTLC we offered to the remote party
+    on our production taproot commitment transaction. We use this when we need
+    to go on chain to time out an HTLC.
+    */
+    TAPROOT_HTLC_OFFERED_TIMEOUT_SECOND_LEVEL_FINAL = 38;
+
+    /*
+    A witness type that allows us to sweep an HTLC we accepted on our
+    production taproot commitment transaction after we go to the second level
+    on chain.
+    */
+    TAPROOT_HTLC_ACCEPTED_SUCCESS_SECOND_LEVEL_FINAL = 39;
+
+    /*
+    A witness that allows us to sweep an HTLC we offered to the remote party
+    that lies on the production taproot commitment transaction for the remote
+    party. We can spend this output after the absolute CLTV timeout of the
+    HTLC as passed.
+    */
+    TAPROOT_HTLC_OFFERED_REMOTE_TIMEOUT_FINAL = 40;
+
+    /*
+    A witness that allows us to sweep an HTLC that was offered to us by the
+    remote party for a production taproot channel. We use this witness in the
+    case that the remote party goes to chain, and we know the pre-image to the
+    HTLC. We can sweep this without any additional timeout.
+    */
+    TAPROOT_HTLC_ACCEPTED_REMOTE_SUCCESS_FINAL = 41;
+
+    /*
+    A witness type that allows us to sweep the settled output of a malicious
+    counterparty's who broadcasts a revoked production taproot commitment
+    transaction.
+    */
+    TAPROOT_COMMITMENT_REVOKE_FINAL = 42;
 }
 
 message PendingSweep {


### PR DESCRIPTION
## Summary

Two commits:

1. **`build: add make protos script + bump CLN v26.06.1 / LND v0.21.0-beta protos`** — the vendored gRPC protos were stale relative to the nodes we run. Refreshes them to CLN `v26.06.1` and LND `v0.21.0-beta`, and adds `make protos` (logic in `scripts/update-protos.sh`) so the refresh is reproducible:
   ```
   CLN_VERSION=... LND_VERSION=... make protos
   ```

2. **`refactor(cln): migrate deprecated pay to xpay`** — CLN's `pay` is deprecated in favour of `xpay` (which `pay` already delegates to internally). Both the gRPC and REST clients now call `xpay`.

## Notes on the xpay migration

- `xpay` takes an **absolute `maxfee`** instead of `pay`'s deprecated `maxfeepercent`/`exemptfee`. We keep both config fields and derive the absolute cap from `amount × maxfeepercent`, floored at `exemptfee` — so existing config and the k8s values keep working unchanged.
- `XpayResponse` omits the payment hash, so we derive it as `sha256(preimage)`.
- `XpayResponse` has no `created_at`/`status`; a returned response means success (failures surface as errors), so `payment_time` is stamped at receipt.

## Testing

`make build` + `make lint` (clippy `-D warnings`) clean. The integration matrix exercises payments against real nodes per provider (`cln_grpc`, `cln_rest`, …), so any payment regression is caught in CI.