### PR TITLE
fix: replay offchain state after listener recovery

### DIFF
--- a/src/domains/event/event_service.rs
+++ b/src/domains/event/event_service.rs
@@ -5,7 +5,7 @@ use tracing::{debug, info, trace};
 use crate::{
     application::{
         composition::{AppStore, Currency, Ledger},
-        errors::{ApplicationError, DataError},
+        errors::ApplicationError,
     },
     domains::{
         bitcoin::{BtcOutput, BtcOutputStatus},
@@ -57,7 +57,11 @@ impl EventUseCases for EventService {
             return Ok(());
         }
 
-        return Err(DataError::NotFound("Lightning invoice not found.".into()).into());
+        debug!(
+            payment_hash = %event.payment_hash,
+            "Ignoring incoming Lightning payment for unknown invoice"
+        );
+        Ok(())
     }
 
     async fn outgoing_payment(&self, event: LnPaySuccessEvent) -> Result<(), ApplicationError> {
@@ -86,7 +90,11 @@ impl EventUseCases for EventService {
             return Ok(());
         }
 
-        return Err(DataError::NotFound("Lightning payment not found.".into()).into());
+        debug!(
+            payment_hash = %event.payment_hash,
+            "Ignoring completed outgoing Lightning payment for unknown payment"
+        );
+        Ok(())
     }
 
     async fn failed_payment(&self, event: LnPayFailureEvent) -> Result<(), ApplicationError> {
@@ -111,7 +119,11 @@ impl EventUseCases for EventService {
             return Ok(());
         }
 
-        return Err(DataError::NotFound("Lightning payment not found.".into()).into());
+        debug!(
+            payment_hash = %event.payment_hash,
+            "Ignoring failed outgoing Lightning payment for unknown payment"
+        );
+        Ok(())
     }
 
     async fn onchain_deposit(&self, event: OnchainDepositEvent, currency: Currency) -> Result<bool, ApplicationError> {
@@ -259,7 +271,7 @@ mod tests {
             use super::*;
 
             #[tokio::test]
-            async fn returns_not_found() {
+            async fn ignores_the_event() {
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .invoice
@@ -274,9 +286,7 @@ mod tests {
                     payment_time: Utc::now(),
                 };
 
-                let err = service(store).invoice_paid(event).await.unwrap_err();
-
-                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+                assert!(service(store).invoice_paid(event).await.is_ok());
             }
         }
     }
@@ -346,7 +356,7 @@ mod tests {
             use super::*;
 
             #[tokio::test]
-            async fn returns_not_found() {
+            async fn ignores_the_event() {
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .payment
@@ -354,9 +364,7 @@ mod tests {
                     .times(1)
                     .returning(|_| Ok(None));
 
-                let err = service(store).outgoing_payment(event()).await.unwrap_err();
-
-                assert!(matches!(err, ApplicationError::Data(DataError::NotFound(_))));
+                assert!(service(store).outgoing_payment(event()).await.is_ok());
             }
         }
     }
@@ -408,6 +416,22 @@ mod tests {
                         ..Default::default()
                     }))
                 });
+
+                assert!(service(store).failed_payment(event()).await.is_ok());
+            }
+        }
+
+        mod when_payment_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn ignores_the_event() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .payment
+                    .expect_find_by_payment_hash()
+                    .times(1)
+                    .returning(|_| Ok(None));
 
                 assert!(service(store).failed_payment(event()).await.is_ok());
             }

--- a/src/infra/app/event_listener.rs
+++ b/src/infra/app/event_listener.rs
@@ -1,6 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
-use tokio::time::{sleep, Instant};
+use tokio::{
+    task::yield_now,
+    time::{sleep, Instant},
+};
 use tracing::{error, warn};
 
 use crate::{
@@ -85,10 +88,21 @@ impl EventListener {
 
     pub async fn start(&self) -> Result<(), ApplicationError> {
         let listener = self.listener.clone();
+        let services = self.services.clone();
         tokio::spawn(async move {
             let mut backoff = LISTENER_MIN_RECONNECT_DELAY;
+            let mut replay_before_listen = false;
 
             loop {
+                if replay_before_listen {
+                    if let Err(err) = Self::sync_offchain_state(&services).await {
+                        error!(%err, ?backoff, "Lightning listener replay sync failed; retrying");
+                        sleep(backoff).await;
+                        backoff = (backoff * 2).min(LISTENER_MAX_RECONNECT_DELAY);
+                        continue;
+                    }
+                }
+
                 let started = Instant::now();
                 let outcome = listener.listen().await;
                 let uptime = started.elapsed();
@@ -101,6 +115,7 @@ impl EventListener {
                 }
 
                 sleep(backoff).await;
+                replay_before_listen = true;
                 backoff = if uptime >= LISTENER_STABLE_THRESHOLD {
                     LISTENER_MIN_RECONNECT_DELAY
                 } else {
@@ -109,8 +124,69 @@ impl EventListener {
             }
         });
 
-        tokio::try_join!(self.services.invoice.sync(), self.services.payment.sync())?;
+        yield_now().await;
+        Self::sync_offchain_state(&self.services).await?;
 
         Ok(())
+    }
+
+    async fn sync_offchain_state(services: &AppServices) -> Result<(), ApplicationError> {
+        let (synced_invoices, synced_payments) = tokio::try_join!(services.invoice.sync(), services.payment.sync())?;
+
+        tracing::debug!(synced_invoices, synced_payments, "Lightning off-chain state replayed");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    use crate::{application::composition::MockAppServicesBuilder, infra::lightning::MockEventsListener};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sync_offchain_state_replays_invoices_and_payments() {
+        let mut builder = MockAppServicesBuilder::new();
+        builder.invoice.expect_sync().times(1).returning(|| Ok(2));
+        builder.payment.expect_sync().times(1).returning(|| Ok(3));
+        let services = builder.build();
+
+        EventListener::sync_offchain_state(&services).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_begins_listening_before_startup_replay() {
+        let listening_started = Arc::new(AtomicBool::new(false));
+        let mut listener = MockEventsListener::new();
+        listener.expect_listen().times(1).returning({
+            let listening_started = listening_started.clone();
+            move || {
+                listening_started.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        });
+
+        let mut builder = MockAppServicesBuilder::new();
+        builder.invoice.expect_sync().times(1).returning({
+            let listening_started = listening_started.clone();
+            move || {
+                assert!(listening_started.load(Ordering::SeqCst));
+                Ok(2)
+            }
+        });
+        builder.payment.expect_sync().times(1).returning(|| Ok(3));
+        let services = Arc::new(builder.build());
+        let event_listener = EventListener {
+            listener: Arc::new(listener),
+            services,
+        };
+
+        event_listener.start().await.unwrap();
     }
 }

--- a/src/infra/database/sea_orm/uow_tests.rs
+++ b/src/infra/database/sea_orm/uow_tests.rs
@@ -203,6 +203,29 @@ async fn fail_releases_the_reservation() {
 }
 
 #[tokio::test]
+async fn duplicate_fail_does_not_double_release() {
+    let conn = connect().await;
+    let wallet = seed_wallet(&conn, 200_000).await;
+    let mut payment = uow(&conn)
+        .reserve(pending_payment(wallet, 100_000, 0), 110_000)
+        .await
+        .expect("reserve");
+    payment.status = PaymentStatus::Failed;
+    payment.error = Some("payment failed".to_string());
+
+    let first = uow(&conn).fail(payment.clone()).await.expect("first fail");
+    assert_eq!(first.status, PaymentStatus::Failed);
+    assert_eq!(balance(&conn, wallet).await, (200_000, 0));
+
+    // The failure event and replay sync can both observe the same failed node
+    // payment. The replay must return the already-failed row without trying to
+    // release the stale reservation again.
+    let second = uow(&conn).fail(payment).await.expect("second fail");
+    assert_eq!(second.status, PaymentStatus::Failed);
+    assert_eq!(balance(&conn, wallet).await, (200_000, 0));
+}
+
+#[tokio::test]
 async fn settle_adjusts_reserved_to_actual() {
     let conn = connect().await;
     let wallet = seed_wallet(&conn, 200_000).await;

--- a/src/infra/lightning/cln/cln_grpc_listener.rs
+++ b/src/infra/lightning/cln/cln_grpc_listener.rs
@@ -93,7 +93,7 @@ impl ClnGrpcListener {
                         match invoice.status() {
                             WaitinvoiceStatus::Paid => {
                                 if let Err(err) = self.services.event.invoice_paid(invoice.clone().into()).await {
-                                    warn!(%err, "Failed to process incoming payment");
+                                    return Err(LightningError::EventProcessing(err.to_string()));
                                 }
                             }
                             WaitinvoiceStatus::Expired => {}
@@ -138,12 +138,8 @@ impl ClnGrpcListener {
                 let payment_hash = hex::encode(&payment_hash_bytes);
                 match sendpays.status() {
                     WaitSendpaysStatus::Complete => {
-                        if let Err(err) = self
-                            .handle_sendpay_complete(payment_hash_bytes, sendpays.partid, sendpays.groupid)
-                            .await
-                        {
-                            warn!(%err, "Failed to process completed outgoing payment");
-                        }
+                        self.handle_sendpay_complete(payment_hash_bytes, sendpays.partid, sendpays.groupid)
+                            .await?;
                     }
                     WaitSendpaysStatus::Failed => {
                         let failure_event = LnPayFailureEvent {
@@ -151,7 +147,7 @@ impl ClnGrpcListener {
                             payment_hash,
                         };
                         if let Err(err) = self.services.event.failed_payment(failure_event).await {
-                            warn!(%err, "Failed to process failed outgoing payment");
+                            return Err(LightningError::EventProcessing(err.to_string()));
                         }
                     }
                     WaitSendpaysStatus::Pending => {}
@@ -267,7 +263,7 @@ impl ClnGrpcListener {
             .event
             .outgoing_payment(success_event)
             .await
-            .map_err(|err| LightningError::Listener(err.to_string()))
+            .map_err(|err| LightningError::EventProcessing(err.to_string()))
     }
 
     async fn handle_chainmoves(&self, start_index: u64) -> Result<u64, LightningError> {

--- a/src/infra/lightning/cln/cln_websocket_listener.rs
+++ b/src/infra/lightning/cln/cln_websocket_listener.rs
@@ -1,22 +1,23 @@
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures_util::{future::BoxFuture, FutureExt};
 use native_tls::{Certificate, TlsConnector};
 use rust_socketio::{
-    asynchronous::{Client, ClientBuilder},
+    asynchronous::{Client, ClientBuilder, ReconnectSettings},
     Payload, TransportType,
 };
-use tokio::{fs, sync};
-use tracing::{error, info, warn};
+use tokio::{
+    fs,
+    sync::{self, mpsc},
+    time::sleep,
+};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     application::{
         composition::{AppServices, Currency},
-        errors::LightningError,
+        errors::{ApplicationError, LightningError},
     },
     domains::bitcoin::{BitcoinWallet, OnchainSyncCursor, OnchainTransaction},
     infra::lightning::EventsListener,
@@ -26,7 +27,7 @@ use super::cln_websocket_types::{InvoicePayment, SendPayFailure, SendPaySuccess}
 use super::ClnRestClientConfig;
 
 pub struct ClnWebsocketListener {
-    client_builder: Mutex<Option<ClientBuilder>>,
+    config: ClnRestClientConfig,
     services: Arc<AppServices>,
     wallet: Arc<dyn BitcoinWallet>,
 }
@@ -37,6 +38,17 @@ impl ClnWebsocketListener {
         services: Arc<AppServices>,
         wallet: Arc<dyn BitcoinWallet>,
     ) -> Result<Self, LightningError> {
+        Ok(Self {
+            config,
+            services,
+            wallet,
+        })
+    }
+
+    async fn client_builder(&self) -> Result<ClientBuilder, LightningError> {
+        let config = &self.config;
+        let reconnect_delay_min = config.ws_min_reconnect_delay;
+        let reconnect_delay_max = config.ws_max_reconnect_delay;
         let mut client_builder = ClientBuilder::new(config.endpoint.clone())
             .transport_type(TransportType::Websocket)
             .reconnect_on_disconnect(true)
@@ -45,6 +57,23 @@ impl ClnWebsocketListener {
                 config.ws_min_reconnect_delay.as_secs(),
                 config.ws_max_reconnect_delay.as_secs(),
             )
+            .on_reconnect({
+                let services = self.services.clone();
+                move || {
+                    let services = services.clone();
+                    async move {
+                        ClnWebsocketListener::sync_offchain_state_until_success(
+                            &services,
+                            "Core Lightning websocket reconnect",
+                            reconnect_delay_min,
+                            reconnect_delay_max,
+                        )
+                        .await;
+                        ReconnectSettings::new()
+                    }
+                    .boxed()
+                }
+            })
             .on("open", on_open)
             .on("close", on_close)
             .on("error", on_error);
@@ -70,18 +99,16 @@ impl ClnWebsocketListener {
             client_builder = client_builder.tls_config(tls_connector);
         }
 
-        Ok(Self {
-            client_builder: Mutex::new(Some(client_builder)),
-            services,
-            wallet,
-        })
+        Ok(client_builder)
     }
 
     fn on_message(
         services: Arc<AppServices>,
         wallet: Arc<dyn BitcoinWallet>,
+        failure_tx: mpsc::Sender<LightningError>,
         cursor: Arc<tokio::sync::Mutex<Option<OnchainSyncCursor>>>,
         payload: Payload,
+        client: Client,
     ) -> BoxFuture<'static, ()> {
         async move {
             match payload {
@@ -91,7 +118,14 @@ impl ClnWebsocketListener {
                             match serde_json::from_value::<InvoicePayment>(event.clone()) {
                                 Ok(invoice_payment) => {
                                     if let Err(err) = services.event.invoice_paid(invoice_payment.into()).await {
-                                        warn!(%err, "Failed to process incoming payment");
+                                        Self::stop_after_offchain_projection_error(
+                                            &failure_tx,
+                                            &client,
+                                            "incoming_payment",
+                                            err,
+                                        )
+                                        .await;
+                                        return;
                                     }
                                 }
                                 Err(err) => {
@@ -116,7 +150,14 @@ impl ClnWebsocketListener {
                                     }
 
                                     if let Err(err) = services.event.outgoing_payment(sendpay_success.into()).await {
-                                        warn!(%err, "Failed to process outgoing payment");
+                                        Self::stop_after_offchain_projection_error(
+                                            &failure_tx,
+                                            &client,
+                                            "outgoing_payment",
+                                            err,
+                                        )
+                                        .await;
+                                        return;
                                     }
                                 }
                                 Err(err) => {
@@ -139,7 +180,14 @@ impl ClnWebsocketListener {
                                     }
 
                                     if let Err(err) = services.event.failed_payment(sendpay_failure.into()).await {
-                                        warn!(%err, "Failed to process failed outgoing payment");
+                                        Self::stop_after_offchain_projection_error(
+                                            &failure_tx,
+                                            &client,
+                                            "failed_payment",
+                                            err,
+                                        )
+                                        .await;
+                                        return;
                                     }
                                 }
                                 Err(err) => {
@@ -204,17 +252,78 @@ impl ClnWebsocketListener {
         }
         .boxed()
     }
+
+    async fn stop_after_offchain_projection_error(
+        failure_tx: &mpsc::Sender<LightningError>,
+        client: &Client,
+        event_type: &'static str,
+        err: ApplicationError,
+    ) {
+        Self::signal_listener_failure(failure_tx, event_type, err);
+
+        if let Err(err) = client.disconnect().await {
+            debug!(%err, event_type, "Failed to disconnect Core Lightning websocket after projection error");
+        }
+    }
+
+    fn signal_listener_failure(
+        failure_tx: &mpsc::Sender<LightningError>,
+        event_type: &'static str,
+        err: ApplicationError,
+    ) {
+        let err = err.to_string();
+        error!(%err, event_type, "Failed to process Lightning off-chain event; reconnecting listener");
+
+        if let Err(send_err) = failure_tx.try_send(LightningError::EventProcessing(err)) {
+            debug!(
+                ?send_err,
+                event_type, "Core Lightning websocket listener failure already signaled"
+            );
+        }
+    }
+
+    async fn sync_offchain_state(services: &AppServices, context: &'static str) -> Result<(), ApplicationError> {
+        let (synced_invoices, synced_payments) = tokio::try_join!(services.invoice.sync(), services.payment.sync())?;
+
+        debug!(
+            context,
+            synced_invoices, synced_payments, "Lightning off-chain state replayed"
+        );
+
+        Ok(())
+    }
+
+    async fn sync_offchain_state_until_success(
+        services: &AppServices,
+        context: &'static str,
+        min_delay: Duration,
+        max_delay: Duration,
+    ) {
+        let min_delay = if min_delay.is_zero() {
+            Duration::from_millis(100)
+        } else {
+            min_delay
+        };
+        let max_delay = max_delay.max(min_delay);
+        let mut backoff = min_delay;
+
+        loop {
+            match Self::sync_offchain_state(services, context).await {
+                Ok(()) => return,
+                Err(err) => {
+                    error!(%err, context, ?backoff, "Lightning off-chain replay failed; retrying before reconnect");
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(max_delay);
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
 impl EventsListener for ClnWebsocketListener {
     async fn listen(&self) -> Result<(), LightningError> {
-        let mut client_builder = self
-            .client_builder
-            .lock()
-            .map_err(|_| LightningError::Listener("Failed to lock client builder".to_string()))?
-            .take()
-            .ok_or_else(|| LightningError::Listener("Listener already started".to_string()))?;
+        let mut client_builder = self.client_builder().await?;
 
         self.services
             .bitcoin
@@ -232,23 +341,31 @@ impl EventsListener for ClnWebsocketListener {
 
         let wallet = self.wallet.clone();
         let services = self.services.clone();
+        let (failure_tx, mut failure_rx) = mpsc::channel(1);
 
-        client_builder = client_builder.on("message", move |payload, _: Client| {
-            Self::on_message(services.clone(), wallet.clone(), cursor.clone(), payload)
+        client_builder = client_builder.on("message", move |payload, client| {
+            Self::on_message(
+                services.clone(),
+                wallet.clone(),
+                failure_tx.clone(),
+                cursor.clone(),
+                payload,
+                client,
+            )
         });
 
         // Hold the connected client: rust_socketio reconnects internally
-        // (reconnect_on_disconnect), so this listener owns its own recovery. Park the task
-        // for the process lifetime — returning would let the supervisor re-enter listen() on
-        // a builder already consumed by take() above, failing with "Listener already started".
+        // (reconnect_on_disconnect) for transport failures. Projection failures are
+        // signaled from callbacks so the supervisor can apply its backoff and replay sync.
         let _client = client_builder
             .connect()
             .await
             .map_err(|e| LightningError::ConnectWebsocket(e.to_string()))?;
 
-        std::future::pending::<()>().await;
-
-        Ok(())
+        Err(failure_rx
+            .recv()
+            .await
+            .unwrap_or_else(|| LightningError::Listener("Core Lightning websocket listener stopped".to_string())))
     }
 }
 
@@ -278,4 +395,89 @@ fn on_error(err: Payload, _: Client) -> BoxFuture<'static, ()> {
         error!(?err, "Error from Core Lightning websocket server ");
     }
     .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use tokio::sync::mpsc;
+
+    use crate::application::{
+        composition::MockAppServicesBuilder,
+        errors::{DataError, DatabaseError, LightningError},
+    };
+
+    use super::ClnWebsocketListener;
+
+    #[test]
+    fn offchain_projection_error_signals_listener_failure() {
+        let (failure_tx, mut failure_rx) = mpsc::channel(1);
+
+        ClnWebsocketListener::signal_listener_failure(
+            &failure_tx,
+            "incoming_payment",
+            DatabaseError::Update("database is locked".to_string()).into(),
+        );
+
+        let err = failure_rx.try_recv().expect("listener failure");
+        assert!(matches!(
+            err,
+            LightningError::EventProcessing(message) if message.contains("database is locked")
+        ));
+    }
+
+    #[test]
+    fn repeated_offchain_projection_error_is_dropped_after_failure_is_signaled() {
+        let (failure_tx, mut failure_rx) = mpsc::channel(1);
+
+        ClnWebsocketListener::signal_listener_failure(
+            &failure_tx,
+            "incoming_payment",
+            DatabaseError::Update("database is locked".to_string()).into(),
+        );
+        ClnWebsocketListener::signal_listener_failure(
+            &failure_tx,
+            "incoming_payment",
+            DataError::NotFound("Lightning invoice not found.".to_string()).into(),
+        );
+
+        assert!(failure_rx.try_recv().is_ok());
+        assert!(failure_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn reconnect_replay_retries_until_sync_succeeds() {
+        let invoice_attempts = Arc::new(AtomicUsize::new(0));
+        let mut builder = MockAppServicesBuilder::new();
+
+        builder.invoice.expect_sync().times(2).returning({
+            let invoice_attempts = invoice_attempts.clone();
+            move || {
+                if invoice_attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(DatabaseError::Update("transient failure".to_string()).into())
+                } else {
+                    Ok(1)
+                }
+            }
+        });
+        builder.payment.expect_sync().returning(|| Ok(1));
+        let services = builder.build();
+
+        ClnWebsocketListener::sync_offchain_state_until_success(
+            &services,
+            "test reconnect",
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert_eq!(invoice_attempts.load(Ordering::SeqCst), 2);
+    }
 }

--- a/src/infra/lightning/lnd/lnd_grpc_listener.rs
+++ b/src/infra/lightning/lnd/lnd_grpc_listener.rs
@@ -59,7 +59,7 @@ impl LndGrpcListener {
             .await
             .map_err(|e| LightningError::Listener(format!("Failed to read invoice stream: {}", e)))?
         {
-            self.handle_invoice(invoice).await;
+            self.handle_invoice(invoice).await?;
         }
 
         Err(LightningError::Listener("LND invoice stream closed".to_string()))
@@ -92,14 +92,14 @@ impl LndGrpcListener {
         Err(LightningError::Listener("LND transaction stream closed".to_string()))
     }
 
-    async fn handle_invoice(&self, invoice: lnrpc::Invoice) {
+    async fn handle_invoice(&self, invoice: lnrpc::Invoice) -> Result<(), LightningError> {
         if invoice.state() != lnrpc::invoice::InvoiceState::Settled {
-            return;
+            return Ok(());
         }
 
         if invoice.r_hash.is_empty() {
             warn!("Invoice update missing payment hash");
-            return;
+            return Ok(());
         }
 
         let payment_time = Utc.timestamp_opt(invoice.settle_date, 0).unwrap();
@@ -110,9 +110,13 @@ impl LndGrpcListener {
             payment_time,
         };
 
-        if let Err(err) = self.services.event.invoice_paid(event).await {
-            warn!(%err, "Failed to process incoming payment");
-        }
+        self.services
+            .event
+            .invoice_paid(event)
+            .await
+            .map_err(|err| LightningError::EventProcessing(err.to_string()))?;
+
+        Ok(())
     }
 
     fn map_transaction(transaction: lnrpc::Transaction) -> BtcTransaction {

--- a/src/infra/lightning/lnd/lnd_websocket_listener.rs
+++ b/src/infra/lightning/lnd/lnd_websocket_listener.rs
@@ -11,7 +11,7 @@ use tokio::fs;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::ClientRequestBuilder;
 use tokio_tungstenite::{connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::application::composition::AppServices;
 use crate::application::errors::LightningError;
@@ -145,11 +145,9 @@ impl LndWebsocketListener {
                 Ok(msg) => {
                     if msg.is_text() {
                         let text = msg.into_text().unwrap();
-                        // Invoice parse/settlement errors are skippable (idempotent and re-synced
-                        // by invoice.sync()), so log and keep reading rather than dropping the stream.
-                        if let Err(e) = self.process_invoice_message(&text).await {
-                            error!(%e, "Failed to process message");
-                        }
+                        // Parse/semantic errors are skippable; database projection errors
+                        // propagate so the supervisor replays pending state before resubscribe.
+                        self.process_invoice_message(&text).await?;
                     } else if msg.is_close() {
                         debug!("WebSocket closed");
                         return Ok(());
@@ -186,15 +184,21 @@ impl LndWebsocketListener {
         Ok(())
     }
 
-    async fn process_invoice_message(&self, text: &str) -> anyhow::Result<()> {
-        let value: Value = serde_json::from_str(text)?;
+    async fn process_invoice_message(&self, text: &str) -> Result<(), LightningError> {
+        let value: Value = match serde_json::from_str(text) {
+            Ok(value) => value,
+            Err(err) => {
+                error!(%err, "Failed to parse invoice message");
+                return Ok(());
+            }
+        };
 
         if let Some(event) = value.get("result") {
             match serde_json::from_value::<InvoiceResponse>(event.clone()) {
                 Ok(invoice) => {
                     if invoice.state.as_str() == "SETTLED" {
                         if let Err(err) = self.services.event.invoice_paid(invoice.into()).await {
-                            warn!(%err, "Failed to process incoming payment");
+                            return Err(LightningError::EventProcessing(err.to_string()));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- replay pending Lightning invoices/payments directly from `EventListener` after the listener supervisor has been spawned, and before supervisor resubscribe attempts; no separate `OffchainReplay` helper
- make `invoice_paid`, `outgoing_payment`, and `failed_payment` ignore unknown hashes with debug logs so node activity outside swissknife is expected
- make LND/CLN supervisor-owned listeners propagate remaining event-service errors so the supervisor reconnects and replays from existing cursors
- keep the CLN socket.io transport reconnect hook for real websocket reconnects, but retry off-chain replay with bounded backoff before letting the internal reconnect proceed
- route CLN websocket callback projection errors back out of `listen()` so the `EventListener` supervisor applies backoff and runs replay sync instead of syncing inside the callback
- add real-DB UOW coverage for duplicate failed-payment replay

Closes #308.

## CLN websocket note

I checked `rust_socketio` 0.6.0: message callbacks return `BoxFuture<()>`, so they cannot directly return a `Result` to `listen()`. The listener bridges projection failures by sending them over a channel, disconnecting the socket, and returning `LightningError::EventProcessing` from `listen()`. That lets the outer supervisor own backoff and replay.

`ClientBuilder::on_reconnect` still runs before socket.io transport reconnect attempts and returns `ReconnectSettings`, so it remains useful for real network/server disconnects handled internally by the socket.io client. Since it cannot fail outward, replay failures in that hook now retry before reconnecting. Custom `on(...)` events are still domain/socket events; they are not a better fit for replay recovery.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test event_service::tests::invoice_paid`
- `cargo test event_service::tests::outgoing_payment`
- `cargo test event_service::tests::failed_payment`
- `cargo test event_listener::tests`
- `cargo test cln_websocket_listener::tests`
- `make test-persistence ITEST_DATABASE=sqlite`
- `make test-persistence ITEST_DATABASE=postgres`
- `make itest-down ITEST_PROJECT=swissknife-itest`
- `cargo test`
- `make lint`
