### PR TITLE
ci: build release images on native arm64 runners instead of QEMU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-jobs:
-  build-and-push:
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
+env:
+  REGISTRY_IMAGE_BASE: docker.io/bitcoinnumeraire
 
-    runs-on: ubuntu-latest
+jobs:
+  # Build each architecture on its own native runner (no QEMU emulation) and
+  # push by digest. The arm64 image is built on GitHub's free ubuntu-24.04-arm
+  # hosted runner instead of being cross-compiled under QEMU.
+  build:
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
       matrix:
+        image: [swissknife, swissknife-server, swissknife-dashboard]
+        platform: [linux/amd64, linux/arm64]
         include:
           - image: swissknife
             context: .
@@ -40,8 +46,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Prepare platform pair
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -56,33 +64,101 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: bitcoinnumeraire/${{ matrix.image }}
+          images: ${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.platform }}
+          pull: true
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-arch registry cache so each runner keeps a warm dependency layer
+          # without the two architectures clobbering each other's cache tag.
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max,ignore-error=true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into a single multi-arch tag per image and
+  # attest the resulting manifest.
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [swissknife, swissknife-server, swissknife-dashboard]
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
-          pull: true
-          push: true
-          cache-from: type=registry,ref=docker.io/bitcoinnumeraire/${{ matrix.image }}:buildcache
-          # Use a Docker Hub registry-backed cache tag for cross-runner reliability
-          cache-to: type=registry,ref=docker.io/bitcoinnumeraire/${{ matrix.image }}:buildcache,mode=max,ignore-error=true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
+      - name: Create multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}@sha256:%s ' *)
+
+      - name: Inspect and capture manifest digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            "${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}" \
+            --format '{{json .manifest.digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
-          subject-name: docker.io/bitcoinnumeraire/${{ matrix.image }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY_IMAGE_BASE }}/${{ matrix.image }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
Closes #281.

## Problem
The `Release` workflow built `linux/amd64,linux/arm64` in a single `ubuntu-latest` job, so the arm64 images were compiled under **QEMU emulation** — combined with the aggressive release profile (`lto=true`, `codegen-units=1`), the arm64 Rust build dominated the run (~141 min for the `swissknife` image alone in the v0.2.0 run).

## Change
Adopt Docker's "distribute build across multiple runners" pattern:

- **`build` job** — matrix of 3 images × 2 arches. amd64 on `ubuntu-latest`, arm64 on GitHub's free native `ubuntu-24.04-arm` runner. Each builds only its own platform and pushes **by digest**. QEMU is removed.
- **`merge` job** — per image, assembles the per-arch digests into one multi-arch tag with `docker buildx imagetools create` (semver/sha tags from `metadata-action`), then attests the final manifest.
- Registry cache is now **per-arch** (`buildcache-linux-amd64` / `buildcache-linux-arm64`) so the two runners don't clobber each other.

Expected: arm64 build drops from ~2h to ~10-15 min; whole release finishes well under 30 min. Published tags stay multi-arch (`amd64`+`arm64`) and attested.

## Testing notes
This only runs on a `v*` tag push and can't be fully exercised without a release. To validate: push a throwaway prerelease tag (e.g. `v0.2.1-rc.1`), confirm `docker buildx imagetools inspect bitcoinnumeraire/swissknife:0.2.1-rc.1` lists both platforms, then delete the tag/images. The first real release after this is cold-cache (the old single `:buildcache` tag is no longer used).