### PR TITLE
fix: settle payments that exceed reserved fees

### DIFF
--- a/src/domains/wallet/wallet_balance_repository.rs
+++ b/src/domains/wallet/wallet_balance_repository.rs
@@ -15,6 +15,19 @@ pub trait WalletBalanceRepository: Send + Sync {
     /// Debit available balance. Returns `false` if available balance is insufficient.
     async fn debit(&self, wallet_id: Uuid, currency: &Currency, amount_msat: u64) -> Result<bool, DatabaseError>;
 
+    /// Debit a confirmed external spend, allowing available balance to go negative.
+    ///
+    /// Use only after the upstream ledger/node has already completed the spend:
+    /// settlement must record the actual debit even when fees exceed the amount
+    /// reserved at admission time. Returns `false` only when the wallet+currency
+    /// balance row is missing.
+    async fn debit_confirmed(
+        &self,
+        wallet_id: Uuid,
+        currency: &Currency,
+        amount_msat: u64,
+    ) -> Result<bool, DatabaseError>;
+
     /// Move `amount_msat` from reserved back to available. Returns `false` if the reservation is missing.
     async fn release(&self, wallet_id: Uuid, currency: &Currency, amount_msat: u64) -> Result<bool, DatabaseError>;
 }

--- a/src/infra/database/sea_orm/repositories/sea_orm_wallet_balance_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_wallet_balance_repository.rs
@@ -92,6 +92,25 @@ where
         Ok(result.rows_affected == 1)
     }
 
+    async fn debit_confirmed(
+        &self,
+        wallet_id: Uuid,
+        currency: &Currency,
+        amount_msat: u64,
+    ) -> Result<bool, DatabaseError> {
+        let amount = amount_msat as i64;
+        let result = WalletBalance::update_many()
+            .col_expr(Column::AvailableAmount, Expr::col(Column::AvailableAmount).sub(amount))
+            .col_expr(Column::UpdatedAt, Expr::value(Utc::now().naive_utc()))
+            .filter(Column::WalletId.eq(wallet_id))
+            .filter(Column::Currency.eq(currency.to_string()))
+            .exec(self.db.connection())
+            .await
+            .map_err(|e| DatabaseError::Update(e.to_string()))?;
+
+        Ok(result.rows_affected == 1)
+    }
+
     async fn release(&self, wallet_id: Uuid, currency: &Currency, amount_msat: u64) -> Result<bool, DatabaseError> {
         let amount = amount_msat as i64;
         let result = WalletBalance::update_many()

--- a/src/infra/database/sea_orm/uow.rs
+++ b/src/infra/database/sea_orm/uow.rs
@@ -114,10 +114,12 @@ impl PaymentUnitOfWork for SeaOrmPaymentUnitOfWork {
         let actual_msat = payment.amount_msat.saturating_add(payment.fee_msat.unwrap_or_default());
         if actual_msat > 0
             && !balance_repo
-                .debit(payment.wallet_id, &payment.currency, actual_msat)
+                .debit_confirmed(payment.wallet_id, &payment.currency, actual_msat)
                 .await?
         {
-            return Err(DataError::InsufficientFunds(actual_msat as f64).into());
+            return Err(
+                DataError::Inconsistency(format!("Wallet balance missing for settled payment {}", payment.id)).into(),
+            );
         }
         payment.reserved_amount = 0;
         // A successful settlement carries no failure reason, even when correcting

--- a/src/infra/database/sea_orm/uow_tests.rs
+++ b/src/infra/database/sea_orm/uow_tests.rs
@@ -247,6 +247,30 @@ async fn settle_adjusts_reserved_to_actual() {
 }
 
 #[tokio::test]
+async fn settle_records_confirmed_spend_when_actual_exceeds_reserved() {
+    let conn = connect().await;
+    let wallet = seed_wallet(&conn, 110_000).await;
+    // The node ultimately reports a 20k fee, exceeding the 10k admission buffer.
+    let mut payment = uow(&conn)
+        .reserve(pending_payment(wallet, 100_000, 20_000), 110_000)
+        .await
+        .expect("reserve");
+    assert_eq!(balance(&conn, wallet).await, (0, 110_000));
+
+    payment.status = PaymentStatus::Settled;
+    let settled = uow(&conn)
+        .settle(payment)
+        .await
+        .expect("confirmed settlement must not be stranded");
+
+    assert_eq!(settled.status, PaymentStatus::Settled);
+    assert_eq!(settled.reserved_amount, 0);
+    // The ledger records the confirmed 120k spend even though only 110k was held,
+    // surfacing the overspend as a negative available balance for reconciliation.
+    assert_eq!(balance(&conn, wallet).await, (-10_000, 0));
+}
+
+#[tokio::test]
 async fn duplicate_settle_does_not_double_debit() {
     let conn = connect().await;
     let wallet = seed_wallet(&conn, 200_000).await;


### PR DESCRIPTION
## Summary
- add a confirmed-debit wallet balance path for completed external spends
- use it during payment settlement so actual fees above the reservation still get recorded
- cover the overspent-reservation case with a real-DB Unit-of-Work regression

Fixes #290

## Validation
- `make fmt`
- `make test-persistence TEST=uow_tests`