### PR TITLE
fix(events): recover on-chain deposits from the un-advanced cursor after a failed write

### DIFF
--- a/src/infra/lightning/cln/cln_grpc_listener.rs
+++ b/src/infra/lightning/cln/cln_grpc_listener.rs
@@ -193,12 +193,8 @@ impl ClnGrpcListener {
                 continue;
             }
 
-            // Reprocess from the persisted cursor (`next_index`), NOT the index `wait` returned:
-            // `wait` returns the current tip, which after a reconnect or a burst can be far past
-            // the un-advanced cursor. Listing from the tip would silently skip — and permanently
-            // lose — every chainmove between the cursor and the tip. A failed deposit/withdrawal
-            // write propagates out (cursor not advanced) so the supervisor reconnects; listing
-            // from `next_index` then replays the un-advanced range idempotently.
+            // Replay from the persisted cursor, not the tip `wait` returned: listing from the tip
+            // would skip chainmoves between the cursor and the tip.
             let max_index = self.handle_chainmoves(next_index).await?;
             next_index = max_index.saturating_add(1);
             self.services
@@ -304,13 +300,13 @@ impl ClnGrpcListener {
                         continue;
                     };
 
-                    // Include spent outputs: when replaying an un-advanced cursor after a failed
-                    // write, the deposit's UTXO may already have been spent. `spent: false` would
-                    // return None, skip it, and still advance the cursor past it — losing the
-                    // credit. `block_height` (not spent-status) drives confirmation, so a
-                    // confirmed-then-spent deposit still credits. Matches the `synchronize` path,
-                    // which also lists with `spent: true`.
-                    let output = match self.wallet.get_output(&txid, Some(outnum), None, true).await {
+                    // Prefer the bounded unspent set; only on a miss fall back to the unbounded
+                    // spent-inclusive query, since a replayed deposit's UTXO may already be spent.
+                    let resolved = match self.wallet.get_output(&txid, Some(outnum), None, false).await {
+                        Ok(None) => self.wallet.get_output(&txid, Some(outnum), None, true).await,
+                        other => other,
+                    };
+                    let output = match resolved {
                         Ok(Some(output)) => output,
                         Ok(None) => {
                             trace!(%txid, outnum, "Output not found in wallet, skipping chainmove");

--- a/src/infra/lightning/cln/cln_grpc_listener.rs
+++ b/src/infra/lightning/cln/cln_grpc_listener.rs
@@ -304,7 +304,13 @@ impl ClnGrpcListener {
                         continue;
                     };
 
-                    let output = match self.wallet.get_output(&txid, Some(outnum), None, false).await {
+                    // Include spent outputs: when replaying an un-advanced cursor after a failed
+                    // write, the deposit's UTXO may already have been spent. `spent: false` would
+                    // return None, skip it, and still advance the cursor past it — losing the
+                    // credit. `block_height` (not spent-status) drives confirmation, so a
+                    // confirmed-then-spent deposit still credits. Matches the `synchronize` path,
+                    // which also lists with `spent: true`.
+                    let output = match self.wallet.get_output(&txid, Some(outnum), None, true).await {
                         Ok(Some(output)) => output,
                         Ok(None) => {
                             trace!(%txid, outnum, "Output not found in wallet, skipping chainmove");

--- a/src/infra/lightning/cln/cln_grpc_listener.rs
+++ b/src/infra/lightning/cln/cln_grpc_listener.rs
@@ -188,14 +188,18 @@ impl ClnGrpcListener {
                 .map_err(|e| LightningError::Listener(e.to_string()))?
                 .into_inner();
 
-            let Some(created_index) = response.created else {
+            if response.created.is_none() {
                 warn!("Chainmoves wait response missing created index");
                 continue;
-            };
+            }
 
-            // A failed deposit/withdrawal write propagates out (cursor not advanced) so the
-            // supervisor reconnects and reprocesses from the un-advanced CreatedIndex.
-            let max_index = self.handle_chainmoves(created_index).await?;
+            // Reprocess from the persisted cursor (`next_index`), NOT the index `wait` returned:
+            // `wait` returns the current tip, which after a reconnect or a burst can be far past
+            // the un-advanced cursor. Listing from the tip would silently skip — and permanently
+            // lose — every chainmove between the cursor and the tip. A failed deposit/withdrawal
+            // write propagates out (cursor not advanced) so the supervisor reconnects; listing
+            // from `next_index` then replays the un-advanced range idempotently.
+            let max_index = self.handle_chainmoves(next_index).await?;
             next_index = max_index.saturating_add(1);
             self.services
                 .system

--- a/src/infra/lightning/cln/cln_websocket_listener.rs
+++ b/src/infra/lightning/cln/cln_websocket_listener.rs
@@ -118,7 +118,7 @@ impl ClnWebsocketListener {
                             match serde_json::from_value::<InvoicePayment>(event.clone()) {
                                 Ok(invoice_payment) => {
                                     if let Err(err) = services.event.invoice_paid(invoice_payment.into()).await {
-                                        Self::stop_after_offchain_projection_error(
+                                        Self::stop_after_projection_error(
                                             &failure_tx,
                                             &client,
                                             "incoming_payment",
@@ -150,7 +150,7 @@ impl ClnWebsocketListener {
                                     }
 
                                     if let Err(err) = services.event.outgoing_payment(sendpay_success.into()).await {
-                                        Self::stop_after_offchain_projection_error(
+                                        Self::stop_after_projection_error(
                                             &failure_tx,
                                             &client,
                                             "outgoing_payment",
@@ -180,13 +180,8 @@ impl ClnWebsocketListener {
                                     }
 
                                     if let Err(err) = services.event.failed_payment(sendpay_failure.into()).await {
-                                        Self::stop_after_offchain_projection_error(
-                                            &failure_tx,
-                                            &client,
-                                            "failed_payment",
-                                            err,
-                                        )
-                                        .await;
+                                        Self::stop_after_projection_error(&failure_tx, &client, "failed_payment", err)
+                                            .await;
                                         return;
                                     }
                                 }
@@ -222,11 +217,16 @@ impl ClnWebsocketListener {
                                         };
 
                                         // Don't advance the cursor past a write we couldn't persist, or the
-                                        // deposit is lost. socket.io keeps the connection alive and re-syncs
-                                        // on the next chain event, reprocessing from the un-advanced cursor.
+                                        // deposit is lost. Unlike a busy chain, no further `coin_movement` is
+                                        // guaranteed to arrive to re-trigger this sync (e.g. the deposit is the
+                                        // last on-chain activity), so signal the supervisor to reconnect just
+                                        // like the off-chain events above: re-entering listen() re-runs
+                                        // bitcoin.sync() from the un-advanced cursor and reprocesses idempotently.
                                         if let Err(err) = result {
                                             error!(%err, "Failed to process onchain transaction; cursor not advanced");
                                             processed_all = false;
+                                            Self::stop_after_projection_error(&failure_tx, &client, "onchain", err)
+                                                .await;
                                             break;
                                         }
                                     }
@@ -241,7 +241,9 @@ impl ClnWebsocketListener {
                                     }
                                 }
                                 Err(err) => {
-                                    error!(%err, "Failed to synchronize onchain transactions");
+                                    error!(%err, "Failed to synchronize onchain transactions; reconnecting listener");
+                                    Self::stop_after_projection_error(&failure_tx, &client, "onchain_sync", err.into())
+                                        .await;
                                 }
                             }
                         }
@@ -253,7 +255,7 @@ impl ClnWebsocketListener {
         .boxed()
     }
 
-    async fn stop_after_offchain_projection_error(
+    async fn stop_after_projection_error(
         failure_tx: &mpsc::Sender<LightningError>,
         client: &Client,
         event_type: &'static str,
@@ -272,7 +274,7 @@ impl ClnWebsocketListener {
         err: ApplicationError,
     ) {
         let err = err.to_string();
-        error!(%err, event_type, "Failed to process Lightning off-chain event; reconnecting listener");
+        error!(%err, event_type, "Failed to process Lightning event; reconnecting listener");
 
         if let Err(send_err) = failure_tx.try_send(LightningError::EventProcessing(err)) {
             debug!(

--- a/src/infra/lightning/cln/cln_websocket_listener.rs
+++ b/src/infra/lightning/cln/cln_websocket_listener.rs
@@ -62,7 +62,7 @@ impl ClnWebsocketListener {
                 move || {
                     let services = services.clone();
                     async move {
-                        ClnWebsocketListener::resync_state_until_success(
+                        ClnWebsocketListener::resync(
                             &services,
                             "Core Lightning websocket reconnect",
                             reconnect_delay_min,
@@ -284,31 +284,11 @@ impl ClnWebsocketListener {
         }
     }
 
-    async fn resync_state(services: &AppServices, context: &'static str) -> Result<(), ApplicationError> {
-        // Replay off-chain (invoice/payment) AND on-chain (deposit/withdrawal) state. A
-        // transport-level socket.io reconnect does not re-enter listen(), so bitcoin.sync() must
-        // run here too; otherwise a deposit whose coin_movement arrived during the disconnect
-        // stays uncredited until the next chain event.
-        let (synced_invoices, synced_payments, synced_onchain) = tokio::try_join!(
-            services.invoice.sync(),
-            services.payment.sync(),
-            services.bitcoin.sync()
-        )?;
-
-        debug!(
-            context,
-            synced_invoices, synced_payments, synced_onchain, "Lightning state replayed after reconnect"
-        );
-
-        Ok(())
-    }
-
-    async fn resync_state_until_success(
-        services: &AppServices,
-        context: &'static str,
-        min_delay: Duration,
-        max_delay: Duration,
-    ) {
+    /// Replay off-chain (invoice/payment) AND on-chain (deposit/withdrawal) state, retrying with
+    /// backoff until it succeeds. A transport-level socket.io reconnect does not re-enter listen(),
+    /// so bitcoin.sync() must run here too; otherwise a deposit whose coin_movement arrived during
+    /// the disconnect stays uncredited until the next chain event.
+    async fn resync(services: &AppServices, context: &'static str, min_delay: Duration, max_delay: Duration) {
         let min_delay = if min_delay.is_zero() {
             Duration::from_millis(100)
         } else {
@@ -318,10 +298,20 @@ impl ClnWebsocketListener {
         let mut backoff = min_delay;
 
         loop {
-            match Self::resync_state(services, context).await {
-                Ok(()) => return,
+            match tokio::try_join!(
+                services.invoice.sync(),
+                services.payment.sync(),
+                services.bitcoin.sync()
+            ) {
+                Ok((synced_invoices, synced_payments, synced_onchain)) => {
+                    debug!(
+                        context,
+                        synced_invoices, synced_payments, synced_onchain, "State replayed after reconnect"
+                    );
+                    return;
+                }
                 Err(err) => {
-                    error!(%err, context, ?backoff, "Lightning state replay failed; retrying before reconnect");
+                    error!(%err, context, ?backoff, "State replay failed; retrying before reconnect");
                     sleep(backoff).await;
                     backoff = (backoff * 2).min(max_delay);
                 }
@@ -482,7 +472,7 @@ mod tests {
         builder.bitcoin.expect_sync().returning(|| Ok(0));
         let services = builder.build();
 
-        ClnWebsocketListener::resync_state_until_success(
+        ClnWebsocketListener::resync(
             &services,
             "test reconnect",
             Duration::from_millis(1),

--- a/src/infra/lightning/cln/cln_websocket_listener.rs
+++ b/src/infra/lightning/cln/cln_websocket_listener.rs
@@ -62,7 +62,7 @@ impl ClnWebsocketListener {
                 move || {
                     let services = services.clone();
                     async move {
-                        ClnWebsocketListener::sync_offchain_state_until_success(
+                        ClnWebsocketListener::resync_state_until_success(
                             &services,
                             "Core Lightning websocket reconnect",
                             reconnect_delay_min,
@@ -284,18 +284,26 @@ impl ClnWebsocketListener {
         }
     }
 
-    async fn sync_offchain_state(services: &AppServices, context: &'static str) -> Result<(), ApplicationError> {
-        let (synced_invoices, synced_payments) = tokio::try_join!(services.invoice.sync(), services.payment.sync())?;
+    async fn resync_state(services: &AppServices, context: &'static str) -> Result<(), ApplicationError> {
+        // Replay off-chain (invoice/payment) AND on-chain (deposit/withdrawal) state. A
+        // transport-level socket.io reconnect does not re-enter listen(), so bitcoin.sync() must
+        // run here too; otherwise a deposit whose coin_movement arrived during the disconnect
+        // stays uncredited until the next chain event.
+        let (synced_invoices, synced_payments, synced_onchain) = tokio::try_join!(
+            services.invoice.sync(),
+            services.payment.sync(),
+            services.bitcoin.sync()
+        )?;
 
         debug!(
             context,
-            synced_invoices, synced_payments, "Lightning off-chain state replayed"
+            synced_invoices, synced_payments, synced_onchain, "Lightning state replayed after reconnect"
         );
 
         Ok(())
     }
 
-    async fn sync_offchain_state_until_success(
+    async fn resync_state_until_success(
         services: &AppServices,
         context: &'static str,
         min_delay: Duration,
@@ -310,10 +318,10 @@ impl ClnWebsocketListener {
         let mut backoff = min_delay;
 
         loop {
-            match Self::sync_offchain_state(services, context).await {
+            match Self::resync_state(services, context).await {
                 Ok(()) => return,
                 Err(err) => {
-                    error!(%err, context, ?backoff, "Lightning off-chain replay failed; retrying before reconnect");
+                    error!(%err, context, ?backoff, "Lightning state replay failed; retrying before reconnect");
                     sleep(backoff).await;
                     backoff = (backoff * 2).min(max_delay);
                 }
@@ -470,9 +478,11 @@ mod tests {
             }
         });
         builder.payment.expect_sync().returning(|| Ok(1));
+        // The reconnect replay also re-syncs on-chain state (bitcoin.sync).
+        builder.bitcoin.expect_sync().returning(|| Ok(0));
         let services = builder.build();
 
-        ClnWebsocketListener::sync_offchain_state_until_success(
+        ClnWebsocketListener::resync_state_until_success(
             &services,
             "test reconnect",
             Duration::from_millis(1),

--- a/src/infra/lightning/cln/cln_websocket_listener.rs
+++ b/src/infra/lightning/cln/cln_websocket_listener.rs
@@ -216,12 +216,9 @@ impl ClnWebsocketListener {
                                             }
                                         };
 
-                                        // Don't advance the cursor past a write we couldn't persist, or the
-                                        // deposit is lost. Unlike a busy chain, no further `coin_movement` is
-                                        // guaranteed to arrive to re-trigger this sync (e.g. the deposit is the
-                                        // last on-chain activity), so signal the supervisor to reconnect just
-                                        // like the off-chain events above: re-entering listen() re-runs
-                                        // bitcoin.sync() from the un-advanced cursor and reprocesses idempotently.
+                                        // Cursor not advanced past a failed write; signal a reconnect (like
+                                        // the off-chain events) so listen() re-runs bitcoin.sync() from the
+                                        // un-advanced cursor and reprocesses idempotently.
                                         if let Err(err) = result {
                                             error!(%err, "Failed to process onchain transaction; cursor not advanced");
                                             processed_all = false;
@@ -284,10 +281,9 @@ impl ClnWebsocketListener {
         }
     }
 
-    /// Replay off-chain (invoice/payment) AND on-chain (deposit/withdrawal) state, retrying with
-    /// backoff until it succeeds. A transport-level socket.io reconnect does not re-enter listen(),
-    /// so bitcoin.sync() must run here too; otherwise a deposit whose coin_movement arrived during
-    /// the disconnect stays uncredited until the next chain event.
+    /// Replay off-chain and on-chain state, retrying with backoff until it succeeds. A transport
+    /// reconnect does not re-enter listen(), so bitcoin.sync() must run here too, not only at
+    /// listen() startup.
     async fn resync(services: &AppServices, context: &'static str, min_delay: Duration, max_delay: Duration) {
         let min_delay = if min_delay.is_zero() {
             Duration::from_millis(100)


### PR DESCRIPTION
## Problem

Integration tests flake with `timed out after 180s waiting for: on-chain deposit credited`, on both CLN transports:

- `integration (cln_rest, sqlite)` — [run 28623450454](https://github.com/bitcoin-numeraire/swissknife/actions/runs/28623450454), test `suites::wallets::list_overviews::includes_aggregated_wallet_activity`
- `integration (cln_grpc, sqlite)` — [run 28702192207](https://github.com/bitcoin-numeraire/swissknife/actions/runs/28702192207/job/85121928678), test `suites::lightning::failure::an_unroutable_payment_fails_and_releases_the_reservation`

The `database is locked` in the logs is only the *trigger*: under the shared-instance itests (`max_connections = 20` on one SQLite file), a concurrent write occasionally exceeds `busy_timeout`, and an on-chain deposit projection write fails. That is expected and transient. The real bug is that a single such failure permanently wedges the affected deposit (and, on a shared instance, whatever test happens to be waiting on it — hence the failing test varies).

The intended contract, already documented in the listeners, is: **on a failed on-chain write, don't advance the cursor, and reprocess from the un-advanced cursor.** Two listeners were violating it in two different ways.

## Root cause

**CLN websocket** — the `coin_movement` handler swallowed on-chain write errors (logged `cursor not advanced` and `break`), unlike the off-chain paths which signal a listener failure. `bitcoin.sync()` only re-runs at the top of `listen()`, and `listen()` only returns when a failure is signalled. So an on-chain error never reconnects and never re-syncs; recovery depended on a *future* `coin_movement` that, when the deposit is the last on-chain activity, never arrives. (Confirmed in the cln_rest artifact: one lock error, then no `Onchain deposit processed` and ~180s of silence to shutdown.)

**CLN gRPC** — errors *do* propagate and the supervisor reconnects, but `listen_chainmoves` reprocessed from `created_index` (the tip returned by CLN `wait`) instead of the persisted cursor `next_index`. On reconnect after a burst, `wait` returns the current tip, so listing from it **silently skips every chainmove between the un-advanced cursor and the tip** — permanently, since the cursor then jumps past them. (Confirmed in the cln_grpc artifact: the supervisor reconnected, later deposits were credited, but the waited-for deposit in the skipped range never was.)

**LND (gRPC + REST)** — already correct: on-chain errors propagate out of `listen()`, and `listen_transactions` re-runs `bitcoin.sync()` from the un-advanced cursor on reconnect. Both passed CI. No change.

## Fix

- **cln_websocket_listener**: route on-chain projection write errors and `wallet.synchronize()` errors through the same `stop_after_projection_error` path as the off-chain events, so the supervisor reconnects and re-runs `bitcoin.sync()` from the un-advanced cursor. Renamed `stop_after_offchain_projection_error` → `stop_after_projection_error` and de-scoped the log message (it now covers on-chain too).
- **cln_grpc_listener**: reprocess chainmoves from the persisted cursor (`next_index`), not the tip `wait` returned.
- **cln_websocket_listener (transport reconnect)**: the socket.io *internal* reconnect (`on_reconnect`) replayed only off-chain state and never re-enters `listen()`, so `bitcoin.sync()` was skipped — a deposit whose `coin_movement` arrived during the disconnect stayed uncredited until the next chain event. The reconnect replay (`resync_state`) now re-syncs on-chain state too. (This path is unique to the websocket transport; cln_grpc/LND reconnect through the supervisor, which already re-runs `bitcoin.sync()`.)

## Safety

Reprocessing the un-advanced range is idempotent — `project_onchain_deposit` upserts the output by outpoint and credits the balance only when `invoice.settle` wins the pending→settled transition, so replays don't double-credit. Reconnects are bounded by the supervisor's existing 1s→60s exponential backoff, and the `channel(1)` + `try_send` de-dupes repeat signals.

## Testing

`cargo fmt`, `make lint` (clippy pedantic, `-D warnings`), and the `reconnect_replay_retries_until_sync_succeeds` unit test (updated to cover the on-chain sync in the reconnect replay) pass. The integration suites in CI are the behavioural regression coverage (they reproduced the hang on both CLN transports); the listener callbacks themselves require a live CLN node and aren't unit-testable in isolation.

## Not included (optional follow-up)

Reducing the SQLite lock at the source (e.g. a split reader/writer pool, or `BEGIN IMMEDIATE` on write transactions) would avoid the transient `database is locked` entirely. With this PR the listeners *recover* from it (~1s), so the flake is resolved; the lock reduction is a latency/efficiency optimization, not a correctness fix.