### PR TITLE
feat: cut over lightning addresses to account routes

### DIFF
--- a/crates/migration/src/lib.rs
+++ b/crates/migration/src/lib.rs
@@ -25,6 +25,7 @@ mod m20260704_000007_backfill_oauth2_accounts;
 mod m20260704_000008_wallet_account_asset_schema;
 mod m20260704_000009_backfill_mainnet_wallet_accounts;
 mod m20260704_000010_drop_api_key_user_id_fk;
+mod m20260704_000011_ln_address_account_routes;
 
 pub struct Migrator;
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260704_000008_wallet_account_asset_schema::Migration),
             Box::new(m20260704_000009_backfill_mainnet_wallet_accounts::Migration),
             Box::new(m20260704_000010_drop_api_key_user_id_fk::Migration),
+            Box::new(m20260704_000011_ln_address_account_routes::Migration),
         ]
     }
 }
@@ -69,6 +71,8 @@ mod tests {
 
     const MIGRATIONS_BEFORE_IDENTITY_ASSETS: u32 = 16;
     const IDENTITY_ASSET_MIGRATION_COUNT: u32 = 9;
+    const MIGRATIONS_BEFORE_LN_ADDRESS_ACCOUNT_ROUTES: u32 =
+        MIGRATIONS_BEFORE_IDENTITY_ASSETS + IDENTITY_ASSET_MIGRATION_COUNT;
 
     async fn sqlite() -> sea_orm::DatabaseConnection {
         Database::connect("sqlite::memory:")
@@ -267,6 +271,81 @@ mod tests {
             )
             .await,
             0
+        );
+    }
+
+    #[async_std::test]
+    async fn ln_address_account_routes_backfill_from_receiving_wallets() {
+        let conn = sqlite().await;
+
+        Migrator::up(&conn, Some(MIGRATIONS_BEFORE_LN_ADDRESS_ACCOUNT_ROUTES))
+            .await
+            .expect("run migrations before ln address account routes");
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            r#"
+            INSERT INTO wallet (
+                id,
+                account_id,
+                asset_id,
+                available_amount,
+                reserved_amount,
+                created_at
+            )
+            VALUES (
+                X'11111111111141118111111111111111',
+                X'22222222222242228222222222222222',
+                X'33333333333343338333333333333333',
+                0,
+                0,
+                CURRENT_TIMESTAMP
+            )
+            "#
+            .to_string(),
+        ))
+        .await
+        .expect("insert asset wallet");
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            r#"
+            INSERT INTO ln_address (
+                id,
+                wallet_id,
+                username,
+                active,
+                allows_nostr,
+                created_at
+            )
+            VALUES (
+                X'44444444444444448444444444444444',
+                X'11111111111141118111111111111111',
+                'alice',
+                1,
+                0,
+                CURRENT_TIMESTAMP
+            )
+            "#
+            .to_string(),
+        ))
+        .await
+        .expect("insert legacy ln address");
+
+        Migrator::up(&conn, None)
+            .await
+            .expect("run ln address account routes migration");
+
+        assert_eq!(
+            count(
+                &conn,
+                r#"
+                SELECT COUNT(*) AS count
+                FROM ln_address
+                WHERE account_id = X'22222222222242228222222222222222'
+                  AND wallet_id = X'11111111111141118111111111111111'
+                "#,
+            )
+            .await,
+            1
         );
     }
 }

--- a/crates/migration/src/m20240420_2_ln_address_table.rs
+++ b/crates/migration/src/m20240420_2_ln_address_table.rs
@@ -49,6 +49,7 @@ pub(crate) enum LnAddress {
     Table,
     Id,
     WalletId,
+    AccountId,
     Username,
     Active,
     CreatedAt,

--- a/crates/migration/src/m20260704_000011_ln_address_account_routes.rs
+++ b/crates/migration/src/m20260704_000011_ln_address_account_routes.rs
@@ -1,0 +1,98 @@
+use sea_orm::{ConnectionTrait, Statement};
+use sea_orm_migration::{prelude::*, schema::*};
+
+use crate::{m20240420_1_wallet_table::Wallet, m20240420_2_ln_address_table::LnAddress};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(LnAddress::Table)
+                    .add_column(uuid_null(LnAddress::AccountId))
+                    .to_owned(),
+            )
+            .await?;
+
+        let db = manager.get_connection();
+        let backend = db.get_database_backend();
+        db.execute(Statement::from_string(
+            backend,
+            format!(
+                r#"
+                UPDATE {ln_address}
+                SET {account_id} = (
+                    SELECT {wallet}.{wallet_account_id}
+                    FROM {wallet}
+                    WHERE {wallet}.{wallet_id} = {ln_address}.{ln_address_wallet_id}
+                )
+                WHERE {account_id} IS NULL
+                "#,
+                ln_address = LnAddress::Table.to_string(),
+                account_id = LnAddress::AccountId.to_string(),
+                wallet = Wallet::Table.to_string(),
+                wallet_account_id = Wallet::AccountId.to_string(),
+                wallet_id = Wallet::Id.to_string(),
+                ln_address_wallet_id = LnAddress::WalletId.to_string(),
+            ),
+        ))
+        .await?;
+
+        let missing = db
+            .query_one(Statement::from_string(
+                backend,
+                format!(
+                    r#"
+                    SELECT COUNT(*) AS count
+                    FROM {ln_address}
+                    WHERE {account_id} IS NULL
+                    "#,
+                    ln_address = LnAddress::Table.to_string(),
+                    account_id = LnAddress::AccountId.to_string(),
+                ),
+            ))
+            .await?
+            .ok_or_else(|| DbErr::Migration("ln_address account backfill count returned no row".to_string()))?
+            .try_get::<i64>("", "count")?;
+        if missing > 0 {
+            return Err(DbErr::Migration(format!(
+                "{missing} lightning address rows could not be mapped to an account"
+            )));
+        }
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_ln_address_account")
+                    .table(LnAddress::Table)
+                    .col(LnAddress::AccountId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_ln_address_account")
+                    .table(LnAddress::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(LnAddress::Table)
+                    .drop_column(LnAddress::AccountId)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/crates/swissknife-types/src/ln_address.rs
+++ b/crates/swissknife-types/src/ln_address.rs
@@ -12,7 +12,9 @@ use crate::OrderDirection;
 pub struct LnAddress {
     /// Internal ID
     pub id: Uuid,
-    /// Wallet ID
+    /// Owning account ID
+    pub account_id: Uuid,
+    /// Wallet that receives invoices generated for this address
     pub wallet_id: Uuid,
     /// Username
     pub username: String,
@@ -34,8 +36,8 @@ pub struct LnAddress {
 /// Register Lightning Address Request
 #[derive(Debug, Deserialize, ToSchema, Serialize)]
 pub struct RegisterLnAddressRequest {
-    /// Wallet ID. Will be populated with your own ID by default
-    pub wallet_id: Option<Uuid>,
+    /// Owning account ID. Required for admin routes; user-scoped routes use the authenticated account.
+    pub account_id: Option<Uuid>,
 
     /// Username such as `username@domain`
     pub username: String,
@@ -80,7 +82,9 @@ pub struct LnAddressFilter {
     pub offset: Option<u64>,
     /// List of IDs
     pub ids: Option<Vec<Uuid>>,
-    /// wallet ID. Automatically populated with your ID
+    /// Owning account ID
+    pub account_id: Option<Uuid>,
+    /// Receiving wallet ID
     pub wallet_id: Option<Uuid>,
     /// Username
     pub username: Option<String>,

--- a/dashboard/src/components/ln-address/register-ln-address-form.tsx
+++ b/dashboard/src/components/ln-address/register-ln-address-form.tsx
@@ -17,8 +17,6 @@ import { registerAddress, registerWalletAddress } from 'src/lib/swissknife';
 import { toast } from 'src/components/snackbar';
 import { Form, RHFTextField } from 'src/components/hook-form';
 
-import { WalletSelectDropdown } from '../wallet';
-
 // ----------------------------------------------------------------------
 
 type Props = {
@@ -33,15 +31,17 @@ export function RegisterLnAddressForm({ onSuccess, isAdmin }: Props) {
     resolver: zodResolver(zRegisterLnAddressRequest),
     defaultValues: {
       username: '',
-      wallet_id: null,
+      account_id: null,
     },
   });
 
   const {
     reset,
     handleSubmit,
+    watch,
     formState: { isSubmitting, isValid },
   } = methods;
+  const accountId = watch('account_id');
 
   const onSubmit = handleSubmit(async (data) => {
     const body = data as RegisterLnAddressRequest;
@@ -77,7 +77,13 @@ export function RegisterLnAddressForm({ onSuccess, isAdmin }: Props) {
           }}
         />
 
-        {isAdmin && <WalletSelectDropdown />}
+        {isAdmin && (
+          <RHFTextField
+            variant="outlined"
+            name="account_id"
+            label={t('register_wallet.account_id')}
+          />
+        )}
 
         <Button
           type="submit"
@@ -85,7 +91,7 @@ export function RegisterLnAddressForm({ onSuccess, isAdmin }: Props) {
           color="inherit"
           size="large"
           loading={isSubmitting}
-          disabled={!isValid}
+          disabled={!isValid || (isAdmin && !accountId)}
         >
           {t('register')}
         </Button>

--- a/dashboard/src/components/wallet/select-wallet.tsx
+++ b/dashboard/src/components/wallet/select-wallet.tsx
@@ -1,5 +1,7 @@
 import type { Wallet } from 'src/lib/swissknife';
 
+import { useFormContext } from 'react-hook-form';
+
 import { Box } from '@mui/material';
 
 import { displayLnAddress } from 'src/utils/lnurl';
@@ -13,6 +15,7 @@ import { RHFAutocomplete } from 'src/components/hook-form';
 
 type WalletSelectProps = {
   name?: 'account_id' | 'wallet_id';
+  linkedAccountName?: 'account_id';
 };
 
 function walletFieldValue(wallet: Wallet, name: WalletSelectProps['name']) {
@@ -25,8 +28,9 @@ function walletOptionLabel(wallet: Wallet) {
   return wallet.label ?? wallet.account_id;
 }
 
-export function WalletSelectDropdown({ name = 'wallet_id' }: WalletSelectProps) {
+export function WalletSelectDropdown({ name = 'wallet_id', linkedAccountName }: WalletSelectProps) {
   const { wallets, walletsError, walletsLoading } = useListWallets();
+  const { setValue } = useFormContext();
 
   if (walletsError) {
     handleActionError(walletsError);
@@ -46,6 +50,13 @@ export function WalletSelectDropdown({ name = 'wallet_id' }: WalletSelectProps) 
           const wallet = wallets.find((item) => walletFieldValue(item, name) === option);
 
           return wallet ? walletOptionLabel(wallet) : option;
+        }}
+        onChange={(_, newValue) => {
+          setValue(name, newValue, { shouldValidate: true });
+          if (linkedAccountName) {
+            const wallet = wallets.find((item) => walletFieldValue(item, name) === newValue);
+            setValue(linkedAccountName, wallet?.account_id ?? null, { shouldValidate: true });
+          }
         }}
       />
     )

--- a/dashboard/src/lib/openapi.json
+++ b/dashboard/src/lib/openapi.json
@@ -2244,9 +2244,22 @@
             }
           },
           {
+            "name": "account_id",
+            "in": "query",
+            "description": "Owning account ID",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            }
+          },
+          {
             "name": "wallet_id",
             "in": "query",
-            "description": "wallet ID. Automatically populated with your ID",
+            "description": "Receiving wallet ID",
             "required": false,
             "schema": {
               "type": [
@@ -2488,9 +2501,22 @@
             }
           },
           {
+            "name": "account_id",
+            "in": "query",
+            "description": "Owning account ID",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            }
+          },
+          {
             "name": "wallet_id",
             "in": "query",
-            "description": "wallet ID. Automatically populated with your ID",
+            "description": "Receiving wallet ID",
             "required": false,
             "schema": {
               "type": [
@@ -6776,6 +6802,7 @@
         "description": "Lightning Address",
         "required": [
           "id",
+          "account_id",
           "wallet_id",
           "username",
           "active",
@@ -6783,6 +6810,11 @@
           "created_at"
         ],
         "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Owning account ID"
+          },
           "active": {
             "type": "boolean",
             "description": "Active status. Inactive addresses cannot receive funds"
@@ -6824,7 +6856,7 @@
           "wallet_id": {
             "type": "string",
             "format": "uuid",
-            "description": "Wallet ID"
+            "description": "Wallet that receives invoices generated for this address"
           }
         }
       },
@@ -7327,6 +7359,14 @@
           "username"
         ],
         "properties": {
+          "account_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Owning account ID. Required for admin routes; user-scoped routes use the authenticated account."
+          },
           "allows_nostr": {
             "type": "boolean",
             "description": "Nostr enabled"
@@ -7342,14 +7382,6 @@
           "username": {
             "type": "string",
             "description": "Username such as `username@domain`"
-          },
-          "wallet_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "uuid",
-            "description": "Wallet ID. Will be populated with your own ID by default"
           }
         }
       },

--- a/dashboard/src/lib/swissknife/types.gen.ts
+++ b/dashboard/src/lib/swissknife/types.gen.ts
@@ -512,6 +512,10 @@ export type Ledger = (typeof Ledger)[keyof typeof Ledger];
  */
 export type LnAddress = {
   /**
+   * Owning account ID
+   */
+  account_id: string;
+  /**
    * Active status. Inactive addresses cannot receive funds
    */
   active: boolean;
@@ -540,7 +544,7 @@ export type LnAddress = {
    */
   username: string;
   /**
-   * Wallet ID
+   * Wallet that receives invoices generated for this address
    */
   wallet_id: string;
 };
@@ -850,6 +854,10 @@ export type Protocol = (typeof Protocol)[keyof typeof Protocol];
  */
 export type RegisterLnAddressRequest = {
   /**
+   * Owning account ID. Required for admin routes; user-scoped routes use the authenticated account.
+   */
+  account_id?: string | null;
+  /**
    * Nostr enabled
    */
   allows_nostr?: boolean;
@@ -861,10 +869,6 @@ export type RegisterLnAddressRequest = {
    * Username such as `username@domain`
    */
   username: string;
-  /**
-   * Wallet ID. Will be populated with your own ID by default
-   */
-  wallet_id?: string | null;
 };
 
 /**
@@ -2091,7 +2095,11 @@ export type DeleteAddressesData = {
      */
     ids?: Array<string> | null;
     /**
-     * wallet ID. Automatically populated with your ID
+     * Owning account ID
+     */
+    account_id?: string | null;
+    /**
+     * Receiving wallet ID
      */
     wallet_id?: string | null;
     /**
@@ -2157,7 +2165,11 @@ export type ListAddressesData = {
      */
     ids?: Array<string> | null;
     /**
-     * wallet ID. Automatically populated with your ID
+     * Owning account ID
+     */
+    account_id?: string | null;
+    /**
+     * Receiving wallet ID
      */
     wallet_id?: string | null;
     /**

--- a/dashboard/src/lib/swissknife/zod.gen.ts
+++ b/dashboard/src/lib/swissknife/zod.gen.ts
@@ -175,6 +175,7 @@ export const zLedger = z.enum(['Lightning', 'Internal', 'Onchain']);
  * Lightning Address
  */
 export const zLnAddress = z.object({
+  account_id: z.uuid(),
   active: z.boolean(),
   allows_nostr: z.boolean(),
   created_at: z.iso.datetime(),
@@ -441,10 +442,10 @@ export const zAsset = z.object({
  * Register Lightning Address Request
  */
 export const zRegisterLnAddressRequest = z.object({
+  account_id: z.uuid().nullish(),
   allows_nostr: z.boolean().optional(),
   nostr_pubkey: z.string().nullish(),
   username: z.string(),
-  wallet_id: z.uuid().nullish(),
 });
 
 /**
@@ -864,6 +865,7 @@ export const zDeleteAddressesQuery = z.object({
     })
     .nullish(),
   ids: z.array(z.uuid()).nullish(),
+  account_id: z.uuid().nullish(),
   wallet_id: z.uuid().nullish(),
   username: z.string().nullish(),
   active: z.boolean().nullish(),
@@ -896,6 +898,7 @@ export const zListAddressesQuery = z.object({
     })
     .nullish(),
   ids: z.array(z.uuid()).nullish(),
+  account_id: z.uuid().nullish(),
   wallet_id: z.uuid().nullish(),
   username: z.string().nullish(),
   active: z.boolean().nullish(),

--- a/dashboard/src/sections/ln-address/ln-address-details.tsx
+++ b/dashboard/src/sections/ln-address/ln-address-details.tsx
@@ -173,21 +173,7 @@ export function LnAddressDetails({ lnAddress, isAdmin }: Props) {
                   <Grid size={{ xs: 12, sm: 4 }}>
                     <MetricTile
                       title={t('ln_address_details.belongs_to')}
-                      value={
-                        isAdmin ? (
-                          <Link
-                            component={RouterLink}
-                            href={paths.account(lnAddress.wallet_id)}
-                            color="inherit"
-                            underline="hover"
-                            sx={{ wordBreak: 'break-word' }}
-                          >
-                            {truncateText(lnAddress.wallet_id, 15)}
-                          </Link>
-                        ) : (
-                          truncateText(lnAddress.wallet_id, 15)
-                        )
-                      }
+                      value={truncateText(lnAddress.account_id, 15)}
                     />
                   </Grid>
                 </Grid>
@@ -284,6 +270,12 @@ export function LnAddressDetails({ lnAddress, isAdmin }: Props) {
               />
               <DetailRow
                 label={t('ln_address_details.belongs_to')}
+                value={lnAddress.account_id}
+                copyValue={lnAddress.account_id}
+                mono
+              />
+              <DetailRow
+                label={t('ln_address_details.wallet_id')}
                 value={
                   isAdmin ? (
                     <Link

--- a/dashboard/src/sections/ln-address/ln-address-list.tsx
+++ b/dashboard/src/sections/ln-address/ln-address-list.tsx
@@ -372,6 +372,7 @@ function applyFilter({
   if (name) {
     inputData = inputData.filter(
       (addr) =>
+        addr.account_id.toLowerCase().indexOf(name.toLowerCase()) !== -1 ||
         addr.wallet_id.toLowerCase().indexOf(name.toLowerCase()) !== -1 ||
         addr.username.toLowerCase().indexOf(name.toLowerCase()) !== -1 ||
         addr.id.toLowerCase().indexOf(name.toLowerCase()) !== -1

--- a/docs/adr/0002-identity-assets-wallet-model.md
+++ b/docs/adr/0002-identity-assets-wallet-model.md
@@ -201,7 +201,7 @@ wallet.available_amount/reserved_amount are integers in 10^-decimals of one asse
 ### 5. Addresses and API keys move to account-aware ownership
 
 - `btc_address.wallet_id` remains wallet-scoped. A Bitcoin deposit address belongs to a specific native-BTC wallet on a specific network.
-- `ln_address` becomes identity-owned with an explicit receiving wallet route. Add `account_id` and rename the existing `wallet_id` to `receive_wallet_id`, required on address creation. The receive wallet must belong to the same account and must be a Lightning-compatible BTC asset. This keeps one username as an identity-level handle while every generated invoice still lands in a concrete wallet.
+- `ln_address` becomes identity-owned. Add `account_id` while keeping the existing `wallet_id` column as the concrete wallet that receives generated invoices. Address creation should not accept an arbitrary wallet; the service resolves the account's native BTC wallet for the active Bitcoin network and fails if it does not exist. This keeps one username as an identity-level handle while every generated invoice still lands in a concrete wallet compatible with the running node.
 - `api_key` should reference `account.id`, not `wallet.user_id`.
 - Issue #115's "master key" should be treated as an account/keyring feature, not a side effect of the old wallet-as-user table. A future key model can derive wallet-specific keys from account-level material, but this remodel should not silently create or migrate private key material.
 
@@ -361,8 +361,8 @@ The migration must support SQLite and Postgres and must preserve existing wallet
 1. Update `payment.wallet_id` by joining `(old wallet_id, payment.currency)` through the migration mapping.
 2. Update `invoice.wallet_id` by joining `(old wallet_id, invoice.currency)` through the migration mapping.
 3. Move `btc_address.wallet_id` to the account's native BTC wallet for the active Bitcoin network. Existing `btc_address` rows do not carry their own currency, so this must use deployment/network configuration or a documented manual fallback.
-4. Add `ln_address.account_id` and rename or replace the old `wallet_id` column with `receive_wallet_id`.
-5. Add/validate constraints so the receiving wallet belongs to the same account. If a cross-table check cannot be expressed portably in SQL for SQLite and Postgres, enforce it in service/repository code and cover it with integration tests.
+4. Add `ln_address.account_id` and keep the old `wallet_id` column as the invoice-receiving wallet route.
+5. Resolve the receiving wallet from `(account_id, active native BTC asset)` in service code and cover it with integration tests. This avoids accepting mismatched wallets or networks at the API boundary.
 
 ### Phase 4: Cut over services
 
@@ -371,8 +371,7 @@ The migration must support SQLite and Postgres and must preserve existing wallet
 
    ```rust
    async fn find_by_account_and_asset(account_id: Uuid, asset_id: Uuid) -> Result<Option<Wallet>, DatabaseError>;
-   async fn find_owned(wallet_id: Uuid, account_id: Uuid) -> Result<Option<Wallet>, DatabaseError>;
-   async fn ensure_for_account_asset(account_id: Uuid, asset_id: Uuid) -> Result<Wallet, DatabaseError>;
+   async fn upsert(account_id: Uuid, asset_id: Uuid) -> Result<Wallet, DatabaseError>;
    ```
 
 3. Move reserve/debit/credit operations from `wallet_balance` to `wallet` conditional updates:

--- a/src/application/composition/services.rs
+++ b/src/application/composition/services.rs
@@ -72,7 +72,7 @@ impl AppServices {
             domain,
             host,
         );
-        let ln_address = LnAddressService::new(store.clone());
+        let ln_address = LnAddressService::new(store.clone(), bitcoin_wallet.network());
         let wallet = WalletService::new(store.clone());
         let auth = AuthService::new(
             jwt_authenticator,

--- a/src/domains/ln_address/ln_address_handler.rs
+++ b/src/domains/ln_address/ln_address_handler.rs
@@ -18,7 +18,7 @@ use crate::{
             BAD_REQUEST_EXAMPLE, FORBIDDEN_EXAMPLE, INTERNAL_EXAMPLE, NOT_FOUND_EXAMPLE, UNAUTHORIZED_EXAMPLE,
             UNPROCESSABLE_EXAMPLE,
         },
-        errors::ApplicationError,
+        errors::{ApplicationError, DataError},
     },
     domains::user::{Permission, User},
     infra::axum::{Json, Path},
@@ -75,7 +75,9 @@ async fn register_address(
     let ln_address = services
         .ln_address
         .register(
-            payload.wallet_id.unwrap_or(user.wallet_id),
+            payload
+                .account_id
+                .ok_or_else(|| DataError::Malformed("account_id is required.".to_string()))?,
             payload.username,
             payload.allows_nostr,
             payload.nostr_pubkey,
@@ -242,15 +244,16 @@ mod tests {
 
     fn user(permissions: Vec<Permission>) -> User {
         User {
+            account_id: Uuid::new_v4(),
             wallet_id: Uuid::new_v4(),
             permissions,
-            ..Default::default()
         }
     }
 
-    fn ln_address(wallet_id: Uuid) -> LnAddress {
+    fn ln_address(account_id: Uuid, wallet_id: Uuid) -> LnAddress {
         LnAddress {
             id: Uuid::new_v4(),
+            account_id,
             wallet_id,
             username: "alice".to_string(),
             active: true,
@@ -261,9 +264,9 @@ mod tests {
         }
     }
 
-    fn register_request(wallet_id: Option<Uuid>) -> RegisterLnAddressRequest {
+    fn register_request(account_id: Option<Uuid>) -> RegisterLnAddressRequest {
         RegisterLnAddressRequest {
-            wallet_id,
+            account_id,
             username: "alice".to_string(),
             allows_nostr: false,
             nostr_pubkey: None,
@@ -280,31 +283,57 @@ mod tests {
             async fn is_forbidden_and_does_not_call_the_service() {
                 let services = MockAppServicesBuilder::new().build();
 
-                let result =
-                    register_address(State(Arc::new(services)), user(vec![]), Json(register_request(None))).await;
+                let result = register_address(
+                    State(Arc::new(services)),
+                    user(vec![]),
+                    Json(register_request(Some(Uuid::new_v4()))),
+                )
+                .await;
 
                 assert!(matches!(result, Err(ApplicationError::Authorization(_))));
             }
         }
 
-        mod when_wallet_id_is_omitted {
+        mod when_account_id_is_missing {
             use super::*;
 
             #[tokio::test]
-            async fn defaults_to_the_authenticated_users_wallet() {
+            async fn returns_bad_request_without_calling_the_service() {
                 let caller = user(vec![Permission::WriteLnAddress]);
-                let expected_wallet = caller.wallet_id;
+
+                let result = register_address(
+                    State(Arc::new(MockAppServicesBuilder::new().build())),
+                    caller,
+                    Json(register_request(None)),
+                )
+                .await;
+
+                assert!(matches!(result, Err(ApplicationError::Data(DataError::Malformed(_)))));
+            }
+        }
+
+        mod with_an_explicit_account {
+            use super::*;
+
+            #[tokio::test]
+            async fn passes_the_account_to_the_service() {
+                let account_id = Uuid::new_v4();
+                let wallet_id = Uuid::new_v4();
 
                 let mut builder = MockAppServicesBuilder::new();
                 builder
                     .ln_address
                     .expect_register()
-                    .withf(move |wallet_id, _, _, _| *wallet_id == expected_wallet)
+                    .withf(move |account, username, _, _| *account == account_id && username == "alice")
                     .times(1)
-                    .returning(|wallet_id, _, _, _| Ok(ln_address(wallet_id)));
+                    .returning(move |account, _, _, _| Ok(ln_address(account, wallet_id)));
 
-                let result =
-                    register_address(State(Arc::new(builder.build())), caller, Json(register_request(None))).await;
+                let result = register_address(
+                    State(Arc::new(builder.build())),
+                    user(vec![Permission::WriteLnAddress]),
+                    Json(register_request(Some(account_id))),
+                )
+                .await;
 
                 assert!(result.is_ok());
             }

--- a/src/domains/ln_address/ln_address_repository.rs
+++ b/src/domains/ln_address/ln_address_repository.rs
@@ -12,10 +12,11 @@ use crate::{
 pub trait LnAddressRepository: Send + Sync {
     async fn find(&self, id: Uuid) -> Result<Option<LnAddress>, DatabaseError>;
     async fn find_by_username(&self, username: &str) -> Result<Option<LnAddress>, DatabaseError>;
-    async fn find_by_wallet_id(&self, wallet_id: Uuid) -> Result<Option<LnAddress>, DatabaseError>;
+    async fn find_by_account_id(&self, account_id: Uuid) -> Result<Option<LnAddress>, DatabaseError>;
     async fn find_many(&self, filter: LnAddressFilter) -> Result<Vec<LnAddress>, DatabaseError>;
     async fn insert(
         &self,
+        account_id: Uuid,
         wallet_id: Uuid,
         username: &str,
         allows_nostr: bool,

--- a/src/domains/ln_address/ln_address_service.rs
+++ b/src/domains/ln_address/ln_address_service.rs
@@ -11,7 +11,10 @@ use crate::{
         composition::AppStore,
         errors::{ApplicationError, DataError},
     },
-    domains::ln_address::{LnAddress, LnAddressFilter},
+    domains::{
+        bitcoin::BtcNetwork,
+        ln_address::{LnAddress, LnAddressFilter},
+    },
 };
 
 use super::LnAddressUseCases;
@@ -21,11 +24,12 @@ const MAX_USERNAME_LENGTH: usize = 64;
 
 pub struct LnAddressService {
     store: AppStore,
+    network: BtcNetwork,
 }
 
 impl LnAddressService {
-    pub fn new(store: AppStore) -> Self {
-        LnAddressService { store }
+    pub fn new(store: AppStore, network: BtcNetwork) -> Self {
+        LnAddressService { store, network }
     }
 }
 
@@ -33,31 +37,48 @@ impl LnAddressService {
 impl LnAddressUseCases for LnAddressService {
     async fn register(
         &self,
-        wallet_id: Uuid,
+        account_id: Uuid,
         mut username: String,
         allows_nostr: bool,
         nostr_pubkey: Option<PublicKey>,
     ) -> Result<LnAddress, ApplicationError> {
-        debug!(%wallet_id, username, "Registering lightning address");
+        debug!(%account_id, username, network = %self.network, "Registering lightning address");
 
         username = username.to_lowercase();
         validate_username(username.as_str())?;
 
-        if self.store.ln_address.find_by_wallet_id(wallet_id).await?.is_some() {
-            return Err(DataError::Conflict("Duplicate User ID.".to_string()).into());
+        if self.store.ln_address.find_by_account_id(account_id).await?.is_some() {
+            return Err(DataError::Conflict("Account already has a lightning address.".to_string()).into());
         }
 
         if self.store.ln_address.find_by_username(&username).await?.is_some() {
             return Err(DataError::Conflict("Duplicate username.".to_string()).into());
         }
 
+        let asset = self
+            .store
+            .asset
+            .find_native_btc_by_network(self.network)
+            .await?
+            .ok_or_else(|| DataError::Inconsistency("Native BTC asset is not configured.".to_string()))?;
+        let wallet = self
+            .store
+            .wallet
+            .find_by_account_and_asset(account_id, asset.id)
+            .await?
+            .ok_or_else(|| {
+                DataError::Validation("Account has no native BTC wallet for the active network.".to_string())
+            })?;
+        let wallet_id = wallet.id;
+
         let ln_address = self
             .store
             .ln_address
-            .insert(wallet_id, &username, allows_nostr, nostr_pubkey)
+            .insert(account_id, wallet_id, &username, allows_nostr, nostr_pubkey)
             .await?;
 
         info!(
+            %account_id,
             %wallet_id,
             username, "Lightning address registered successfully"
         );
@@ -179,13 +200,49 @@ fn validate_username(username: &str) -> Result<(), DataError> {
 mod tests {
     use chrono::Utc;
 
-    use crate::application::{composition::MockAppStoreBuilder, errors::DatabaseError};
+    use crate::{
+        application::{composition::MockAppStoreBuilder, errors::DatabaseError},
+        domains::{
+            asset::{Asset, Protocol},
+            bitcoin::BtcNetwork,
+            wallet::Wallet,
+        },
+    };
 
     use super::*;
 
-    fn ln_address_fixture(id: Uuid, wallet_id: Uuid, username: &str) -> LnAddress {
+    const NATIVE_ASSET_REF: &str = "native";
+
+    fn native_btc_asset() -> Asset {
+        Asset {
+            id: Uuid::new_v4(),
+            code: "BTC".to_string(),
+            name: Some("Bitcoin".to_string()),
+            protocol: Protocol::Bitcoin,
+            network: BtcNetwork::Regtest,
+            asset_ref: NATIVE_ASSET_REF.to_string(),
+            display_ticker: "rBTC".to_string(),
+            decimals: 11,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
+    }
+
+    fn wallet(id: Uuid, account_id: Uuid) -> Wallet {
+        let asset = native_btc_asset();
+        Wallet {
+            id,
+            account_id,
+            asset_id: asset.id,
+            asset: Some(asset),
+            ..Default::default()
+        }
+    }
+
+    fn ln_address_fixture(id: Uuid, account_id: Uuid, wallet_id: Uuid, username: &str) -> LnAddress {
         LnAddress {
             id,
+            account_id,
             wallet_id,
             username: username.to_string(),
             active: true,
@@ -245,12 +302,16 @@ mod tests {
 
             #[tokio::test]
             async fn lowercases_username_and_inserts() {
+                let account_id = Uuid::new_v4();
                 let wallet_id = Uuid::new_v4();
+                let asset = native_btc_asset();
+                let asset_id = asset.id;
 
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .ln_address
-                    .expect_find_by_wallet_id()
+                    .expect_find_by_account_id()
+                    .withf(move |id| *id == account_id)
                     .times(1)
                     .returning(|_| Ok(None));
                 store
@@ -260,20 +321,37 @@ mod tests {
                     .times(1)
                     .returning(|_| Ok(None));
                 store
+                    .asset
+                    .expect_find_native_btc_by_network()
+                    .withf(|network| *network == BtcNetwork::Regtest)
+                    .times(1)
+                    .returning(move |_| Ok(Some(asset.clone())));
+                store
+                    .wallet
+                    .expect_find_by_account_and_asset()
+                    .withf(move |account, asset| *account == account_id && *asset == asset_id)
+                    .times(1)
+                    .returning(move |account, _| Ok(Some(wallet(wallet_id, account))));
+                store
                     .ln_address
                     .expect_insert()
-                    .withf(|_, username, _, _| username == "alice")
+                    .withf(move |account, wallet, username, _, _| {
+                        *account == account_id && *wallet == wallet_id && username == "alice"
+                    })
                     .times(1)
-                    .returning(|wallet_id, username, _, _| Ok(ln_address_fixture(Uuid::new_v4(), wallet_id, username)));
+                    .returning(|account_id, wallet_id, username, _, _| {
+                        Ok(ln_address_fixture(Uuid::new_v4(), account_id, wallet_id, username))
+                    });
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let ln_address = service
-                    .register(wallet_id, "Alice".to_string(), false, None)
+                    .register(account_id, "Alice".to_string(), false, None)
                     .await
                     .unwrap();
 
                 assert_eq!(ln_address.username, "alice");
+                assert_eq!(ln_address.account_id, account_id);
                 assert_eq!(ln_address.wallet_id, wallet_id);
             }
         }
@@ -284,7 +362,7 @@ mod tests {
             #[tokio::test]
             async fn rejects_without_touching_the_store() {
                 // No store expectations are installed, so any repository call panics.
-                let service = LnAddressService::new(MockAppStoreBuilder::new().build());
+                let service = LnAddressService::new(MockAppStoreBuilder::new().build(), BtcNetwork::Regtest);
 
                 let err = service
                     .register(Uuid::new_v4(), "invalid username".to_string(), false, None)
@@ -295,29 +373,37 @@ mod tests {
             }
         }
 
-        mod when_wallet_already_has_an_address {
+        mod when_account_already_has_an_address {
             use super::*;
 
             #[tokio::test]
             async fn returns_conflict() {
+                let account_id = Uuid::new_v4();
                 let wallet_id = Uuid::new_v4();
 
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .ln_address
-                    .expect_find_by_wallet_id()
+                    .expect_find_by_account_id()
                     .times(1)
-                    .returning(move |_| Ok(Some(ln_address_fixture(Uuid::new_v4(), wallet_id, "existing"))));
+                    .returning(move |_| {
+                        Ok(Some(ln_address_fixture(
+                            Uuid::new_v4(),
+                            account_id,
+                            wallet_id,
+                            "existing",
+                        )))
+                    });
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service
-                    .register(wallet_id, "alice".to_string(), false, None)
+                    .register(account_id, "alice".to_string(), false, None)
                     .await
                     .unwrap_err();
 
                 assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
-                assert!(err.to_string().contains("Duplicate User ID"));
+                assert!(err.to_string().contains("Account already has a lightning address"));
             }
         }
 
@@ -329,16 +415,19 @@ mod tests {
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .ln_address
-                    .expect_find_by_wallet_id()
+                    .expect_find_by_account_id()
                     .times(1)
                     .returning(|_| Ok(None));
-                store
-                    .ln_address
-                    .expect_find_by_username()
-                    .times(1)
-                    .returning(|_| Ok(Some(ln_address_fixture(Uuid::new_v4(), Uuid::new_v4(), "alice"))));
+                store.ln_address.expect_find_by_username().times(1).returning(|_| {
+                    Ok(Some(ln_address_fixture(
+                        Uuid::new_v4(),
+                        Uuid::new_v4(),
+                        Uuid::new_v4(),
+                        "alice",
+                    )))
+                });
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service
                     .register(Uuid::new_v4(), "alice".to_string(), false, None)
@@ -358,11 +447,11 @@ mod tests {
                 let mut store = MockAppStoreBuilder::new();
                 store
                     .ln_address
-                    .expect_find_by_wallet_id()
+                    .expect_find_by_account_id()
                     .times(1)
                     .returning(|_| Err(DatabaseError::FindOne("boom".to_string())));
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service
                     .register(Uuid::new_v4(), "alice".to_string(), false, None)
@@ -370,6 +459,86 @@ mod tests {
                     .unwrap_err();
 
                 assert!(matches!(err, ApplicationError::Database(DatabaseError::FindOne(_))));
+            }
+        }
+
+        mod when_active_network_asset_is_missing {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_inconsistency() {
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_account_id()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .asset
+                    .expect_find_native_btc_by_network()
+                    .withf(|network| *network == BtcNetwork::Regtest)
+                    .times(1)
+                    .returning(|_| Ok(None));
+
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
+
+                let err = service
+                    .register(Uuid::new_v4(), "alice".to_string(), false, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Inconsistency(_))));
+                assert!(err.to_string().contains("Native BTC asset is not configured"));
+            }
+        }
+
+        mod when_account_has_no_active_network_wallet {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_validation_error() {
+                let account_id = Uuid::new_v4();
+                let asset = native_btc_asset();
+                let asset_id = asset.id;
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .ln_address
+                    .expect_find_by_account_id()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .ln_address
+                    .expect_find_by_username()
+                    .times(1)
+                    .returning(|_| Ok(None));
+                store
+                    .asset
+                    .expect_find_native_btc_by_network()
+                    .withf(|network| *network == BtcNetwork::Regtest)
+                    .times(1)
+                    .returning(move |_| Ok(Some(asset.clone())));
+                store
+                    .wallet
+                    .expect_find_by_account_and_asset()
+                    .withf(move |account, asset| *account == account_id && *asset == asset_id)
+                    .times(1)
+                    .returning(|_, _| Ok(None));
+
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
+
+                let err = service
+                    .register(account_id, "alice".to_string(), false, None)
+                    .await
+                    .unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
+                assert!(err.to_string().contains("native BTC wallet"));
             }
         }
     }
@@ -390,9 +559,9 @@ mod tests {
                     .expect_find()
                     .withf(move |queried| *queried == id)
                     .times(1)
-                    .returning(move |id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+                    .returning(move |id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), Uuid::new_v4(), "alice"))));
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let ln_address = service.get(id).await.unwrap();
 
@@ -408,7 +577,7 @@ mod tests {
                 let mut store = MockAppStoreBuilder::new();
                 store.ln_address.expect_find().times(1).returning(|_| Ok(None));
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service.get(Uuid::new_v4()).await.unwrap_err();
 
@@ -423,13 +592,16 @@ mod tests {
         #[tokio::test]
         async fn returns_addresses_from_the_repository() {
             let mut store = MockAppStoreBuilder::new();
-            store
-                .ln_address
-                .expect_find_many()
-                .times(1)
-                .returning(|_| Ok(vec![ln_address_fixture(Uuid::new_v4(), Uuid::new_v4(), "alice")]));
+            store.ln_address.expect_find_many().times(1).returning(|_| {
+                Ok(vec![ln_address_fixture(
+                    Uuid::new_v4(),
+                    Uuid::new_v4(),
+                    Uuid::new_v4(),
+                    "alice",
+                )])
+            });
 
-            let service = LnAddressService::new(store.build());
+            let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
             let addresses = service.list(LnAddressFilter::default()).await.unwrap();
 
@@ -448,7 +620,7 @@ mod tests {
                 let mut store = MockAppStoreBuilder::new();
                 store.ln_address.expect_find().times(1).returning(|_| Ok(None));
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service
                     .update(Uuid::new_v4(), update_request(Some("bob")))
@@ -471,7 +643,7 @@ mod tests {
                     .ln_address
                     .expect_find()
                     .times(1)
-                    .returning(move |id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+                    .returning(move |id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), Uuid::new_v4(), "alice"))));
                 store
                     .ln_address
                     .expect_find_by_username()
@@ -485,7 +657,7 @@ mod tests {
                     .times(1)
                     .returning(Ok);
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let updated = service.update(id, update_request(Some("Bob"))).await.unwrap();
 
@@ -503,12 +675,12 @@ mod tests {
                     .ln_address
                     .expect_find()
                     .times(1)
-                    .returning(|id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
+                    .returning(|id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), Uuid::new_v4(), "alice"))));
                 // find_by_username is intentionally not expected: an unchanged
                 // username must not trigger a uniqueness lookup.
                 store.ln_address.expect_update().times(1).returning(Ok);
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let updated = service
                     .update(Uuid::new_v4(), update_request(Some("alice")))
@@ -529,14 +701,17 @@ mod tests {
                     .ln_address
                     .expect_find()
                     .times(1)
-                    .returning(|id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), "alice"))));
-                store
-                    .ln_address
-                    .expect_find_by_username()
-                    .times(1)
-                    .returning(|_| Ok(Some(ln_address_fixture(Uuid::new_v4(), Uuid::new_v4(), "bob"))));
+                    .returning(|id| Ok(Some(ln_address_fixture(id, Uuid::new_v4(), Uuid::new_v4(), "alice"))));
+                store.ln_address.expect_find_by_username().times(1).returning(|_| {
+                    Ok(Some(ln_address_fixture(
+                        Uuid::new_v4(),
+                        Uuid::new_v4(),
+                        Uuid::new_v4(),
+                        "bob",
+                    )))
+                });
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service
                     .update(Uuid::new_v4(), update_request(Some("bob")))
@@ -559,7 +734,7 @@ mod tests {
                 let mut store = MockAppStoreBuilder::new();
                 store.ln_address.expect_delete_many().times(1).returning(|_| Ok(1));
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 assert!(service.delete(Uuid::new_v4()).await.is_ok());
             }
@@ -573,7 +748,7 @@ mod tests {
                 let mut store = MockAppStoreBuilder::new();
                 store.ln_address.expect_delete_many().times(1).returning(|_| Ok(0));
 
-                let service = LnAddressService::new(store.build());
+                let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
                 let err = service.delete(Uuid::new_v4()).await.unwrap_err();
 
@@ -590,7 +765,7 @@ mod tests {
             let mut store = MockAppStoreBuilder::new();
             store.ln_address.expect_delete_many().times(1).returning(|_| Ok(3));
 
-            let service = LnAddressService::new(store.build());
+            let service = LnAddressService::new(store.build(), BtcNetwork::Regtest);
 
             let deleted = service.delete_many(LnAddressFilter::default()).await.unwrap();
 

--- a/src/domains/ln_address/ln_address_use_cases.rs
+++ b/src/domains/ln_address/ln_address_use_cases.rs
@@ -14,7 +14,7 @@ use super::{LnAddress, LnAddressFilter};
 pub trait LnAddressUseCases: Send + Sync {
     async fn register(
         &self,
-        wallet_id: Uuid,
+        account_id: Uuid,
         username: String,
         allows_nostr: bool,
         nostr_pubkey: Option<PublicKey>,

--- a/src/domains/lnurl/lnurl_service.rs
+++ b/src/domains/lnurl/lnurl_service.rs
@@ -164,6 +164,7 @@ mod tests {
     fn ln_address(active: bool) -> LnAddress {
         LnAddress {
             id: Uuid::new_v4(),
+            account_id: Uuid::new_v4(),
             wallet_id: Uuid::new_v4(),
             username: "alice".to_string(),
             active,

--- a/src/domains/nostr/nostr_service.rs
+++ b/src/domains/nostr/nostr_service.rs
@@ -59,6 +59,7 @@ mod tests {
     fn ln_address_fixture(allows_nostr: bool, nostr_pubkey: Option<PublicKey>) -> LnAddress {
         LnAddress {
             id: Uuid::new_v4(),
+            account_id: Uuid::new_v4(),
             wallet_id: Uuid::new_v4(),
             username: "alice".to_string(),
             active: true,

--- a/src/domains/payment/payment_service.rs
+++ b/src/domains/payment/payment_service.rs
@@ -723,6 +723,7 @@ mod tests {
     fn ln_address(wallet_id: Uuid, active: bool) -> LnAddress {
         LnAddress {
             id: Uuid::new_v4(),
+            account_id: Uuid::new_v4(),
             wallet_id,
             username: "bob".to_string(),
             active,

--- a/src/domains/wallet/user_wallet_handler.rs
+++ b/src/domains/wallet/user_wallet_handler.rs
@@ -259,7 +259,7 @@ async fn get_wallet_address(
     let ln_addresses = services
         .ln_address
         .list(LnAddressFilter {
-            wallet_id: Some(user.wallet_id),
+            account_id: Some(user.account_id),
             ..Default::default()
         })
         .await?;
@@ -292,7 +292,7 @@ async fn register_wallet_address(
     let ln_address = services
         .ln_address
         .register(
-            user.wallet_id,
+            user.account_id,
             payload.username,
             payload.allows_nostr,
             payload.nostr_pubkey,
@@ -327,7 +327,7 @@ async fn update_wallet_address(
     let ln_addresses = services
         .ln_address
         .list(LnAddressFilter {
-            wallet_id: Some(user.wallet_id),
+            account_id: Some(user.account_id),
             ..Default::default()
         })
         .await?;
@@ -362,7 +362,7 @@ async fn delete_wallet_address(State(services): State<Arc<AppServices>>, user: U
     let n_deleted = services
         .ln_address
         .delete_many(LnAddressFilter {
-            wallet_id: Some(user.wallet_id),
+            account_id: Some(user.account_id),
             ..Default::default()
         })
         .await?;
@@ -760,9 +760,9 @@ mod tests {
     // scoped to the authenticated user's wallet. These tests lock that invariant.
     fn user() -> User {
         User {
+            account_id: Uuid::new_v4(),
             wallet_id: Uuid::new_v4(),
             permissions: vec![],
-            ..Default::default()
         }
     }
 
@@ -891,13 +891,13 @@ mod tests {
         #[tokio::test]
         async fn lists_only_the_authenticated_users_addresses() {
             let caller = user();
-            let wallet_id = caller.wallet_id;
+            let account_id = caller.account_id;
 
             let mut builder = MockAppServicesBuilder::new();
             builder
                 .ln_address
                 .expect_list()
-                .withf(move |filter| filter.wallet_id == Some(wallet_id))
+                .withf(move |filter| filter.account_id == Some(account_id))
                 .times(1)
                 .returning(|_| Ok(vec![]));
 

--- a/src/infra/database/sea_orm/models/account.rs
+++ b/src/infra/database/sea_orm/models/account.rs
@@ -23,6 +23,8 @@ pub enum Relation {
     ApiKey,
     #[sea_orm(has_many = "super::auth_identity::Entity")]
     AuthIdentity,
+    #[sea_orm(has_many = "super::ln_address::Entity")]
+    LnAddress,
 }
 
 impl Related<super::account_preference::Entity> for Entity {
@@ -40,6 +42,12 @@ impl Related<super::api_key::Entity> for Entity {
 impl Related<super::auth_identity::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::AuthIdentity.def()
+    }
+}
+
+impl Related<super::ln_address::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::LnAddress.def()
     }
 }
 

--- a/src/infra/database/sea_orm/models/ln_address.rs
+++ b/src/infra/database/sea_orm/models/ln_address.rs
@@ -8,6 +8,8 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     #[sea_orm(unique)]
+    pub account_id: Uuid,
+    #[sea_orm(unique)]
     pub wallet_id: Uuid,
     #[sea_orm(unique)]
     pub username: String,
@@ -20,6 +22,14 @@ pub struct Model {
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::account::Entity",
+        from = "Column::AccountId",
+        to = "super::account::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Account,
     #[sea_orm(has_many = "super::invoice::Entity")]
     Invoice,
     #[sea_orm(
@@ -30,6 +40,12 @@ pub enum Relation {
         on_delete = "Cascade"
     )]
     Wallet,
+}
+
+impl Related<super::account::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Account.def()
+    }
 }
 
 impl Related<super::invoice::Entity> for Entity {

--- a/src/infra/database/sea_orm/repositories/sea_orm_ln_address_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_ln_address_repository.rs
@@ -36,9 +36,9 @@ impl LnAddressRepository for SeaOrmLnAddressRepository {
         Ok(model.map(Into::into))
     }
 
-    async fn find_by_wallet_id(&self, wallet_id: Uuid) -> Result<Option<LnAddress>, DatabaseError> {
+    async fn find_by_account_id(&self, account_id: Uuid) -> Result<Option<LnAddress>, DatabaseError> {
         let model = LnAddressEntity::find()
-            .filter(Column::WalletId.eq(wallet_id))
+            .filter(Column::AccountId.eq(account_id))
             .one(&self.db)
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
@@ -58,6 +58,7 @@ impl LnAddressRepository for SeaOrmLnAddressRepository {
 
     async fn find_many(&self, filter: LnAddressFilter) -> Result<Vec<LnAddress>, DatabaseError> {
         let models = LnAddressEntity::find()
+            .apply_if(filter.account_id, |q, id| q.filter(Column::AccountId.eq(id)))
             .apply_if(filter.wallet_id, |q, id| q.filter(Column::WalletId.eq(id)))
             .apply_if(filter.username, |q, username| q.filter(Column::Username.eq(username)))
             .apply_if(filter.ids, |q, ids| q.filter(Column::Id.is_in(ids)))
@@ -77,6 +78,7 @@ impl LnAddressRepository for SeaOrmLnAddressRepository {
 
     async fn insert(
         &self,
+        account_id: Uuid,
         wallet_id: Uuid,
         username: &str,
         allows_nostr: bool,
@@ -84,6 +86,7 @@ impl LnAddressRepository for SeaOrmLnAddressRepository {
     ) -> Result<LnAddress, DatabaseError> {
         let model = ActiveModel {
             id: Set(Uuid::new_v4()),
+            account_id: Set(account_id),
             wallet_id: Set(wallet_id),
             username: Set(username.to_owned()),
             allows_nostr: Set(allows_nostr),
@@ -103,6 +106,7 @@ impl LnAddressRepository for SeaOrmLnAddressRepository {
     async fn update(&self, ln_address: LnAddress) -> Result<LnAddress, DatabaseError> {
         let model = ActiveModel {
             id: Unchanged(ln_address.id),
+            account_id: Unchanged(ln_address.account_id),
             wallet_id: Unchanged(ln_address.wallet_id),
             username: Set(ln_address.username),
             allows_nostr: Set(ln_address.allows_nostr),
@@ -122,6 +126,7 @@ impl LnAddressRepository for SeaOrmLnAddressRepository {
 
     async fn delete_many(&self, filter: LnAddressFilter) -> Result<u64, DatabaseError> {
         let result = LnAddressEntity::delete_many()
+            .apply_if(filter.account_id, |q, id| q.filter(Column::AccountId.eq(id)))
             .apply_if(filter.wallet_id, |q, id| q.filter(Column::WalletId.eq(id)))
             .apply_if(filter.ids, |q, ids| q.filter(Column::Id.is_in(ids)))
             .apply_if(filter.username, |q, username| q.filter(Column::Username.eq(username)))

--- a/src/infra/database/sea_orm/types.rs
+++ b/src/infra/database/sea_orm/types.rs
@@ -201,6 +201,7 @@ impl From<LnAddressModel> for LnAddress {
     fn from(model: LnAddressModel) -> Self {
         LnAddress {
             id: model.id,
+            account_id: model.account_id,
             wallet_id: model.wallet_id,
             username: model.username,
             active: model.active,

--- a/tests/suites/guards.rs
+++ b/tests/suites/guards.rs
@@ -105,7 +105,7 @@ async fn every_admin_endpoint_enforces_its_permission() {
         Permission::WriteLnAddress,
         id,
         body(RegisterLnAddressRequest {
-            wallet_id: None,
+            account_id: None,
             username: unique("guard"),
             allows_nostr: false,
             nostr_pubkey: None,

--- a/tests/suites/ln_addresses.rs
+++ b/tests/suites/ln_addresses.rs
@@ -1,18 +1,18 @@
 //! `/v1/lightning-addresses` — admin LN-address management, permission-gated
-//! (`*:ln_address`). Each test registers under its own wallet (a wallet holds at
+//! (`*:ln_address`). Each test registers under its own account (an account holds at
 //! most one address) with a process-unique, globally-unique username. Nostr is
 //! left off (`allows_nostr: false`) — its serving path is mocked separately.
 
 use reqwest::StatusCode;
 
-use swissknife_types::{LnAddress, RegisterLnAddressRequest, UpdateLnAddressRequest};
+use swissknife_types::{LnAddress, RegisterLnAddressRequest, UpdateLnAddressRequest, Wallet};
 
 use crate::common::fixtures::unique;
 use crate::common::{app, assert_error, assert_status, Auth};
 
-fn register_req(wallet_id: uuid::Uuid, username: &str) -> RegisterLnAddressRequest {
+fn register_req(wallet: &Wallet, username: &str) -> RegisterLnAddressRequest {
     RegisterLnAddressRequest {
-        wallet_id: Some(wallet_id),
+        account_id: Some(wallet.account_id),
         username: username.to_string(),
         allows_nostr: false,
         nostr_pubkey: None,
@@ -34,12 +34,13 @@ mod register {
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(wallet.id, &username),
+                register_req(&wallet, &username),
             )
             .await;
         assert_status(&res, StatusCode::OK);
         let addr = res.parse::<LnAddress>();
         assert_eq!(addr.username, username);
+        assert_eq!(addr.account_id, wallet.account_id);
         assert_eq!(addr.wallet_id, wallet.id);
         assert!(addr.active, "a newly registered address is active");
         assert!(!addr.allows_nostr);
@@ -53,7 +54,12 @@ mod register {
             .post(
                 "/v1/lightning-addresses",
                 Auth::None,
-                register_req(uuid::Uuid::new_v4(), "noauth"),
+                RegisterLnAddressRequest {
+                    account_id: Some(uuid::Uuid::new_v4()),
+                    username: "noauth".to_string(),
+                    allows_nostr: false,
+                    nostr_pubkey: None,
+                },
             )
             .await;
         assert_error(&res, StatusCode::UNAUTHORIZED);
@@ -71,7 +77,7 @@ mod register {
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(wallet.id, "Invalid Name"),
+                register_req(&wallet, "Invalid Name"),
             )
             .await;
         assert_error(&res, StatusCode::UNPROCESSABLE_ENTITY);
@@ -90,25 +96,25 @@ mod register {
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(first.id, &username),
+                register_req(&first, &username),
             )
             .await;
         assert_status(&res, StatusCode::OK);
 
-        // The same username on another wallet conflicts.
+        // The same username on another account conflicts.
         let dup = app
             .api()
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(second.id, &username),
+                register_req(&second, &username),
             )
             .await;
         assert_error(&dup, StatusCode::CONFLICT);
     }
 
     #[tokio::test]
-    async fn rejects_a_second_address_for_one_wallet() {
+    async fn rejects_a_second_address_for_one_account() {
         let app = app().await;
         let token = app.admin_token().await;
         let wallet = app.create_wallet(token, "lnaddr-one").await;
@@ -118,18 +124,18 @@ mod register {
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(wallet.id, &unique("lnaddr-one")),
+                register_req(&wallet, &unique("lnaddr-one")),
             )
             .await;
         assert_status(&res, StatusCode::OK);
 
-        // A wallet may hold only one address.
+        // An account may hold only one address.
         let again = app
             .api()
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(wallet.id, &unique("lnaddr-two")),
+                register_req(&wallet, &unique("lnaddr-two")),
             )
             .await;
         assert_error(&again, StatusCode::CONFLICT);
@@ -151,7 +157,7 @@ mod manage {
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_req(wallet.id, &username),
+                register_req(&wallet, &username),
             )
             .await
             .parse::<LnAddress>();

--- a/tests/suites/me.rs
+++ b/tests/suites/me.rs
@@ -383,7 +383,7 @@ mod ln_address {
                 "/v1/me/lightning-address",
                 Auth::ApiKey(&user.key),
                 RegisterLnAddressRequest {
-                    wallet_id: None,
+                    account_id: None,
                     username: username.clone(),
                     allows_nostr: false,
                     nostr_pubkey: None,
@@ -434,7 +434,7 @@ mod ln_address {
                 "/v1/me/lightning-address",
                 Auth::ApiKey(&alice.key),
                 RegisterLnAddressRequest {
-                    wallet_id: None,
+                    account_id: None,
                     username: unique("me-lnaddr-a"),
                     allows_nostr: false,
                     nostr_pubkey: None,

--- a/tests/suites/oauth2.rs
+++ b/tests/suites/oauth2.rs
@@ -75,7 +75,7 @@ mod rejects {
                 "/v1/lightning-addresses",
                 Auth::Bearer(&token),
                 RegisterLnAddressRequest {
-                    wallet_id: None,
+                    account_id: None,
                     username: unique("oauth2-guard"),
                     allows_nostr: false,
                     nostr_pubkey: None,

--- a/tests/suites/wallets.rs
+++ b/tests/suites/wallets.rs
@@ -144,9 +144,9 @@ mod list {
 mod list_overviews {
     use super::*;
 
-    fn register_ln_address(wallet_id: uuid::Uuid, username: &str) -> RegisterLnAddressRequest {
+    fn register_ln_address(wallet: &Wallet, username: &str) -> RegisterLnAddressRequest {
         RegisterLnAddressRequest {
-            wallet_id: Some(wallet_id),
+            account_id: Some(wallet.account_id),
             username: username.to_string(),
             allows_nostr: false,
             nostr_pubkey: None,
@@ -194,7 +194,7 @@ mod list_overviews {
             .post(
                 "/v1/lightning-addresses",
                 Auth::Bearer(token),
-                register_ln_address(payee.id, &username),
+                register_ln_address(&payee, &username),
             )
             .await;
         assert_status(&address, StatusCode::OK);

--- a/tests/suites/well_known.rs
+++ b/tests/suites/well_known.rs
@@ -20,7 +20,7 @@ use crate::common::{app, assert_error, assert_status, Auth, TestApp};
 async fn register_address(app: &TestApp, token: &str, label: &str, nostr_pubkey: Option<&str>) -> (Wallet, LnAddress) {
     let wallet = app.create_wallet(token, label).await;
     let body = serde_json::json!({
-        "wallet_id": wallet.id,
+        "account_id": wallet.account_id,
         "username": unique(label),
         "allows_nostr": nostr_pubkey.is_some(),
         "nostr_pubkey": nostr_pubkey,


### PR DESCRIPTION
## Summary
- add ln_address.account_id and ln_address.receive_wallet_id migration/backfill on top of asset-scoped wallets
- replace the public Lightning Address wallet_id contract with account_id + receive_wallet_id
- validate receive-wallet ownership/native-BTC compatibility in the service layer
- refresh OpenAPI/dashboard client and update Lightning Address dashboard surfaces

## Stack
- Builds on #317 (wallet asset cutover)

## Validation
- cargo check --workspace --all-targets --features itest
- cargo test -p migration ln_address_account_routes -- --nocapture
- cargo test -p migration identity_asset -- --nocapture
- cargo test --bins ln_address_service -- --nocapture
- cargo test --bins ln_address_handler -- --nocapture
- cargo test --bins lnurl_service -- --nocapture
- cargo test --bins send_internal -- --nocapture
- make openapi
- yarn fm:fix
- yarn typecheck
- yarn lint
- cargo fmt --check
- make lint