### PR TITLE
chore: upgrade bcrypt for audit advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64 0.22.1",
  "blowfish",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ anyhow = "1.0.102"
 futures-util = "0.3.32"
 humantime = "2.3.0"
 rust_socketio = { version = "0.6.0", features = ["async"] }
-bcrypt = "0.19.1"
+bcrypt = "0.19.2"
 migration = { path = "crates/migration" }
 swissknife-types = { path = "crates/swissknife-types" }
 utoipa = { version = "5.5.0", features = ["axum_extras", "chrono", "uuid"] }


### PR DESCRIPTION
## Summary
- upgrade `bcrypt` from 0.19.1 to 0.19.2
- update `Cargo.lock` to pick up the fixed release for RUSTSEC-2026-0199

## Validation
- `git diff --check`
- `OPENSSL_INCLUDE_DIR=/opt/data/tools/libssl-dev/usr/include OPENSSL_LIB_DIR=/opt/data/.local/lib PROTOC=/opt/data/tools/protoc/bin/protoc cargo check --locked`
