### PR TITLE
debug: instrument LND REST listener for missed-deposit flake [DO NOT MERGE]

### DIFF
--- a/config/itest.toml
+++ b/config/itest.toml
@@ -20,7 +20,7 @@ dashboard_dir = ""
 format = "compact"
 ansi = false
 level = "info"
-filter = "warn,swissknife=info,sea_orm_migration=warn"
+filter = "warn,swissknife=debug,swissknife::infra::lightning=trace,sea_orm_migration=warn"
 file = false
 
 [jwt]

--- a/src/infra/lightning/lnd/lnd_websocket_listener.rs
+++ b/src/infra/lightning/lnd/lnd_websocket_listener.rs
@@ -11,7 +11,7 @@ use tokio::fs;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::ClientRequestBuilder;
 use tokio_tungstenite::{connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream};
-use tracing::{debug, error};
+use tracing::{debug, error, trace, warn};
 
 use crate::application::composition::AppServices;
 use crate::application::errors::LightningError;
@@ -145,18 +145,23 @@ impl LndWebsocketListener {
                 Ok(msg) => {
                     if msg.is_text() {
                         let text = msg.into_text().unwrap();
+                        // [DEBUG-FLAKE] raw invoice frame as received from LND.
+                        debug!(%text, "LND invoice frame received");
                         // Parse/semantic errors are skippable; database projection errors
                         // propagate so the supervisor replays pending state before resubscribe.
                         self.process_invoice_message(&text).await?;
                     } else if msg.is_close() {
-                        debug!("WebSocket closed");
+                        debug!(?msg, "LND invoice websocket closed by peer");
                         return Ok(());
+                    } else {
+                        trace!(?msg, "LND invoice non-text frame");
                     }
                 }
                 Err(err) => return Err(LightningError::ConnectWebsocket(err.to_string())),
             }
         }
 
+        debug!("LND invoice stream ended (next() returned None)");
         Ok(())
     }
 
@@ -169,18 +174,25 @@ impl LndWebsocketListener {
                 Ok(msg) => {
                     if msg.is_text() {
                         let text = msg.into_text().unwrap();
+                        // [DEBUG-FLAKE] raw frame as received from LND, before any parsing/filtering.
+                        debug!(%text, "LND transaction frame received");
                         // A failed deposit/withdrawal write propagates so the supervisor
                         // reconnects and re-syncs; parse errors are skipped inside.
                         self.process_transaction_message(&text).await?;
                     } else if msg.is_close() {
-                        debug!("WebSocket closed");
+                        debug!(?msg, "LND transaction websocket closed by peer");
                         return Ok(());
+                    } else {
+                        // [DEBUG-FLAKE] ping/pong/binary — currently ignored silently.
+                        trace!(?msg, "LND transaction non-text frame");
                     }
                 }
                 Err(err) => return Err(LightningError::ConnectWebsocket(err.to_string())),
             }
         }
 
+        // [DEBUG-FLAKE] stream ended without a close frame — surfaces as a reconnect upstream.
+        debug!("LND transaction stream ended (next() returned None)");
         Ok(())
     }
 
@@ -188,7 +200,7 @@ impl LndWebsocketListener {
         let value: Value = match serde_json::from_str(text) {
             Ok(value) => value,
             Err(err) => {
-                error!(%err, "Failed to parse invoice message");
+                error!(%err, %text, "Failed to parse invoice message");
                 return Ok(());
             }
         };
@@ -196,6 +208,7 @@ impl LndWebsocketListener {
         if let Some(event) = value.get("result") {
             match serde_json::from_value::<InvoiceResponse>(event.clone()) {
                 Ok(invoice) => {
+                    debug!(state = %invoice.state, "LND invoice event parsed");
                     if invoice.state.as_str() == "SETTLED" {
                         if let Err(err) = self.services.event.invoice_paid(invoice.into()).await {
                             return Err(LightningError::EventProcessing(err.to_string()));
@@ -203,9 +216,12 @@ impl LndWebsocketListener {
                     }
                 }
                 Err(err) => {
-                    error!(%err, "Failed to parse SubscribeInvoices event");
+                    error!(%err, %text, "Failed to parse SubscribeInvoices event");
                 }
             }
+        } else {
+            // [DEBUG-FLAKE] frame with no "result" key (e.g. an LND {"error": ...}) was silently dropped.
+            warn!(%text, "LND invoice frame without 'result' key; ignoring");
         }
 
         Ok(())
@@ -227,15 +243,29 @@ impl LndWebsocketListener {
                     self.handle_transaction(transaction).await?;
                 }
                 Err(err) => {
-                    error!(%err, "Failed to parse SubscribeTransactions event");
+                    error!(%err, %text, "Failed to parse SubscribeTransactions event");
                 }
             }
+        } else {
+            // [DEBUG-FLAKE] frame with no "result" key (e.g. an LND {"error": ...}) was silently dropped.
+            warn!(%text, "LND transaction frame without 'result' key; ignoring");
         }
 
         Ok(())
     }
 
     async fn handle_transaction(&self, transaction: BtcTransaction) -> Result<(), LightningError> {
+        // [DEBUG-FLAKE] full parsed tx: direction, confirmation height, and every output's
+        // ownership/address/amount, so we can see if a deposit arrived unconfirmed-only or was
+        // filtered out by is_ours.
+        debug!(
+            txid = %transaction.txid,
+            block_height = ?transaction.block_height,
+            is_outgoing = transaction.is_outgoing,
+            n_outputs = transaction.outputs.len(),
+            outputs = ?transaction.outputs,
+            "Handling LND transaction"
+        );
         // Filter outputs based on transaction direction:
         // - Incoming tx (deposit): only process outputs that are ours
         // - Outgoing tx (withdrawal): only process outputs that are NOT ours (skip change)
@@ -248,6 +278,9 @@ impl LndWebsocketListener {
         });
 
         for output in relevant_outputs {
+            // [DEBUG-FLAKE] the output we are about to project (relevant ones only). If an expected
+            // deposit never logs here, it was filtered out above (is_ours == false).
+            debug!(txid = %transaction.txid, ?output, is_outgoing = transaction.is_outgoing, "Projecting LND output");
             let result = if transaction.is_outgoing {
                 self.services
                     .event

--- a/tests/itest/config/lnd/lnd.conf
+++ b/tests/itest/config/lnd/lnd.conf
@@ -4,7 +4,7 @@
 # cert carrying localhost/lnd/127.0.0.1 SANs.
 [Application Options]
 alias=swissknife-itest-lnd
-debuglevel=info
+debuglevel=info,RPCS=debug,NTFN=debug,LNWL=debug
 rpclisten=0.0.0.0:10009
 restlisten=0.0.0.0:8080
 listen=0.0.0.0:9735


### PR DESCRIPTION
**Draft / DO NOT MERGE — diagnostics only.**

Purpose: capture a failing `integration (lnd_rest, sqlite)` run to find the root cause of the intermittent `timed out after 180s waiting for: on-chain deposit credited` flake (it passes ~3/4 of the time on untouched LND code). Existing artifacts were useless because the itest is pinned to `swissknife=info` and `setup_tracing` ignores `RUST_LOG`.

What this changes (all diagnostics):
- itest logging → `swissknife=debug` + `swissknife::infra::lightning=trace`; LND `debuglevel` adds `RPCS/NTFN/LNWL=debug` so we see what LND sends vs. what we receive.
- LND REST listener: log every raw invoice/transaction frame, non-text frames, and the stream/close exit reason; make silently-ignored frames (no `"result"` key) a `WARN` with payload; include the raw payload on parse failures; log each parsed tx (direction, block_height, all outputs) and each projected output.

How to use: re-run the `lnd_rest` job until it goes red, then read the `itest-sqlite-lnd_rest` artifact. The logs answer *where the deposit vanishes* — LND never delivered it (silent stall), we dropped/mis-parsed the frame, or it was filtered (`is_ours=false`) / only arrived unconfirmed. Each points to a distinct event-driven fix (no polling).