### PR TITLE
test: complete account and wallet integration coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ make fmt                       # Check formatting
 make fmt-fix                   # Fix formatting
 make test                      # Run unit tests
 make test-integration          # Run one black-box integration-test cell
+make test-integration-fresh    # Recreate volumes before a liquidity-sensitive cell
 make check                     # Format, lint, build, and unit tests
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ release notes when a tag is published.
 - Added an authenticated dashboard account context and header wallet selector;
   wallet-scoped pages now use an explicit persisted wallet selection instead of
   inferring the first wallet ([#326]).
+- Added administrative account CRUD and permission grant APIs, including
+  aggregate deletion of wallets and API keys ([#327]).
+- Added black-box account lifecycle, concurrent provisioning, explicit wallet
+  routing, and cross-network balance isolation coverage ([#329]).
 
 ### Changed
 
@@ -31,6 +35,8 @@ release notes when a tag is published.
 - Renamed internal user-as-account modules, handlers, generated operations, and
   dashboard actions to the account vocabulary. `User` now refers only to the
   authenticated runtime principal ([#330]).
+- Account-scoped wallet child routes now use a lightweight ownership check
+  before loading their resource collections ([#328]).
 
 - Migrated CLN Lightning payments from the deprecated `pay` RPC to `xpay`, and
   refreshed the vendored CLN and LND gRPC protos to CLN v26.06 and LND v0.21
@@ -44,6 +50,10 @@ release notes when a tag is published.
 
 ### Fixed
 
+- Made concurrent local sign-up return one success and deterministic conflicts
+  instead of leaking database uniqueness errors as HTTP 500 responses ([#329]).
+- Rejected Lightning invoice creation when the selected wallet's native BTC
+  network does not match the configured node network ([#329]).
 - Fixed CLN REST Lightning payments charging the routing fee twice for payments
   that incur a non-zero fee ([#282]).
 
@@ -130,6 +140,9 @@ release notes when a tag is published.
 [#321]: https://github.com/bitcoin-numeraire/swissknife/pull/321
 [#324]: https://github.com/bitcoin-numeraire/swissknife/pull/324
 [#326]: https://github.com/bitcoin-numeraire/swissknife/issues/326
+[#327]: https://github.com/bitcoin-numeraire/swissknife/issues/327
+[#328]: https://github.com/bitcoin-numeraire/swissknife/issues/328
+[#329]: https://github.com/bitcoin-numeraire/swissknife/issues/329
 [#330]: https://github.com/bitcoin-numeraire/swissknife/issues/330
 [#331]: https://github.com/bitcoin-numeraire/swissknife/pull/331
 [398e89f]: https://github.com/bitcoin-numeraire/swissknife/commit/398e89f

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ITEST_ENV = SWISSKNIFE_ITEST_COMPOSE_PROJECT=$(ITEST_PROJECT) \
 	SWISSKNIFE_ITEST_DATABASE=$(ITEST_DATABASE) \
 	SWISSKNIFE_ITEST_PROVIDER=$(ITEST_PROVIDER)
 
-.PHONY: watch up up-swissknife up-server up-postgres up-pgadmin up-oauth2 down-oauth2 oauth2-token shutdown down generate-certs build protos build-docker build-docker-server build-docker-dashboard run-docker lint fmt fmt-fix test test-unit test-integration test-persistence itest-up itest-down itest-shutdown itest-logs coverage coverage-html coverage-lcov coverage-matrix clean check deps-upgrade deps-outdated install-tools generate-models new-migration run-migrations fresh-migrations
+.PHONY: watch up up-swissknife up-server up-postgres up-pgadmin up-oauth2 down-oauth2 oauth2-token shutdown down generate-certs build protos build-docker build-docker-server build-docker-dashboard run-docker lint fmt fmt-fix test test-unit test-integration test-integration-fresh test-persistence itest-up itest-down itest-shutdown itest-logs coverage coverage-html coverage-lcov coverage-matrix clean check deps-upgrade deps-outdated install-tools generate-models new-migration run-migrations fresh-migrations
 
 watch:
 	@cargo watch -x run
@@ -133,6 +133,11 @@ test-unit:
 # Narrow to a suite/test with TEST=... and pass runner flags with TESTARGS=...
 test-integration: itest-up
 	@$(ITEST_ENV) cargo test --features itest --test api $(TEST) -- $(TESTARGS)
+
+# Recreate dependency volumes before a liquidity-sensitive integration run.
+test-integration-fresh:
+	@$(MAKE) itest-shutdown
+	@$(MAKE) test-integration ITEST_DATABASE=$(ITEST_DATABASE) ITEST_PROVIDER=$(ITEST_PROVIDER) ITEST_PROJECT=$(ITEST_PROJECT) TESTARGS="$(TESTARGS) --test-threads=1"
 
 # Run the persistence / Unit-of-Work tests for one database cell: real-DB
 # coverage of the reservation/settlement balance invariants and concurrency.

--- a/crates/swissknife-types/src/system.rs
+++ b/crates/swissknife-types/src/system.rs
@@ -37,7 +37,7 @@ impl HealthCheck {
 pub struct SetupInfo {
     /// Whether the welcome flow has been completed
     pub welcome_complete: bool,
-    /// Whether the admin user has been created
+    /// Whether the admin account has been created
     pub sign_up_complete: bool,
 }
 

--- a/crates/swissknife-types/src/wallet.rs
+++ b/crates/swissknife-types/src/wallet.rs
@@ -138,7 +138,7 @@ pub struct WalletOverview {
     pub label: Option<String>,
     /// Lightning Address
     pub ln_address: Option<LnAddress>,
-    /// User Balance
+    /// Wallet balance
     pub balance: Balance,
     /// Number of payments
     pub n_payments: u32,

--- a/dashboard/docs/REDESIGN.md
+++ b/dashboard/docs/REDESIGN.md
@@ -38,7 +38,7 @@ All four judges ranked D1 or D5 at the top; both money-UX laws and the compositi
 | One fused BIP21 QR shippable today | **TRUE (frontend-composed)** | display-only: compose `bitcoin:<addr>?amount=…&lightning=<bolt11>` on the client from the on-chain address + the bolt11 we already have. No backend leg needed. _(v2 correction)_ |
 | Unified Send routes on-chain | **TRUE** | on-chain send IS supported; the `SendPaymentRequest.input` doc string ("…not yet supported") is **stale** — remove it backend-side. _(v2 correction)_ |
 | On-chain receive (address) shippable | **True** | `BtcAddress.used:boolean` (`:98`); generate/list/delete BTC address endpoints exist |
-| Local JWT creates one admin login | **True** | `AuthService::sign_up` stores one `password_hash` config entry and returns `Conflict("Admin user already created")` after that; local JWT `sign_in` always issues subject `admin` with all permissions. Multiple dashboard identities/account ownership separation is tracked by [#252](https://github.com/bitcoin-numeraire/swissknife/issues/252). |
+| Local JWT creates one admin login | **True** | `AuthService::sign_up` provisions the `admin` account before atomically claiming the `password_hash` config entry and returns `Conflict("Admin account already created")` after that; local JWT `sign_in` resolves that persisted account and uses its database permissions. Additional local JWT identities are not supported. |
 | Per-account RBAC roles / spending policy / approvals | **FALSE — by design, v0.3.0** | `Permission` (`:742`) is a flat scope enum today; spending policy/budgets are scoped to the v0.3.0 AI-agent work, not a surprise gap |
 | Permission-gated nav engine exists | **True** | `hasAllPermissions()` (`auth/permissions.ts`), `navData` items carry `permissions?: string[]` |
 | Scope switcher is mock | **True** | `workspaces-popover.tsx:35` `useState(data[0])`, hardcoded `plan` Label |
@@ -46,7 +46,7 @@ All four judges ranked D1 or D5 at the top; both money-UX laws and the compositi
 
 **Design law for the whole RFC (v2):** design for the *real target product*; where the backend is missing something non-trivial, treat it as an implementation task (the team can add it), not a wall. Reserve manifest `flag`s for genuinely *future* surfaces (the v0.3.0 agent/policy/L402/webhook work), which still degrade gracefully when absent. On-chain send and the fused-QR receive are **real, shippable flows** — not fenced.
 
-**JWT deployment note.** Until #252 (or a narrower user/account refactor) lands, JWT mode should be presented as a single local admin login suitable for Umbrel, desktop, and first-server-run installs. Additional human dashboard users require an external auth provider plus role/scope mapping; the dashboard must not imply that JWT self-sign-up can create multiple independent accounts.
+**JWT deployment note.** JWT mode is a single local admin login suitable for Umbrel, desktop, and first-server-run installs. Additional human dashboard users require an external identity provider plus role/scope mapping; the dashboard must not imply that JWT self-sign-up can create multiple independent accounts.
 
 ---
 

--- a/dashboard/src/components/api-key/create-api-key-form.tsx
+++ b/dashboard/src/components/api-key/create-api-key-form.tsx
@@ -158,7 +158,7 @@ export function CreateApiKeyForm({ onSuccess, isAdmin }: Props) {
           ) : (
             <Alert variant="filled" severity="info">
               {t('create_api_key_form.no_permissions')}:{' '}
-              <Link href={`${CONFIG.serverUrl}/docs#tag/user-wallet`} target="_blank">
+              <Link href={`${CONFIG.serverUrl}/docs#tag/me`} target="_blank">
                 See Docs
               </Link>
             </Alert>

--- a/dashboard/src/lib/openapi.json
+++ b/dashboard/src/lib/openapi.json
@@ -532,7 +532,7 @@
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 },
-                "example": "\n{\n    \"status\": \"409 Conflict\",\n    \"reason\": \"Admin user already created\"\n}\n"
+                "example": "\n{\n    \"status\": \"409 Conflict\",\n    \"reason\": \"Admin account already created\"\n}\n"
               }
             }
           },
@@ -1059,7 +1059,7 @@
           "API Keys"
         ],
         "summary": "Generate a new API Key",
-        "description": "Returns the generated API Key for the requested account. Users can create API keys with permissions\nas a subset of their current permissions.",
+        "description": "Returns the generated API Key for the requested account. Callers can create API keys with permissions\nas a subset of their current permissions.",
         "operationId": "create_api_key",
         "requestBody": {
           "content": {
@@ -3857,7 +3857,7 @@
           "Me"
         ],
         "summary": "Generate a new API Key",
-        "description": "Returns the generated API Key for the account. Users can create API keys with\npermissions as a subset of their current permissions.",
+        "description": "Returns the generated API Key for the account. Callers can create API keys with\npermissions as a subset of their current permissions.",
         "operationId": "create_account_api_key",
         "requestBody": {
           "content": {
@@ -8962,7 +8962,7 @@
         "properties": {
           "sign_up_complete": {
             "type": "boolean",
-            "description": "Whether the admin user has been created"
+            "description": "Whether the admin account has been created"
           },
           "welcome_complete": {
             "type": "boolean",
@@ -9252,7 +9252,7 @@
           },
           "balance": {
             "$ref": "#/components/schemas/Balance",
-            "description": "User Balance"
+            "description": "Wallet balance"
           },
           "created_at": {
             "type": "string",

--- a/dashboard/src/lib/swissknife/sdk.gen.ts
+++ b/dashboard/src/lib/swissknife/sdk.gen.ts
@@ -496,7 +496,7 @@ export const listApiKeys = <ThrowOnError extends boolean = false>(
 /**
  * Generate a new API Key
  *
- * Returns the generated API Key for the requested account. Users can create API keys with permissions
+ * Returns the generated API Key for the requested account. Callers can create API keys with permissions
  * as a subset of their current permissions.
  */
 export const createApiKey = <ThrowOnError extends boolean = false>(
@@ -930,7 +930,7 @@ export const listAccountApiKeys = <ThrowOnError extends boolean = false>(
 /**
  * Generate a new API Key
  *
- * Returns the generated API Key for the account. Users can create API keys with
+ * Returns the generated API Key for the account. Callers can create API keys with
  * permissions as a subset of their current permissions.
  */
 export const createAccountApiKey = <ThrowOnError extends boolean = false>(

--- a/dashboard/src/lib/swissknife/types.gen.ts
+++ b/dashboard/src/lib/swissknife/types.gen.ts
@@ -969,7 +969,7 @@ export type SendPaymentRequest = {
  */
 export type SetupInfo = {
   /**
-   * Whether the admin user has been created
+   * Whether the admin account has been created
    */
   sign_up_complete: boolean;
   /**
@@ -1140,7 +1140,7 @@ export type WalletOverview = {
    */
   asset_id: string;
   /**
-   * User Balance
+   * Wallet balance
    */
   balance: Balance;
   /**

--- a/dashboard/src/locales/langs/en/common.json
+++ b/dashboard/src/locales/langs/en/common.json
@@ -477,7 +477,7 @@
     "use_unused_address": "Use unused address",
     "copy_unused_address": "Copy unused address",
     "unused_address_available": "An unused address of this type is already available.",
-    "btc_addresses_unavailable": "Bitcoin address list is unavailable. The backend may need read:btc_address for this user.",
+    "btc_addresses_unavailable": "Bitcoin address list is unavailable. The backend may need read:btc_address for this account.",
     "loading_addresses": "Loading addresses...",
     "used": "Used",
     "unused": "Unused",
@@ -581,7 +581,7 @@
     "search_placeholder": "Search ID, wallet, address or type"
   },
   "wallet_toolbar": {
-    "search_placeholder": "Search ID, User or LN Address"
+    "search_placeholder": "Search ID, Account or LN Address"
   },
   "transaction_list": {
     "description": "Description",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,6 +31,7 @@ database behavior should also run at least one black-box integration cell:
 
 ```bash
 make test-integration ITEST_DATABASE=sqlite ITEST_PROVIDER=lnd_grpc
+make test-integration-fresh ITEST_DATABASE=sqlite ITEST_PROVIDER=lnd_grpc
 ```
 
 Dashboard changes should be checked from `dashboard/`:

--- a/src/application/composition/services.rs
+++ b/src/application/composition/services.rs
@@ -65,6 +65,7 @@ impl AppServices {
             ln_client.clone(),
             invoice_expiry.as_secs() as u32,
             event.clone(),
+            bitcoin_wallet.network(),
         );
         let lnurl = LnUrlService::new(
             store.clone(),

--- a/src/domains/account/api_key_handler.rs
+++ b/src/domains/account/api_key_handler.rs
@@ -47,7 +47,7 @@ pub fn api_key_router() -> Router<Arc<AppServices>> {
 
 /// Generate a new API Key
 ///
-/// Returns the generated API Key for the requested account. Users can create API keys with permissions
+/// Returns the generated API Key for the requested account. Callers can create API keys with permissions
 /// as a subset of their current permissions.
 #[utoipa::path(
     post,

--- a/src/domains/account/auth_service.rs
+++ b/src/domains/account/auth_service.rs
@@ -83,17 +83,21 @@ impl AuthUseCases for AuthService {
 
         let password_hash = hash(&password, DEFAULT_COST).map_err(|e| AuthenticationError::Hash(e.to_string()))?;
 
-        self.store
-            .config
-            .insert(PASSWORD_HASH_KEY, password_hash.into())
-            .await?;
-
         let permissions = Permission::all_permissions();
         let account = self
             .store
             .account
             .upsert(self.provider, BOOTSTRAP_ADMIN_SUBJECT, None, &permissions)
             .await?;
+
+        if !self
+            .store
+            .config
+            .insert_if_absent(PASSWORD_HASH_KEY, password_hash.into())
+            .await?
+        {
+            return Err(DataError::Conflict("Admin account already created".into()).into());
+        }
 
         let token = self.jwt_authenticator.encode(account)?;
 
@@ -117,20 +121,14 @@ impl AuthUseCases for AuthService {
                     return Err(AuthenticationError::InvalidCredentials.into());
                 }
 
-                let account = match self
+                let account = self
                     .store
                     .account
                     .find_by_identity(self.provider, BOOTSTRAP_ADMIN_SUBJECT)
                     .await?
-                {
-                    Some(account) => account,
-                    None => {
-                        self.store
-                            .account
-                            .upsert(self.provider, BOOTSTRAP_ADMIN_SUBJECT, None, &[])
-                            .await?
-                    }
-                };
+                    .ok_or_else(|| {
+                        DataError::Inconsistency("Admin credentials exist without an account identity".to_string())
+                    })?;
 
                 let token = self.jwt_authenticator.encode(account)?;
 
@@ -243,7 +241,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        application::composition::MockAppStoreBuilder,
+        application::{composition::MockAppStoreBuilder, errors::DatabaseError},
         domains::{
             account::{Account, ApiKey, AuthClaims, AuthIdentity},
             asset::{Asset, Protocol, NATIVE_ASSET_REF},
@@ -363,10 +361,10 @@ mod tests {
                 store.config.expect_find().times(1).returning(|_| Ok(None));
                 store
                     .config
-                    .expect_insert()
+                    .expect_insert_if_absent()
                     .withf(|key, _| key == PASSWORD_HASH_KEY)
                     .times(1)
-                    .returning(|_, _| Ok(()));
+                    .returning(|_, _| Ok(true));
                 store
                     .account
                     .expect_upsert()
@@ -399,6 +397,63 @@ mod tests {
                 let token = service.sign_up("password".to_string()).await.unwrap();
 
                 assert_eq!(token, "token");
+            }
+        }
+
+        mod when_another_request_claims_the_admin_during_sign_up {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_conflict() {
+                let account_id = Uuid::new_v4();
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(None));
+                store
+                    .account
+                    .expect_upsert()
+                    .withf(|provider, subject, display_name, granted| {
+                        *provider == AuthProvider::Jwt
+                            && subject == "admin"
+                            && display_name.is_none()
+                            && granted == Permission::all_permissions().as_slice()
+                    })
+                    .times(1)
+                    .returning(move |provider, subject, _, permissions| {
+                        Ok(account_fixture(account_id, provider, subject, permissions.to_vec()))
+                    });
+                store
+                    .config
+                    .expect_insert_if_absent()
+                    .withf(|key, _| key == PASSWORD_HASH_KEY)
+                    .times(1)
+                    .returning(|_, _| Ok(false));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_up("password".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Conflict(_))));
+            }
+        }
+
+        mod when_admin_account_creation_fails {
+            use super::*;
+
+            #[tokio::test]
+            async fn does_not_claim_the_password() {
+                let mut store = MockAppStoreBuilder::new();
+                store.config.expect_find().times(1).returning(|_| Ok(None));
+                store
+                    .account
+                    .expect_upsert()
+                    .times(1)
+                    .returning(|_, _, _, _| Err(DatabaseError::Insert("boom".to_string())));
+
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_up("password".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Database(DatabaseError::Insert(_))));
             }
         }
     }
@@ -447,12 +502,11 @@ mod tests {
             }
         }
 
-        mod with_the_correct_password {
+        mod with_the_correct_password_but_missing_account_identity {
             use super::*;
 
             #[tokio::test]
-            async fn returns_token() {
-                let account_id = Uuid::new_v4();
+            async fn returns_inconsistency_without_recreating_the_account() {
                 let stored_hash = hash("correct", 4).unwrap();
 
                 let mut store = MockAppStoreBuilder::new();
@@ -467,33 +521,53 @@ mod tests {
                     .withf(|provider, subject| *provider == AuthProvider::Jwt && subject == "admin")
                     .times(1)
                     .returning(|_, _| Ok(None));
+                let service = service(MockJWTAuthenticator::new(), store, AuthProvider::Jwt);
+
+                let err = service.sign_in("correct".to_string()).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Inconsistency(_))));
+            }
+        }
+
+        mod with_the_correct_password_and_account_identity {
+            use super::*;
+
+            #[tokio::test]
+            async fn returns_token() {
+                let account_id = Uuid::new_v4();
+                let stored_hash = hash("correct", 4).unwrap();
+                let permissions = Permission::all_permissions();
+
+                let mut store = MockAppStoreBuilder::new();
+                store
+                    .config
+                    .expect_find()
+                    .times(1)
+                    .returning(move |_| Ok(Some(stored_hash.clone().into())));
+                let account_permissions = permissions.clone();
                 store
                     .account
-                    .expect_upsert()
-                    .withf(|provider, subject, display_name, granted| {
-                        *provider == AuthProvider::Jwt
-                            && subject == "admin"
-                            && display_name.is_none()
-                            && granted.is_empty()
-                    })
+                    .expect_find_by_identity()
+                    .withf(|provider, subject| *provider == AuthProvider::Jwt && subject == "admin")
                     .times(1)
-                    .returning(move |provider, subject, _, _| {
-                        Ok(account_fixture(
+                    .returning(move |provider, subject| {
+                        Ok(Some(account_fixture(
                             account_id,
                             provider,
                             subject,
-                            vec![Permission::ReadWallet],
-                        ))
+                            account_permissions.clone(),
+                        )))
                     });
 
+                let expected_permissions = permissions.clone();
                 let mut jwt = MockJWTAuthenticator::new();
                 jwt.expect_encode()
-                    .withf(|account| {
+                    .withf(move |account| {
                         account
                             .identity
                             .as_ref()
                             .is_some_and(|identity| identity.subject == "admin")
-                            && account.permissions.as_deref() == Some(&[Permission::ReadWallet][..])
+                            && account.permissions.as_ref() == Some(&expected_permissions)
                     })
                     .times(1)
                     .returning(|_| Ok("token".to_string()));

--- a/src/domains/invoice/invoice_service.rs
+++ b/src/domains/invoice/invoice_service.rs
@@ -10,7 +10,11 @@ use crate::{
         composition::{AppStore, Ledger},
         errors::{ApplicationError, DataError},
     },
-    domains::event::{EventUseCases, LnInvoicePaidEvent},
+    domains::{
+        asset::{Protocol, NATIVE_ASSET_REF},
+        bitcoin::BtcNetwork,
+        event::{EventUseCases, LnInvoicePaidEvent},
+    },
     infra::lightning::LnClient,
 };
 
@@ -23,6 +27,7 @@ pub struct InvoiceService {
     ln_client: Arc<dyn LnClient>,
     invoice_expiry: u32,
     events: Arc<dyn EventUseCases>,
+    network: BtcNetwork,
 }
 
 impl InvoiceService {
@@ -31,13 +36,38 @@ impl InvoiceService {
         ln_client: Arc<dyn LnClient>,
         invoice_expiry: u32,
         events: Arc<dyn EventUseCases>,
+        network: BtcNetwork,
     ) -> Self {
         InvoiceService {
             store,
             ln_client,
             invoice_expiry,
             events,
+            network,
         }
+    }
+
+    async fn ensure_wallet_network(&self, wallet_id: Uuid) -> Result<(), ApplicationError> {
+        let wallet = self
+            .store
+            .wallet
+            .find(wallet_id)
+            .await?
+            .ok_or_else(|| DataError::NotFound(format!("Wallet {wallet_id} not found")))?;
+        let asset = wallet.asset.ok_or_else(|| {
+            DataError::Inconsistency(format!(
+                "Wallet {wallet_id} is missing asset metadata for invoice validation"
+            ))
+        })?;
+        if asset.protocol == Protocol::Bitcoin && asset.asset_ref == NATIVE_ASSET_REF && asset.network == self.network {
+            return Ok(());
+        }
+
+        Err(DataError::Validation(format!(
+            "Wallet {wallet_id} holds {} on {}, but invoice creation requires native BTC on {}",
+            asset.display_ticker, asset.network, self.network
+        ))
+        .into())
     }
 }
 
@@ -51,6 +81,8 @@ impl InvoiceUseCases for InvoiceService {
         expiry: Option<u32>,
     ) -> Result<Invoice, ApplicationError> {
         debug!(%wallet_id, "Generating invoice");
+
+        self.ensure_wallet_network(wallet_id).await?;
 
         let invoice_id = Uuid::new_v4();
         let mut invoice = self
@@ -190,7 +222,7 @@ mod tests {
             composition::MockAppStoreBuilder,
             errors::{DatabaseError, LightningError},
         },
-        domains::{event::MockEventUseCases, invoice::LnInvoice},
+        domains::{asset::Asset, event::MockEventUseCases, invoice::LnInvoice, wallet::Wallet},
         infra::lightning::MockLnClient,
     };
 
@@ -198,8 +230,40 @@ mod tests {
 
     const EXPIRY: u32 = 3_600;
 
-    fn service(store: MockAppStoreBuilder, ln_client: MockLnClient, events: MockEventUseCases) -> InvoiceService {
-        InvoiceService::new(store.build(), Arc::new(ln_client), EXPIRY, Arc::new(events))
+    fn service(mut store: MockAppStoreBuilder, ln_client: MockLnClient, events: MockEventUseCases) -> InvoiceService {
+        store.wallet.expect_find().returning(|wallet_id| {
+            Ok(Some(Wallet {
+                id: wallet_id,
+                asset: Some(native_btc_asset(BtcNetwork::Regtest)),
+                ..Default::default()
+            }))
+        });
+        raw_service(store, ln_client, events)
+    }
+
+    fn raw_service(store: MockAppStoreBuilder, ln_client: MockLnClient, events: MockEventUseCases) -> InvoiceService {
+        InvoiceService::new(
+            store.build(),
+            Arc::new(ln_client),
+            EXPIRY,
+            Arc::new(events),
+            BtcNetwork::Regtest,
+        )
+    }
+
+    fn native_btc_asset(network: BtcNetwork) -> Asset {
+        Asset {
+            id: Uuid::new_v4(),
+            code: "BTC".to_string(),
+            name: Some("Bitcoin".to_string()),
+            protocol: Protocol::Bitcoin,
+            network,
+            asset_ref: NATIVE_ASSET_REF.to_string(),
+            display_ticker: "BTC".to_string(),
+            decimals: 11,
+            created_at: Utc::now(),
+            updated_at: None,
+        }
     }
 
     fn lightning_invoice(payment_hash: &str, status: InvoiceStatus) -> Invoice {
@@ -300,6 +364,29 @@ mod tests {
                 let err = service.invoice(Uuid::new_v4(), 1_000, None, None).await.unwrap_err();
 
                 assert!(matches!(err, ApplicationError::Database(DatabaseError::Insert(_))));
+            }
+        }
+
+        mod when_wallet_network_differs_from_the_node {
+            use super::*;
+
+            #[tokio::test]
+            async fn rejects_before_requesting_an_invoice() {
+                let wallet_id = Uuid::new_v4();
+                let mut store = MockAppStoreBuilder::new();
+                store.wallet.expect_find().times(1).returning(move |_| {
+                    Ok(Some(Wallet {
+                        id: wallet_id,
+                        asset: Some(native_btc_asset(BtcNetwork::Bitcoin)),
+                        ..Default::default()
+                    }))
+                });
+
+                let service = raw_service(store, MockLnClient::new(), MockEventUseCases::new());
+
+                let err = service.invoice(wallet_id, 1_000, None, None).await.unwrap_err();
+
+                assert!(matches!(err, ApplicationError::Data(DataError::Validation(_))));
             }
         }
     }

--- a/src/domains/system/config_repository.rs
+++ b/src/domains/system/config_repository.rs
@@ -8,5 +8,6 @@ use crate::application::errors::DatabaseError;
 pub trait ConfigRepository: Send + Sync {
     async fn find(&self, key: &str) -> Result<Option<Value>, DatabaseError>;
     async fn insert(&self, key: &str, value: Value) -> Result<(), DatabaseError>;
+    async fn insert_if_absent(&self, key: &str, value: Value) -> Result<bool, DatabaseError>;
     async fn upsert(&self, key: &str, value: Value) -> Result<(), DatabaseError>;
 }

--- a/src/domains/wallet/account_wallet_handler.rs
+++ b/src/domains/wallet/account_wallet_handler.rs
@@ -776,7 +776,7 @@ async fn delete_failed_payments(
 
 /// Generate a new API Key
 ///
-/// Returns the generated API Key for the account. Users can create API keys with
+/// Returns the generated API Key for the account. Callers can create API keys with
 /// permissions as a subset of their current permissions.
 #[utoipa::path(
     post,

--- a/src/infra/database/sea_orm/repositories/sea_orm_config_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_config_repository.rs
@@ -1,10 +1,12 @@
 use crate::{
     application::errors::DatabaseError,
     domains::system::ConfigRepository,
-    infra::database::sea_orm::models::{config::ActiveModel, prelude::Config},
+    infra::database::sea_orm::models::{config, config::ActiveModel, prelude::Config},
 };
 use async_trait::async_trait;
-use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
+use sea_orm::{
+    sea_query::OnConflict, ActiveModelTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryTrait, Set,
+};
 use serde_json::Value;
 
 #[derive(Clone)]
@@ -45,6 +47,23 @@ impl ConfigRepository for SeaOrmConfigRepository {
             .map_err(|e| DatabaseError::Insert(e.to_string()))?;
 
         Ok(())
+    }
+
+    async fn insert_if_absent(&self, key: &str, value: Value) -> Result<bool, DatabaseError> {
+        let model = ActiveModel {
+            key: Set(key.to_string()),
+            value: Set(Some(value)),
+        };
+        let statement = Config::insert(model)
+            .on_conflict(OnConflict::column(config::Column::Key).do_nothing().to_owned())
+            .build(self.db.get_database_backend());
+        let result = self
+            .db
+            .execute(statement)
+            .await
+            .map_err(|e| DatabaseError::Insert(e.to_string()))?;
+
+        Ok(result.rows_affected() == 1)
     }
 
     async fn upsert(&self, key: &str, value: Value) -> Result<(), DatabaseError> {

--- a/src/infra/database/sea_orm/uow_tests.rs
+++ b/src/infra/database/sea_orm/uow_tests.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::application::composition::Ledger;
 use crate::application::errors::{ApplicationError, DataError};
-use crate::domains::account::{AccountFilter, AccountRepository, AuthProvider, Permission};
+use crate::domains::account::{AccountFilter, AccountRepository, ApiKey, ApiKeyRepository, AuthProvider, Permission};
 use crate::domains::event::EventProjectionUnitOfWork;
 use crate::domains::invoice::{Invoice, InvoiceRepository};
 use crate::domains::payment::{LnPayment, Payment, PaymentStatus, PaymentUnitOfWork};
@@ -25,8 +25,8 @@ use crate::domains::{asset::AssetRepository, bitcoin::BtcNetwork, wallet::Wallet
 
 use super::models::{prelude::Wallet, wallet};
 use super::{
-    SeaOrmAccountRepository, SeaOrmAssetRepository, SeaOrmEventProjectionUnitOfWork, SeaOrmInvoiceRepository,
-    SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
+    SeaOrmAccountRepository, SeaOrmApiKeyRepository, SeaOrmAssetRepository, SeaOrmEventProjectionUnitOfWork,
+    SeaOrmInvoiceRepository, SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
 };
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -386,6 +386,16 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
     let wallet = wallet_repo.upsert(account.id, asset.id).await.unwrap();
     assert!(wallet_repo.exists_for_account(account.id, wallet.id).await.unwrap());
     assert!(!wallet_repo.exists_for_account(Uuid::new_v4(), wallet.id).await.unwrap());
+    SeaOrmApiKeyRepository::new(conn.clone())
+        .insert(ApiKey {
+            account_id: account.id,
+            name: "operator key".to_string(),
+            key_hash: vec![42; 32],
+            permissions: vec![Permission::ReadWallet],
+            ..Default::default()
+        })
+        .await
+        .unwrap();
 
     assert_eq!(
         repo.delete_many(AccountFilter {
@@ -403,6 +413,7 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
         0
     );
     assert_eq!(count(&conn, "SELECT COUNT(*) AS count FROM wallet").await, 0);
+    assert_eq!(count(&conn, "SELECT COUNT(*) AS count FROM api_key").await, 0);
 }
 
 #[tokio::test]

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement};
 use uuid::Uuid;
 
 use swissknife_types::{
@@ -15,10 +14,12 @@ use super::wait::wait_until;
 use super::TestApp;
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
+const MAINNET_BTC_ASSET_ID: &str = "00000000-0000-4000-8000-000000000001";
 const REGTEST_BTC_ASSET_ID: &str = "00000000-0000-4000-8000-000000000004";
+const SIGNET_BTC_ASSET_ID: &str = "00000000-0000-4000-8000-000000000006";
 
 /// A process-unique, lowercase identifier with the given prefix, so tests
-/// sharing one instance never collide on wallet user ids, usernames, etc.
+/// sharing one instance never collide on identity subjects, usernames, etc.
 pub fn unique(prefix: &str) -> String {
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("{prefix}-{}-{n}", std::process::id()).to_ascii_lowercase()
@@ -27,6 +28,16 @@ pub fn unique(prefix: &str) -> String {
 impl TestApp {
     /// Create an administrator-managed account without a login identity.
     pub async fn create_account(&self, token: &str, display_name: &str) -> Account {
+        self.create_account_with_permissions(token, display_name, vec![]).await
+    }
+
+    /// Create an administrator-managed account with the requested stored permissions.
+    pub async fn create_account_with_permissions(
+        &self,
+        token: &str,
+        display_name: &str,
+        permissions: Vec<Permission>,
+    ) -> Account {
         let res = self
             .api()
             .post(
@@ -34,7 +45,7 @@ impl TestApp {
                 Auth::Bearer(token),
                 CreateAccountRequest {
                     display_name: Some(display_name.to_string()),
-                    permissions: vec![],
+                    permissions,
                 },
             )
             .await;
@@ -45,9 +56,8 @@ impl TestApp {
     /// Provision a fresh account and return its regtest BTC wallet. Behavioural
     /// tests use their own account wallet so balances stay isolated on the
     /// shared instance.
-    pub async fn create_wallet(&self, token: &str, _label: &str) -> Wallet {
-        let account_id = Uuid::new_v4();
-        self.create_account_fixture(account_id).await;
+    pub async fn create_wallet(&self, token: &str, label: &str) -> Wallet {
+        let account = self.create_account(token, label).await;
 
         let res = self
             .api()
@@ -55,7 +65,7 @@ impl TestApp {
                 "/v1/wallets",
                 Auth::Bearer(token),
                 CreateWalletRequest {
-                    account_id: Some(account_id),
+                    account_id: Some(account.id),
                     asset_id: regtest_btc_asset_id(),
                 },
             )
@@ -131,11 +141,10 @@ impl TestApp {
             .expect("a freshly created key returns its secret")
     }
 
-    /// Mint an API key for `account_id` via the admin endpoint with `permissions`,
-    /// returning its secret. The key authenticates into that account.
-    pub async fn user_api_key(&self, token: &str, account_id: Uuid, permissions: Vec<Permission>) -> String {
-        self.create_account_fixture(account_id).await;
-
+    /// Mint an API key for `account_id` via the admin endpoint with
+    /// `permissions`, returning its secret. The key authenticates into that
+    /// account.
+    pub async fn account_api_key(&self, token: &str, account_id: Uuid, permissions: Vec<Permission>) -> String {
         let res = self
             .api()
             .post(
@@ -143,57 +152,25 @@ impl TestApp {
                 Auth::Bearer(token),
                 CreateApiKeyRequest {
                     account_id: Some(account_id),
-                    name: unique("user-key"),
+                    name: unique("account-key"),
                     permissions,
                     description: None,
                     expiry: None,
                 },
             )
             .await;
-        assert_eq!(res.status.as_u16(), 200, "mint user key failed: {}", res.body);
+        assert_eq!(res.status.as_u16(), 200, "mint account key failed: {}", res.body);
         res.parse::<ApiKey>()
             .key
             .expect("a freshly created key returns its secret")
     }
 
-    async fn create_account_fixture(&self, account_id: Uuid) {
-        let db = Database::connect(&self.database_url)
-            .await
-            .expect("connect to integration database");
-        let backend = db.get_database_backend();
-        let identity_id = uuid_literal(backend, Uuid::new_v4());
-        let subject = sql_string_literal(&format!("fixture:{account_id}"));
-        let account_id = uuid_literal(backend, account_id);
-
-        for sql in [
-            format!(
-                "INSERT INTO account (id, permissions, created_at) \
-                 VALUES ({account_id}, '[]', CURRENT_TIMESTAMP) \
-                 ON CONFLICT (id) DO NOTHING"
-            ),
-            format!(
-                "INSERT INTO auth_identity (id, account_id, provider, subject, created_at) \
-                 VALUES ({identity_id}, {account_id}, 'jwt', {subject}, CURRENT_TIMESTAMP) \
-                 ON CONFLICT (provider, subject) DO NOTHING"
-            ),
-            format!(
-                "INSERT INTO account_preference (account_id, dashboard_settings, created_at) \
-                 VALUES ({account_id}, '{{}}', CURRENT_TIMESTAMP) \
-                 ON CONFLICT (account_id) DO NOTHING"
-            ),
-        ] {
-            db.execute(Statement::from_string(backend, sql))
-                .await
-                .expect("seed integration account fixture");
-        }
-    }
-
-    /// Register a fresh wallet and a full-permission API key for it: a distinct
-    /// external account for exercising the `/me` endpoints.
-    pub async fn create_user(&self, token: &str, _label: &str) -> TestUser {
-        let account_id = Uuid::new_v4();
+    /// Create a fresh account, a full-permission API key, and its regtest BTC
+    /// wallet through public HTTP endpoints for exercising `/v1/me` routes.
+    pub async fn create_account_with_wallet(&self, token: &str, label: &str) -> TestAccount {
+        let account = self.create_account(token, label).await;
         let key = self
-            .user_api_key(token, account_id, Permission::all_permissions())
+            .account_api_key(token, account.id, Permission::all_permissions())
             .await;
         let res = self
             .api()
@@ -206,35 +183,31 @@ impl TestApp {
                 },
             )
             .await;
-        assert_eq!(
-            res.status.as_u16(),
-            200,
-            "create_user /v1/me/wallets failed: {}",
-            res.body
-        );
+        assert_eq!(res.status.as_u16(), 200, "create account wallet failed: {}", res.body);
         let wallet = res.parse::<Wallet>();
-        TestUser { wallet, key }
+        TestAccount { account, wallet, key }
     }
 }
 
-/// A distinct user (own wallet) with an API-key credential, for `/me` tests.
-pub struct TestUser {
+/// A distinct account with an API-key credential and regtest BTC wallet.
+pub struct TestAccount {
+    pub account: Account,
     pub wallet: Wallet,
     pub key: String,
 }
 
-fn uuid_literal(backend: DatabaseBackend, id: Uuid) -> String {
-    match backend {
-        DatabaseBackend::Sqlite => format!("X'{}'", id.as_simple()),
-        DatabaseBackend::Postgres => format!("'{id}'::uuid"),
-        DatabaseBackend::MySql => format!("'{id}'"),
-    }
+pub fn regtest_btc_asset_id() -> Uuid {
+    seeded_asset_id(REGTEST_BTC_ASSET_ID)
 }
 
-fn regtest_btc_asset_id() -> Uuid {
-    Uuid::parse_str(REGTEST_BTC_ASSET_ID).expect("seeded regtest BTC asset ID is valid")
+pub fn mainnet_btc_asset_id() -> Uuid {
+    seeded_asset_id(MAINNET_BTC_ASSET_ID)
 }
 
-fn sql_string_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
+pub fn signet_btc_asset_id() -> Uuid {
+    seeded_asset_id(SIGNET_BTC_ASSET_ID)
+}
+
+fn seeded_asset_id(value: &str) -> Uuid {
+    Uuid::parse_str(value).expect("seeded BTC asset ID is valid")
 }

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -17,7 +17,7 @@ use tokio::{
 use super::client::{ApiClient, Auth};
 use super::db::TestDatabase;
 
-/// Password for the bootstrap admin user created during [`TestApp::start`].
+/// Password for the bootstrap admin account created during [`TestApp::start`].
 pub const ADMIN_PASSWORD: &str = "integration-admin-password";
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(90);
@@ -66,7 +66,6 @@ pub async fn app() -> &'static TestApp {
 pub struct TestApp {
     pub base_url: String,
     pub database: String,
-    pub database_url: String,
     pub provider: String,
     admin_jwt: String,
     stdout_path: PathBuf,
@@ -84,7 +83,6 @@ pub fn matrix_cell() -> (String, String) {
 /// A spawned, ready SwissKnife instance: its base URL and log paths.
 pub struct Spawned {
     pub base_url: String,
-    pub database_url: String,
     pub stdout_path: PathBuf,
     pub stderr_path: PathBuf,
 }
@@ -101,7 +99,6 @@ pub async fn spawn_instance(database: &str, provider: &str, label: &str, extra_e
     let root = repo_root();
 
     let db = TestDatabase::provision(database, &root, label).await;
-    let database_url = db.url().to_string();
     let port = free_port();
     let base_url = format!("http://127.0.0.1:{port}");
 
@@ -141,7 +138,6 @@ pub async fn spawn_instance(database: &str, provider: &str, label: &str, extra_e
 
     Spawned {
         base_url,
-        database_url,
         stdout_path,
         stderr_path,
     }
@@ -160,7 +156,6 @@ impl TestApp {
         TestApp {
             base_url: spawned.base_url,
             database,
-            database_url: spawned.database_url,
             provider,
             admin_jwt,
             stdout_path: spawned.stdout_path,
@@ -198,18 +193,6 @@ async fn bootstrap_admin(api: &ApiClient) -> String {
         .as_str()
         .expect("auth response contains a token")
         .to_string();
-
-    // The admin's wallet is provisioned lazily on the first authenticated
-    // request, and that path is a non-atomic find-then-insert (see the itest
-    // follow-up issue). Trigger it once here, serially, so parallel tests never
-    // race to create the same wallet.
-    let warmup = api.get("/v1/me", Auth::Bearer(&token)).await;
-    assert_eq!(
-        warmup.status.as_u16(),
-        200,
-        "admin warmup (/v1/me) failed: {}",
-        warmup.body
-    );
 
     token
 }

--- a/tests/common/oauth2.rs
+++ b/tests/common/oauth2.rs
@@ -13,7 +13,7 @@ use reqwest::Client;
 use serde_json::Value;
 use tokio::sync::OnceCell;
 
-use super::client::{ApiClient, Auth};
+use super::client::ApiClient;
 use super::harness::{matrix_cell, spawn_instance};
 
 /// Audience the IdP mints into tokens and the instance is configured to require.
@@ -26,6 +26,7 @@ pub const ISSUER_ID: &str = "default";
 /// `client_id`s the IdP config maps to specific claim sets.
 pub const CLIENT_FULL: &str = "itest-full"; // all permissions
 pub const CLIENT_READONLY: &str = "itest-readonly"; // read:wallet only
+pub const CLIENT_CONCURRENT: &str = "itest-concurrent"; // fresh provisioning subject
 pub const CLIENT_WRONG_AUD: &str = "itest-wrong-aud"; // mismatched audience
 
 /// Host:port at which both the binary and the tests reach the IdP, so the
@@ -71,28 +72,9 @@ impl OAuth2App {
         )
         .await;
 
-        let app = OAuth2App {
+        OAuth2App {
             base_url: spawned.base_url,
             idp_base,
-        };
-        app.warmup().await;
-        app
-    }
-
-    /// Provision the wallets for the fixed subjects up front, serially, so
-    /// parallel tests never race the non-atomic first-login wallet creation
-    /// (see bitcoin-numeraire/swissknife#254). `/v1/me` runs no permission check,
-    /// so any authenticated token reaches it.
-    async fn warmup(&self) {
-        for client_id in [CLIENT_FULL, CLIENT_READONLY] {
-            let token = self.token(client_id).await;
-            let res = self.api().get("/v1/me", Auth::Bearer(&token)).await;
-            assert_eq!(
-                res.status.as_u16(),
-                200,
-                "oauth2 warmup (/v1/me) for {client_id} failed: {}",
-                res.body
-            );
         }
     }
 

--- a/tests/itest/README.md
+++ b/tests/itest/README.md
@@ -33,12 +33,20 @@ config/itest.toml   all static SwissKnife test config (RUN_MODE=itest)
 make itest-up                      # bring up + initialize the regtest stack (idempotent)
 make test-integration              # default cell: sqlite + lnd_grpc
 make test-integration ITEST_DATABASE=postgres ITEST_PROVIDER=cln_grpc
+make test-integration-fresh        # recreate volumes, then run sqlite + lnd_grpc
 make itest-shutdown                # stop stack + delete runtime/artifacts
 ```
 
 `make test-integration` brings the stack up first, then runs
 `cargo test --features itest --test api` for the selected cell. A plain
 `cargo test` runs only unit tests (the suite is feature-gated).
+
+Use `make test-integration-fresh` before a local liquidity-sensitive run when
+the previous channel balances or chain state are unknown. The fresh target runs
+test cases serially to avoid unrelated SQLite writers contending for the same
+database; concurrency scenarios still issue simultaneous requests inside their
+test case. CI jobs start with a new runner and therefore already get fresh
+dependency volumes.
 
 ## Persistence (Unit-of-Work) tests
 
@@ -90,8 +98,19 @@ audience must match the harness-set `SWISSKNIFE_OAUTH2__AUDIENCE`.
 One shared SwissKnife instance per `(database, provider)` cell (plus the shared
 OAuth2 instance once the oauth2 suite runs); each gets its own database. Tests
 isolate by creating uniquely-named entities and asserting on presence rather
-than global totals. The admin (JWT) and the OAuth2 subjects' wallets are
-provisioned once during startup.
+than global totals.
+
+Fixtures are explicit and use the same public API as clients: the harness signs
+up the local admin, while behavioral tests create their account with
+`POST /v1/accounts`, mint an account API key, and create the required asset
+wallets before exercising `/v1/me`. OAuth2 tests deliberately provision their
+subjects on the request under test, including simultaneous first requests. No
+account, identity, or wallet rows are inserted directly by the test harness.
+
+The `asset_scoping` suite creates mainnet, regtest, and signet BTC wallets for
+one account. It verifies that balances, resources, reservations, and overview
+aggregates stay attached to the concrete wallet and that the regtest runtime
+rejects invoice/payment operations through incompatible network wallets.
 
 ## Coverage
 

--- a/tests/itest/config/mock-oauth2/config.json
+++ b/tests/itest/config/mock-oauth2/config.json
@@ -38,6 +38,15 @@
         },
         {
           "requestParam": "client_id",
+          "match": "itest-concurrent",
+          "claims": {
+            "sub": "itest-oauth2-concurrent",
+            "aud": ["https://swissknife.itest/api"],
+            "permissions": ["read:wallet"]
+          }
+        },
+        {
+          "requestParam": "client_id",
           "match": "itest-wrong-aud",
           "claims": {
             "sub": "itest-oauth2-wrong-aud",

--- a/tests/suites/accounts.rs
+++ b/tests/suites/accounts.rs
@@ -1,115 +1,213 @@
-//! `/v1/accounts` administrator-managed account CRUD.
+//! `/v1/accounts` administrative account lifecycle and permission enforcement.
 
 use reqwest::StatusCode;
 
 use swissknife_types::{
-    Account, CreateAccountRequest, Permission, UpdateAccountPermissionsRequest, UpdateAccountRequest,
+    Account, CreateAccountRequest, CreateWalletRequest, Permission, RegisterLnAddressRequest,
+    UpdateAccountPermissionsRequest, UpdateAccountRequest, Wallet,
 };
 
-use crate::common::fixtures::unique;
+use crate::common::fixtures::{regtest_btc_asset_id, unique};
 use crate::common::{app, assert_error, assert_status, Auth};
 
-#[tokio::test]
-async fn manages_an_account_without_a_login_identity() {
-    let app = app().await;
-    let token = app.admin_token().await;
-    let display_name = unique("account");
+mod lifecycle {
+    use super::*;
 
-    let created = app
-        .api()
-        .post(
-            "/v1/accounts",
-            Auth::Bearer(token),
-            CreateAccountRequest {
-                display_name: Some(display_name.clone()),
-                permissions: vec![Permission::ReadWallet],
-            },
-        )
-        .await;
-    assert_status(&created, StatusCode::OK);
-    let created = created.parse::<Account>();
-    assert_eq!(created.display_name.as_deref(), Some(display_name.as_str()));
-    assert_eq!(created.permissions, Some(vec![Permission::ReadWallet]));
-    assert!(created.identity.is_none());
+    #[tokio::test]
+    async fn creates_lists_updates_permissions_and_deletes_an_account_aggregate() {
+        let app = app().await;
+        let admin = app.admin_token().await;
+        let display_name = unique("account-lifecycle");
+        let request = CreateAccountRequest {
+            display_name: Some(display_name.clone()),
+            permissions: vec![Permission::ReadWallet],
+        };
 
-    let updated = app
-        .api()
-        .put(
-            &format!("/v1/accounts/{}", created.id),
-            Auth::Bearer(token),
-            UpdateAccountRequest {
-                display_name: Some("Treasury".to_string()),
-            },
-        )
-        .await;
-    assert_status(&updated, StatusCode::OK);
-    assert_eq!(updated.parse::<Account>().display_name.as_deref(), Some("Treasury"));
+        let created = app.api().post("/v1/accounts", Auth::Bearer(admin), request).await;
+        assert_status(&created, StatusCode::OK);
+        let created = created.parse::<Account>();
+        assert_eq!(created.display_name.as_deref(), Some(display_name.as_str()));
+        assert!(created.identity.is_none());
+        assert_eq!(created.permissions.as_deref(), Some(&[Permission::ReadWallet][..]));
 
-    let permissions = app
-        .api()
-        .put(
-            &format!("/v1/accounts/{}/permissions", created.id),
-            Auth::Bearer(token),
-            UpdateAccountPermissionsRequest {
-                permissions: vec![Permission::ReadAccount, Permission::WriteWallet],
-            },
-        )
-        .await;
-    assert_status(&permissions, StatusCode::OK);
-    assert_eq!(
-        permissions.parse::<Account>().permissions,
-        Some(vec![Permission::ReadAccount, Permission::WriteWallet])
-    );
+        let listed = app.api().get("/v1/accounts?limit=1000", Auth::Bearer(admin)).await;
+        assert_status(&listed, StatusCode::OK);
+        assert!(listed
+            .parse::<Vec<Account>>()
+            .iter()
+            .any(|account| account.id == created.id));
 
-    let listed = app.api().get("/v1/accounts", Auth::Bearer(token)).await;
-    assert_status(&listed, StatusCode::OK);
-    assert!(listed
-        .parse::<Vec<Account>>()
-        .iter()
-        .any(|account| account.id == created.id));
+        let fetched = app
+            .api()
+            .get(&format!("/v1/accounts/{}", created.id), Auth::Bearer(admin))
+            .await;
+        assert_status(&fetched, StatusCode::OK);
+        assert_eq!(fetched.parse::<Account>().id, created.id);
 
-    let deleted = app
-        .api()
-        .delete(&format!("/v1/accounts/{}", created.id), Auth::Bearer(token))
-        .await;
-    assert_status(&deleted, StatusCode::OK);
+        let updated = app
+            .api()
+            .put(
+                &format!("/v1/accounts/{}", created.id),
+                Auth::Bearer(admin),
+                UpdateAccountRequest {
+                    display_name: Some("Updated account".to_string()),
+                },
+            )
+            .await;
+        assert_status(&updated, StatusCode::OK);
+        assert_eq!(
+            updated.parse::<Account>().display_name.as_deref(),
+            Some("Updated account")
+        );
 
-    let missing = app
-        .api()
-        .get(&format!("/v1/accounts/{}", created.id), Auth::Bearer(token))
-        .await;
-    assert_error(&missing, StatusCode::NOT_FOUND);
+        let permissions = app
+            .api()
+            .put(
+                &format!("/v1/accounts/{}/permissions", created.id),
+                Auth::Bearer(admin),
+                UpdateAccountPermissionsRequest {
+                    permissions: vec![Permission::ReadWallet, Permission::WriteWallet, Permission::ReadWallet],
+                },
+            )
+            .await;
+        assert_status(&permissions, StatusCode::OK);
+        assert_eq!(
+            permissions.parse::<Account>().permissions.as_deref(),
+            Some(&[Permission::ReadWallet, Permission::WriteWallet][..])
+        );
+
+        let wallet = app
+            .api()
+            .post(
+                "/v1/wallets",
+                Auth::Bearer(admin),
+                CreateWalletRequest {
+                    account_id: Some(created.id),
+                    asset_id: regtest_btc_asset_id(),
+                },
+            )
+            .await;
+        assert_status(&wallet, StatusCode::OK);
+        let wallet = wallet.parse::<Wallet>();
+        let lightning_address = app
+            .api()
+            .post(
+                "/v1/lightning-addresses",
+                Auth::Bearer(admin),
+                RegisterLnAddressRequest {
+                    account_id: Some(created.id),
+                    username: unique("deleted-account"),
+                    allows_nostr: false,
+                    nostr_pubkey: None,
+                },
+            )
+            .await;
+        assert_status(&lightning_address, StatusCode::OK);
+        let lightning_address = lightning_address.parse::<swissknife_types::LnAddress>();
+        let account_key = app
+            .account_api_key(admin, created.id, Permission::all_permissions())
+            .await;
+
+        let deleted = app
+            .api()
+            .delete(&format!("/v1/accounts/{}", created.id), Auth::Bearer(admin))
+            .await;
+        assert_status(&deleted, StatusCode::OK);
+
+        let missing_account = app
+            .api()
+            .get(&format!("/v1/accounts/{}", created.id), Auth::Bearer(admin))
+            .await;
+        assert_error(&missing_account, StatusCode::NOT_FOUND);
+        let missing_wallet = app
+            .api()
+            .get(&format!("/v1/wallets/{}", wallet.id), Auth::Bearer(admin))
+            .await;
+        assert_error(&missing_wallet, StatusCode::NOT_FOUND);
+        let missing_address = app
+            .api()
+            .get(
+                &format!("/v1/lightning-addresses/{}", lightning_address.id),
+                Auth::Bearer(admin),
+            )
+            .await;
+        assert_error(&missing_address, StatusCode::NOT_FOUND);
+        let revoked_key = app.api().get("/v1/me", Auth::ApiKey(&account_key)).await;
+        assert_error(&revoked_key, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn bulk_deletes_selected_accounts() {
+        let app = app().await;
+        let admin = app.admin_token().await;
+        let first = app.create_account(admin, &unique("account")).await;
+        let second = app.create_account(admin, &unique("account")).await;
+
+        let deleted = app
+            .api()
+            .delete(
+                &format!("/v1/accounts?ids={}&ids={}", first.id, second.id),
+                Auth::Bearer(admin),
+            )
+            .await;
+
+        assert_status(&deleted, StatusCode::OK);
+        assert_eq!(deleted.parse::<u64>(), 2);
+    }
+
+    #[tokio::test]
+    async fn cannot_delete_the_authenticated_account() {
+        let app = app().await;
+        let admin = app.admin_token().await;
+        let account = app.api().get("/v1/me", Auth::Bearer(admin)).await.parse::<Account>();
+
+        let response = app
+            .api()
+            .delete(&format!("/v1/accounts/{}", account.id), Auth::Bearer(admin))
+            .await;
+
+        assert_error(&response, StatusCode::CONFLICT);
+    }
 }
 
-#[tokio::test]
-async fn bulk_deletes_selected_accounts() {
-    let app = app().await;
-    let token = app.admin_token().await;
-    let first = app.create_account(token, &unique("account")).await;
-    let second = app.create_account(token, &unique("account")).await;
+mod permissions {
+    use super::*;
 
-    let deleted = app
-        .api()
-        .delete(
-            &format!("/v1/accounts?ids={}&ids={}", first.id, second.id),
-            Auth::Bearer(token),
-        )
-        .await;
+    #[tokio::test]
+    async fn read_and_write_scopes_are_enforced_independently() {
+        let app = app().await;
+        let admin = app.admin_token().await;
+        let read_key = app.api_key(admin, vec![Permission::ReadAccount]).await;
+        let write_key = app.api_key(admin, vec![Permission::WriteAccount]).await;
 
-    assert_status(&deleted, StatusCode::OK);
-    assert_eq!(deleted.parse::<u64>(), 2);
-}
+        let list = app.api().get("/v1/accounts?limit=1", Auth::ApiKey(&read_key)).await;
+        assert_status(&list, StatusCode::OK);
+        let create_with_read = app
+            .api()
+            .post(
+                "/v1/accounts",
+                Auth::ApiKey(&read_key),
+                CreateAccountRequest {
+                    display_name: None,
+                    permissions: vec![],
+                },
+            )
+            .await;
+        assert_error(&create_with_read, StatusCode::FORBIDDEN);
 
-#[tokio::test]
-async fn rejects_deleting_the_authenticated_account() {
-    let app = app().await;
-    let token = app.admin_token().await;
-    let account = app.api().get("/v1/me", Auth::Bearer(token)).await.parse::<Account>();
-
-    let deleted = app
-        .api()
-        .delete(&format!("/v1/accounts/{}", account.id), Auth::Bearer(token))
-        .await;
-
-    assert_error(&deleted, StatusCode::CONFLICT);
+        let created = app
+            .api()
+            .post(
+                "/v1/accounts",
+                Auth::ApiKey(&write_key),
+                CreateAccountRequest {
+                    display_name: None,
+                    permissions: vec![],
+                },
+            )
+            .await;
+        assert_status(&created, StatusCode::OK);
+        let list_with_write = app.api().get("/v1/accounts?limit=1", Auth::ApiKey(&write_key)).await;
+        assert_error(&list_with_write, StatusCode::FORBIDDEN);
+    }
 }

--- a/tests/suites/asset_scoping.rs
+++ b/tests/suites/asset_scoping.rs
@@ -1,0 +1,176 @@
+//! Multi-asset wallet isolation for one account. These assertions fail if
+//! balances, resources, or overview aggregates are keyed by account or ticker
+//! instead of the concrete wallet and asset network.
+
+use reqwest::StatusCode;
+
+use swissknife_types::{
+    Balance, BtcNetwork, CreateWalletRequest, Invoice, NewInvoiceRequest, SendPaymentRequest, Wallet, WalletOverview,
+};
+
+use crate::common::fixtures::{mainnet_btc_asset_id, signet_btc_asset_id};
+use crate::common::{app, assert_error, assert_status, Auth};
+
+#[tokio::test]
+async fn keeps_balances_resources_and_aggregates_separate_across_bitcoin_networks() {
+    let app = app().await;
+    let admin = app.admin_token().await;
+    let account = app.create_account_with_wallet(admin, "asset-scope").await;
+    let regtest = account.wallet;
+
+    let mainnet = create_wallet(app, &account.key, mainnet_btc_asset_id()).await;
+    let signet = create_wallet(app, &account.key, signet_btc_asset_id()).await;
+    let mainnet_again = create_wallet(app, &account.key, mainnet_btc_asset_id()).await;
+    assert_eq!(mainnet_again.id, mainnet.id, "one wallet exists per account and asset");
+
+    let wallets = app
+        .api()
+        .get("/v1/me/wallets?limit=1000", Auth::ApiKey(&account.key))
+        .await;
+    assert_status(&wallets, StatusCode::OK);
+    let wallets = wallets.parse::<Vec<Wallet>>();
+    assert_eq!(
+        wallets
+            .iter()
+            .filter(|wallet| wallet.account_id == account.account.id)
+            .count(),
+        3
+    );
+    assert_network(&wallets, regtest.id, BtcNetwork::Regtest);
+    assert_network(&wallets, mainnet.id, BtcNetwork::Bitcoin);
+    assert_network(&wallets, signet.id, BtcNetwork::Signet);
+
+    app.fund_onchain(admin, regtest.id, 100_000).await;
+    let regtest_balance = balance(app, &account.key, regtest.id).await;
+    let mainnet_balance = balance(app, &account.key, mainnet.id).await;
+    let signet_balance = balance(app, &account.key, signet.id).await;
+    assert!(regtest_balance.available_msat >= 100_000_000);
+    assert_eq!(mainnet_balance.available_msat, 0);
+    assert_eq!(signet_balance.available_msat, 0);
+
+    let invoice = app
+        .api()
+        .post(
+            &format!("/v1/me/wallets/{}/invoices", regtest.id),
+            Auth::ApiKey(&account.key),
+            NewInvoiceRequest {
+                wallet_id: None,
+                amount_msat: 25_000,
+                description: Some("network-scoped invoice".to_string()),
+                expiry: None,
+            },
+        )
+        .await;
+    assert_status(&invoice, StatusCode::OK);
+    let invoice = invoice.parse::<Invoice>();
+
+    let regtest_invoices = app
+        .api()
+        .get(
+            &format!("/v1/me/wallets/{}/invoices", regtest.id),
+            Auth::ApiKey(&account.key),
+        )
+        .await;
+    assert!(regtest_invoices
+        .parse::<Vec<Invoice>>()
+        .iter()
+        .any(|candidate| candidate.id == invoice.id));
+    let mainnet_invoices = app
+        .api()
+        .get(
+            &format!("/v1/me/wallets/{}/invoices", mainnet.id),
+            Auth::ApiKey(&account.key),
+        )
+        .await;
+    assert_status(&mainnet_invoices, StatusCode::OK);
+    assert!(mainnet_invoices.parse::<Vec<Invoice>>().is_empty());
+
+    let incompatible_invoice = app
+        .api()
+        .post(
+            &format!("/v1/me/wallets/{}/invoices", mainnet.id),
+            Auth::ApiKey(&account.key),
+            NewInvoiceRequest {
+                wallet_id: None,
+                amount_msat: 25_000,
+                description: None,
+                expiry: None,
+            },
+        )
+        .await;
+    assert_error(&incompatible_invoice, StatusCode::UNPROCESSABLE_ENTITY);
+
+    let incompatible_payment = app
+        .api()
+        .post(
+            &format!("/v1/me/wallets/{}/payments", mainnet.id),
+            Auth::ApiKey(&account.key),
+            SendPaymentRequest {
+                wallet_id: None,
+                input: invoice.ln_invoice.expect("Lightning invoice").bolt11,
+                amount_msat: None,
+                comment: None,
+            },
+        )
+        .await;
+    assert_error(&incompatible_payment, StatusCode::UNPROCESSABLE_ENTITY);
+    let unchanged_mainnet_balance = balance(app, &account.key, mainnet.id).await;
+    assert_eq!(unchanged_mainnet_balance.available_msat, 0);
+    assert_eq!(unchanged_mainnet_balance.reserved_msat, 0);
+
+    let overviews = app.api().get("/v1/wallets/overviews", Auth::Bearer(admin)).await;
+    assert_status(&overviews, StatusCode::OK);
+    let overviews = overviews.parse::<Vec<WalletOverview>>();
+    let regtest_overview = overview(&overviews, regtest.id);
+    let mainnet_overview = overview(&overviews, mainnet.id);
+    let signet_overview = overview(&overviews, signet.id);
+    assert_eq!(regtest_overview.balance.available_msat, regtest_balance.available_msat);
+    assert!(
+        regtest_overview.n_invoices >= 1,
+        "the regtest overview includes its Lightning and deposit activity"
+    );
+    assert_eq!(mainnet_overview.balance.available_msat, 0);
+    assert_eq!(mainnet_overview.n_invoices, 0);
+    assert_eq!(signet_overview.balance.available_msat, 0);
+    assert_eq!(signet_overview.n_invoices, 0);
+}
+
+async fn create_wallet(app: &crate::common::TestApp, key: &str, asset_id: uuid::Uuid) -> Wallet {
+    let response = app
+        .api()
+        .post(
+            "/v1/me/wallets",
+            Auth::ApiKey(key),
+            CreateWalletRequest {
+                account_id: None,
+                asset_id,
+            },
+        )
+        .await;
+    assert_status(&response, StatusCode::OK);
+    response.parse::<Wallet>()
+}
+
+async fn balance(app: &crate::common::TestApp, key: &str, wallet_id: uuid::Uuid) -> Balance {
+    let response = app
+        .api()
+        .get(&format!("/v1/me/wallets/{wallet_id}/balance"), Auth::ApiKey(key))
+        .await;
+    assert_status(&response, StatusCode::OK);
+    response.parse::<Balance>()
+}
+
+fn assert_network(wallets: &[Wallet], wallet_id: uuid::Uuid, expected: BtcNetwork) {
+    let wallet = wallets
+        .iter()
+        .find(|wallet| wallet.id == wallet_id)
+        .expect("wallet is listed");
+    assert_eq!(wallet.asset.as_ref().expect("asset metadata").network, expected);
+}
+
+fn overview(overviews: &[WalletOverview], wallet_id: uuid::Uuid) -> &WalletOverview {
+    overviews
+        .iter()
+        .find(|overview| overview.id == wallet_id)
+        .expect("wallet overview exists")
+}

--- a/tests/suites/auth.rs
+++ b/tests/suites/auth.rs
@@ -1,5 +1,6 @@
 //! `/v1/auth/*` (local JWT) plus auth-middleware enforcement on protected routes.
 
+use futures_util::future::join_all;
 use reqwest::StatusCode;
 
 use swissknife_types::{ChangePasswordRequest, SignInRequest, SignInResponse, SignUpRequest};
@@ -65,6 +66,48 @@ mod sign_up {
             )
             .await;
         assert_error(&res, StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn concurrent_sign_ups_have_one_winner_and_no_server_errors() {
+        let (database, provider) = matrix_cell();
+        let label = format!("{database}-{provider}-auth-concurrent-sign-up");
+        let spawned = spawn_instance(&database, &provider, &label, &[]).await;
+        let api = ApiClient::new(spawned.base_url);
+
+        let responses = join_all((0..8).map(|_| {
+            let api = api.clone();
+            async move {
+                api.post(
+                    "/v1/auth/sign-up",
+                    Auth::None,
+                    SignUpRequest {
+                        password: ADMIN_PASSWORD.to_string(),
+                    },
+                )
+                .await
+            }
+        }))
+        .await;
+
+        let mut winner = None;
+        let mut conflicts = 0;
+        for response in responses {
+            match response.status {
+                StatusCode::OK => winner = Some(response.parse::<SignInResponse>().token),
+                StatusCode::CONFLICT => conflicts += 1,
+                status => panic!("concurrent sign-up returned {status}: {}", response.body),
+            }
+        }
+        assert!(winner.is_some(), "one sign-up must create the admin account");
+        assert_eq!(conflicts, 7, "all losing sign-ups must report conflict");
+
+        let token = winner.expect("sign-up winner token");
+        let profile = api.get("/v1/me", Auth::Bearer(&token)).await;
+        assert_status(&profile, StatusCode::OK);
+        let wallets = api.get("/v1/me/wallets", Auth::Bearer(&token)).await;
+        assert_status(&wallets, StatusCode::OK);
+        assert_eq!(wallets.parse::<Vec<swissknife_types::Wallet>>().len(), 1);
     }
 }
 
@@ -170,12 +213,7 @@ mod change_password {
             )
             .await;
         assert_status(&res, StatusCode::OK);
-        let token = res.parse::<SignInResponse>().token;
-
-        let warmup = api.get("/v1/me", Auth::Bearer(&token)).await;
-        assert_status(&warmup, StatusCode::OK);
-
-        token
+        res.parse::<SignInResponse>().token
     }
 }
 

--- a/tests/suites/me.rs
+++ b/tests/suites/me.rs
@@ -1,4 +1,4 @@
-//! `/v1/me/*` — the account-scoped user surface. Authenticated callers get an
+//! `/v1/me/*` — the account-scoped caller surface. Authenticated callers get an
 //! account profile at `/v1/me`; money-moving operations require an explicit
 //! account-owned wallet in the path.
 
@@ -8,7 +8,7 @@ use serde_json::json;
 use swissknife_types::{
     Account, AccountPreferences, ApiKey, Balance, BtcAddress, Contact, CreateApiKeyRequest, Invoice, LnAddress,
     NewBtcAddressRequest, NewInvoiceRequest, Payment, PaymentStatus, Permission, RegisterLnAddressRequest,
-    SendPaymentRequest, UpdateAccountPreferencesRequest, UpdateLnAddressRequest, Wallet,
+    SendPaymentRequest, UpdateAccountPreferencesRequest, UpdateAccountRequest, UpdateLnAddressRequest, Wallet,
 };
 
 use crate::common::fixtures::unique;
@@ -21,13 +21,13 @@ mod account {
     async fn returns_the_callers_account_profile() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-profile").await;
+        let account = app.create_account_with_wallet(token, "me-profile").await;
 
-        let res = app.api().get("/v1/me", Auth::ApiKey(&user.key)).await;
+        let res = app.api().get("/v1/me", Auth::ApiKey(&account.key)).await;
         assert_status(&res, StatusCode::OK);
         let profile = res.parse::<Account>();
 
-        assert_eq!(profile.id, user.wallet.account_id);
+        assert_eq!(profile.id, account.wallet.account_id);
         assert!(profile
             .permissions
             .expect("profile exposes effective permissions")
@@ -35,11 +35,40 @@ mod account {
     }
 
     #[tokio::test]
+    async fn updates_the_callers_display_name() {
+        let app = app().await;
+        let token = app.admin_token().await;
+        let account = app.create_account_with_wallet(token, "me-display-name").await;
+
+        let updated = app
+            .api()
+            .put(
+                "/v1/me",
+                Auth::ApiKey(&account.key),
+                UpdateAccountRequest {
+                    display_name: Some("Dashboard account".to_string()),
+                },
+            )
+            .await;
+        assert_status(&updated, StatusCode::OK);
+        assert_eq!(
+            updated.parse::<Account>().display_name.as_deref(),
+            Some("Dashboard account")
+        );
+
+        let fetched = app.api().get("/v1/me", Auth::ApiKey(&account.key)).await;
+        assert_eq!(
+            fetched.parse::<Account>().display_name.as_deref(),
+            Some("Dashboard account")
+        );
+    }
+
+    #[tokio::test]
     async fn lists_only_the_callers_wallets() {
         let app = app().await;
         let token = app.admin_token().await;
-        let alice = app.create_user(token, "me-wallet-a").await;
-        let bob = app.create_user(token, "me-wallet-b").await;
+        let alice = app.create_account_with_wallet(token, "me-wallet-a").await;
+        let bob = app.create_account_with_wallet(token, "me-wallet-b").await;
 
         let res = app.api().get("/v1/me/wallets", Auth::ApiKey(&alice.key)).await;
         assert_status(&res, StatusCode::OK);
@@ -56,20 +85,23 @@ mod account {
     async fn gets_wallet_and_balance_by_path() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-wallet-get").await;
+        let account = app.create_account_with_wallet(token, "me-wallet-get").await;
 
         let wallet = app
             .api()
-            .get(&format!("/v1/me/wallets/{}", user.wallet.id), Auth::ApiKey(&user.key))
+            .get(
+                &format!("/v1/me/wallets/{}", account.wallet.id),
+                Auth::ApiKey(&account.key),
+            )
             .await;
         assert_status(&wallet, StatusCode::OK);
-        assert_eq!(wallet.parse::<Wallet>().id, user.wallet.id);
+        assert_eq!(wallet.parse::<Wallet>().id, account.wallet.id);
 
         let balance = app
             .api()
             .get(
-                &format!("/v1/me/wallets/{}/balance", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/balance", account.wallet.id),
+                Auth::ApiKey(&account.key),
             )
             .await;
         assert_status(&balance, StatusCode::OK);
@@ -80,8 +112,8 @@ mod account {
     async fn rejects_another_accounts_wallet() {
         let app = app().await;
         let token = app.admin_token().await;
-        let alice = app.create_user(token, "me-wallet-own-a").await;
-        let bob = app.create_user(token, "me-wallet-own-b").await;
+        let alice = app.create_account_with_wallet(token, "me-wallet-own-a").await;
+        let bob = app.create_account_with_wallet(token, "me-wallet-own-b").await;
 
         let res = app
             .api()
@@ -102,8 +134,8 @@ mod account {
     async fn works_without_any_permission() {
         let app = app().await;
         let token = app.admin_token().await;
-        let _subject = unique("me-noperm");
-        let key = app.user_api_key(token, uuid::Uuid::new_v4(), vec![]).await;
+        let account = app.create_account_with_permissions(token, "me-noperm", vec![]).await;
+        let key = app.account_api_key(token, account.id, vec![]).await;
 
         let res = app.api().get("/v1/me", Auth::ApiKey(&key)).await;
         assert_status(&res, StatusCode::OK);
@@ -118,9 +150,9 @@ mod preferences {
     async fn get_and_replace_dashboard_settings() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-prefs").await;
+        let account = app.create_account_with_wallet(token, "me-prefs").await;
 
-        let before = app.api().get("/v1/me/preferences", Auth::ApiKey(&user.key)).await;
+        let before = app.api().get("/v1/me/preferences", Auth::ApiKey(&account.key)).await;
         assert_status(&before, StatusCode::OK);
         assert_eq!(before.parse::<AccountPreferences>().dashboard_settings, json!({}));
 
@@ -128,7 +160,7 @@ mod preferences {
             .api()
             .put(
                 "/v1/me/preferences",
-                Auth::ApiKey(&user.key),
+                Auth::ApiKey(&account.key),
                 UpdateAccountPreferencesRequest {
                     dashboard_settings: json!({ "version": 1, "wallet": { "density": "compact" } }),
                 },
@@ -149,13 +181,13 @@ mod bitcoin {
     async fn generates_and_lists_deposit_addresses_for_the_path_wallet() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-btc").await;
+        let account = app.create_account_with_wallet(token, "me-btc").await;
 
         let created = app
             .api()
             .post(
-                &format!("/v1/me/wallets/{}/bitcoin/addresses", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/bitcoin/addresses", account.wallet.id),
+                Auth::ApiKey(&account.key),
                 NewBtcAddressRequest {
                     wallet_id: None,
                     address_type: None,
@@ -164,13 +196,13 @@ mod bitcoin {
             .await;
         assert_status(&created, StatusCode::OK);
         let created = created.parse::<BtcAddress>();
-        assert_eq!(created.wallet_id, user.wallet.id);
+        assert_eq!(created.wallet_id, account.wallet.id);
 
         let list = app
             .api()
             .get(
-                &format!("/v1/me/wallets/{}/bitcoin/addresses", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/bitcoin/addresses", account.wallet.id),
+                Auth::ApiKey(&account.key),
             )
             .await;
         assert_status(&list, StatusCode::OK);
@@ -184,8 +216,8 @@ mod bitcoin {
     async fn rejects_another_accounts_wallet() {
         let app = app().await;
         let token = app.admin_token().await;
-        let alice = app.create_user(token, "me-btc-a").await;
-        let bob = app.create_user(token, "me-btc-b").await;
+        let alice = app.create_account_with_wallet(token, "me-btc-a").await;
+        let bob = app.create_account_with_wallet(token, "me-btc-b").await;
 
         let res = app
             .api()
@@ -210,13 +242,13 @@ mod invoices {
     async fn generates_lists_and_gets_for_the_path_wallet() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-inv").await;
+        let account = app.create_account_with_wallet(token, "me-inv").await;
 
         let created = app
             .api()
             .post(
-                &format!("/v1/me/wallets/{}/invoices", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/invoices", account.wallet.id),
+                Auth::ApiKey(&account.key),
                 NewInvoiceRequest {
                     wallet_id: None,
                     amount_msat: 21_000,
@@ -227,13 +259,13 @@ mod invoices {
             .await;
         assert_status(&created, StatusCode::OK);
         let created = created.parse::<Invoice>();
-        assert_eq!(created.wallet_id, user.wallet.id);
+        assert_eq!(created.wallet_id, account.wallet.id);
 
         let list = app
             .api()
             .get(
-                &format!("/v1/me/wallets/{}/invoices", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/invoices", account.wallet.id),
+                Auth::ApiKey(&account.key),
             )
             .await;
         assert!(list
@@ -244,8 +276,8 @@ mod invoices {
         let got = app
             .api()
             .get(
-                &format!("/v1/me/wallets/{}/invoices/{}", user.wallet.id, created.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/invoices/{}", account.wallet.id, created.id),
+                Auth::ApiKey(&account.key),
             )
             .await;
         assert_status(&got, StatusCode::OK);
@@ -255,8 +287,8 @@ mod invoices {
     async fn rejects_another_accounts_wallet() {
         let app = app().await;
         let token = app.admin_token().await;
-        let alice = app.create_user(token, "me-inv-a").await;
-        let bob = app.create_user(token, "me-inv-b").await;
+        let alice = app.create_account_with_wallet(token, "me-inv-a").await;
+        let bob = app.create_account_with_wallet(token, "me-inv-b").await;
 
         let res = app
             .api()
@@ -283,13 +315,13 @@ mod payments {
     async fn rejects_an_unparseable_input() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-pay-bad").await;
+        let account = app.create_account_with_wallet(token, "me-pay-bad").await;
 
         let res = app
             .api()
             .post(
-                &format!("/v1/me/wallets/{}/payments", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/payments", account.wallet.id),
+                Auth::ApiKey(&account.key),
                 SendPaymentRequest {
                     wallet_id: None,
                     input: "notapaymentinput".to_string(),
@@ -305,9 +337,9 @@ mod payments {
     async fn settles_internally_and_is_isolated() {
         let app = app().await;
         let token = app.admin_token().await;
-        let payer = app.create_user(token, "me-pay-src").await;
-        let payee = app.create_user(token, "me-pay-dst").await;
-        let other = app.create_user(token, "me-pay-other").await;
+        let payer = app.create_account_with_wallet(token, "me-pay-src").await;
+        let payee = app.create_account_with_wallet(token, "me-pay-dst").await;
+        let other = app.create_account_with_wallet(token, "me-pay-other").await;
 
         app.fund_onchain(token, payer.wallet.id, 200_000).await;
 
@@ -381,10 +413,13 @@ mod ln_address {
     async fn register_get_update_delete() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-lnaddr").await;
+        let account = app.create_account_with_wallet(token, "me-lnaddr").await;
         let username = unique("me-lnaddr");
 
-        let before = app.api().get("/v1/me/lightning-address", Auth::ApiKey(&user.key)).await;
+        let before = app
+            .api()
+            .get("/v1/me/lightning-address", Auth::ApiKey(&account.key))
+            .await;
         assert_status(&before, StatusCode::OK);
         assert!(before.parse::<Option<LnAddress>>().is_none());
 
@@ -392,7 +427,7 @@ mod ln_address {
             .api()
             .post(
                 "/v1/me/lightning-address",
-                Auth::ApiKey(&user.key),
+                Auth::ApiKey(&account.key),
                 RegisterLnAddressRequest {
                     account_id: None,
                     username: username.clone(),
@@ -404,14 +439,17 @@ mod ln_address {
         assert_status(&reg, StatusCode::OK);
         assert_eq!(reg.parse::<LnAddress>().username, username);
 
-        let got = app.api().get("/v1/me/lightning-address", Auth::ApiKey(&user.key)).await;
+        let got = app
+            .api()
+            .get("/v1/me/lightning-address", Auth::ApiKey(&account.key))
+            .await;
         assert_eq!(got.parse::<Option<LnAddress>>().expect("registered").username, username);
 
         let updated = app
             .api()
             .put(
                 "/v1/me/lightning-address",
-                Auth::ApiKey(&user.key),
+                Auth::ApiKey(&account.key),
                 UpdateLnAddressRequest {
                     username: None,
                     active: Some(false),
@@ -425,10 +463,13 @@ mod ln_address {
 
         let del = app
             .api()
-            .delete("/v1/me/lightning-address", Auth::ApiKey(&user.key))
+            .delete("/v1/me/lightning-address", Auth::ApiKey(&account.key))
             .await;
         assert_status(&del, StatusCode::OK);
-        let after = app.api().get("/v1/me/lightning-address", Auth::ApiKey(&user.key)).await;
+        let after = app
+            .api()
+            .get("/v1/me/lightning-address", Auth::ApiKey(&account.key))
+            .await;
         assert!(after.parse::<Option<LnAddress>>().is_none());
     }
 }
@@ -440,13 +481,13 @@ mod contacts {
     async fn lists_contacts_for_the_path_wallet() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-contacts").await;
+        let account = app.create_account_with_wallet(token, "me-contacts").await;
 
         let res = app
             .api()
             .get(
-                &format!("/v1/me/wallets/{}/contacts", user.wallet.id),
-                Auth::ApiKey(&user.key),
+                &format!("/v1/me/wallets/{}/contacts", account.wallet.id),
+                Auth::ApiKey(&account.key),
             )
             .await;
         assert_status(&res, StatusCode::OK);
@@ -461,13 +502,13 @@ mod api_keys {
     async fn create_list_get_revoke() {
         let app = app().await;
         let token = app.admin_token().await;
-        let user = app.create_user(token, "me-keys").await;
+        let account = app.create_account_with_wallet(token, "me-keys").await;
 
         let created = app
             .api()
             .post(
                 "/v1/me/api-keys",
-                Auth::ApiKey(&user.key),
+                Auth::ApiKey(&account.key),
                 CreateApiKeyRequest {
                     account_id: None,
                     name: unique("me-key"),
@@ -479,35 +520,35 @@ mod api_keys {
             .await;
         assert_status(&created, StatusCode::OK);
         let created = created.parse::<ApiKey>();
-        assert_eq!(created.account_id, user.wallet.account_id);
+        assert_eq!(created.account_id, account.wallet.account_id);
 
-        let list = app.api().get("/v1/me/api-keys", Auth::ApiKey(&user.key)).await;
+        let list = app.api().get("/v1/me/api-keys", Auth::ApiKey(&account.key)).await;
         assert!(list.parse::<Vec<ApiKey>>().iter().any(|key| key.id == created.id));
 
         let got = app
             .api()
-            .get(&format!("/v1/me/api-keys/{}", created.id), Auth::ApiKey(&user.key))
+            .get(&format!("/v1/me/api-keys/{}", created.id), Auth::ApiKey(&account.key))
             .await;
         assert_status(&got, StatusCode::OK);
 
         let del = app
             .api()
-            .delete(&format!("/v1/me/api-keys/{}", created.id), Auth::ApiKey(&user.key))
+            .delete(&format!("/v1/me/api-keys/{}", created.id), Auth::ApiKey(&account.key))
             .await;
         assert_status(&del, StatusCode::OK);
         let gone = app
             .api()
-            .get(&format!("/v1/me/api-keys/{}", created.id), Auth::ApiKey(&user.key))
+            .get(&format!("/v1/me/api-keys/{}", created.id), Auth::ApiKey(&account.key))
             .await;
         assert_error(&gone, StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
-    async fn is_isolated_between_users() {
+    async fn is_isolated_between_accounts() {
         let app = app().await;
         let token = app.admin_token().await;
-        let alice = app.create_user(token, "me-keys-a").await;
-        let bob = app.create_user(token, "me-keys-b").await;
+        let alice = app.create_account_with_wallet(token, "me-keys-a").await;
+        let bob = app.create_account_with_wallet(token, "me-keys-b").await;
 
         let created = app
             .api()

--- a/tests/suites/mod.rs
+++ b/tests/suites/mod.rs
@@ -2,6 +2,7 @@
 
 mod accounts;
 mod api_keys;
+mod asset_scoping;
 mod auth;
 mod bitcoin;
 mod guards;

--- a/tests/suites/oauth2.rs
+++ b/tests/suites/oauth2.rs
@@ -7,13 +7,14 @@
 //! signature validation against the fetched JWKS, audience/issuer/expiry checks,
 //! the `sub` -> account/wallet provisioning, and JWT-scope -> permission enforcement.
 
+use futures_util::future::join_all;
 use reqwest::StatusCode;
 use serde_json::json;
 
 use swissknife_types::{Account, RegisterLnAddressRequest, Wallet};
 
 use crate::common::fixtures::unique;
-use crate::common::oauth2::{oauth2_app, CLIENT_FULL, CLIENT_READONLY, CLIENT_WRONG_AUD};
+use crate::common::oauth2::{oauth2_app, CLIENT_CONCURRENT, CLIENT_FULL, CLIENT_READONLY, CLIENT_WRONG_AUD};
 use crate::common::{assert_error, assert_status, Auth};
 
 mod accepts {
@@ -67,6 +68,31 @@ mod accepts {
 
         let res = app.api().get("/v1/wallets", Auth::Bearer(&token)).await;
         assert_status(&res, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_requests_provision_one_account_and_wallet_without_server_errors() {
+        let app = oauth2_app().await;
+        let token = app.token(CLIENT_CONCURRENT).await;
+        let responses = join_all((0..8).map(|_| {
+            let api = app.api();
+            let token = token.clone();
+            async move { api.get("/v1/me", Auth::Bearer(&token)).await }
+        }))
+        .await;
+
+        let mut account_id = None;
+        for response in responses {
+            assert_status(&response, StatusCode::OK);
+            let current = response.parse::<Account>().id;
+            assert_eq!(*account_id.get_or_insert(current), current);
+        }
+
+        let wallets = app.api().get("/v1/me/wallets", Auth::Bearer(&token)).await;
+        assert_status(&wallets, StatusCode::OK);
+        let wallets = wallets.parse::<Vec<Wallet>>();
+        assert_eq!(wallets.len(), 1, "concurrent authentication provisions one wallet");
+        assert_eq!(wallets[0].account_id, account_id.expect("provisioned account ID"));
     }
 }
 


### PR DESCRIPTION
## Summary

- replace direct database fixture seeding with public account, API-key, and wallet APIs
- add black-box account CRUD, permission, database-cascade deletion, `/v1/me`, preferences, wallet-resource, and API-key coverage
- cover concurrent local sign-up and OAuth2 first-request provisioning without HTTP 500 responses
- cover one account with mainnet, regtest, and signet wallets, proving balances, reservations, resources, and overview aggregates remain wallet/network scoped
- reject invoice creation through a wallet on the wrong Bitcoin network
- add a fresh-volume serial integration target and document the full test workflow

## PR 331 alignment audit

This branch was rebuilt on the merged PRs #331-#333 after a semantic audit against the ADR and the review decisions made in #331.

- account deletion relies on the schema's `ON DELETE CASCADE` foreign keys for wallets and API keys; the repository does not manually delete child records
- local sign-up provisions the full-permission `admin` account before atomically claiming the password, so a failed account write cannot leave the instance unusable
- local sign-in resolves the persisted admin account and its database permissions; it no longer recreates a missing account as an authentication side effect
- identity-less accounts and API-key permissions remain independent; integration fixtures authenticate with an explicitly created API key
- one wallet per `(account_id, asset_id)` remains enforced, while network compatibility is checked at the operation boundary
- residual pre-account terminology and the generated OpenAPI conflict example are corrected in a separate commit

## Stack

Follows merged PRs #331, #332, and #333 on `main`.

- Next: #336, dashboard account administration and account-wallet aggregate completion
- Cross-repo docs: bitcoin-numeraire/doc#11
- The obsolete migration-env Helm PR was closed because the final backfill has no migration-only configuration.

## Validation

- `make fmt`
- `make lint`
- `make test`
- `make test-persistence ITEST_DATABASE=sqlite`
- targeted auth-service and SQLite cascade persistence tests
- fresh-volume `lnd_grpc`/SQLite concurrent sign-up integration test
- `make openapi` followed by dashboard formatting, with a clean generated diff
- dashboard `yarn lint`
- dashboard `yarn typecheck`
- dashboard `yarn test`
- dashboard `yarn fm:check`
- dashboard `yarn build`

Closes #329
Related: #297, #337
