### PR TITLE
feat: expose account wallet aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ release notes when a tag is published.
   aggregate deletion of wallets and API keys ([#327]).
 - Added black-box account lifecycle, concurrent provisioning, explicit wallet
   routing, and cross-network balance isolation coverage ([#329]).
+- Added lightweight wallets with asset, balance, and Lightning Address metadata
+  to account responses ([#335]).
 
 ### Changed
 

--- a/crates/swissknife-types/src/account.rs
+++ b/crates/swissknife-types/src/account.rs
@@ -5,11 +5,11 @@ use serde_with::{serde_as, DisplayFromStr};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
-use crate::{AuthProvider, OrderDirection, Permission};
+use crate::{AuthProvider, OrderDirection, Permission, Wallet};
 
 /// An account is the owner and authorization boundary for identities, wallets,
 /// API keys, permissions, and account-scoped preferences.
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
 pub struct Account {
     /// Stable internal account ID.
     pub id: Uuid,
@@ -30,6 +30,13 @@ pub struct Account {
     /// Account-scoped dashboard and UI preferences.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferences: Option<AccountPreferences>,
+
+    /// Wallets owned by this account.
+    ///
+    /// These include asset metadata, balances, and the linked Lightning
+    /// Address, but not payments, invoices, Bitcoin addresses, or contacts.
+    /// Fetch a wallet by ID when those related resources are needed.
+    pub wallets: Vec<Wallet>,
 
     /// Date of creation in database.
     pub created_at: DateTime<Utc>,

--- a/dashboard/src/lib/openapi.json
+++ b/dashboard/src/lib/openapi.json
@@ -7496,6 +7496,7 @@
         "description": "An account is the owner and authorization boundary for identities, wallets,\nAPI keys, permissions, and account-scoped preferences.",
         "required": [
           "id",
+          "wallets",
           "created_at"
         ],
         "properties": {
@@ -7556,6 +7557,13 @@
             ],
             "format": "date-time",
             "description": "Date of update in database."
+          },
+          "wallets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Wallet"
+            },
+            "description": "Wallets owned by this account.\n\nThese include asset metadata, balances, and the linked Lightning\nAddress, but not payments, invoices, Bitcoin addresses, or contacts.\nFetch a wallet by ID when those related resources are needed."
           }
         }
       },

--- a/dashboard/src/lib/swissknife/transformers.gen.ts
+++ b/dashboard/src/lib/swissknife/transformers.gen.ts
@@ -63,6 +63,97 @@ const accountPreferencesSchemaResponseTransformer = (data: any) => {
   return data;
 };
 
+const assetSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const btcAddressSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const contactSchemaResponseTransformer = (data: any) => {
+  data.contact_since = new Date(data.contact_since);
+  return data;
+};
+
+const btcOutputSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const lnInvoiceSchemaResponseTransformer = (data: any) => {
+  data.expires_at = new Date(data.expires_at);
+  return data;
+};
+
+const invoiceSchemaResponseTransformer = (data: any) => {
+  if (data.bitcoin_output) {
+    data.bitcoin_output = btcOutputSchemaResponseTransformer(data.bitcoin_output);
+  }
+  data.created_at = new Date(data.created_at);
+  if (data.ln_invoice) {
+    data.ln_invoice = lnInvoiceSchemaResponseTransformer(data.ln_invoice);
+  }
+  if (data.payment_time) {
+    data.payment_time = new Date(data.payment_time);
+  }
+  data.timestamp = new Date(data.timestamp);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const lnAddressSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const paymentSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.payment_time) {
+    data.payment_time = new Date(data.payment_time);
+  }
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const walletSchemaResponseTransformer = (data: any) => {
+  if (data.asset) {
+    data.asset = assetSchemaResponseTransformer(data.asset);
+  }
+  data.btc_addresses = data.btc_addresses.map((item: any) =>
+    btcAddressSchemaResponseTransformer(item)
+  );
+  data.contacts = data.contacts.map((item: any) => contactSchemaResponseTransformer(item));
+  data.created_at = new Date(data.created_at);
+  data.invoices = data.invoices.map((item: any) => invoiceSchemaResponseTransformer(item));
+  if (data.ln_address) {
+    data.ln_address = lnAddressSchemaResponseTransformer(data.ln_address);
+  }
+  data.payments = data.payments.map((item: any) => paymentSchemaResponseTransformer(item));
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
 const accountSchemaResponseTransformer = (data: any) => {
   data.created_at = new Date(data.created_at);
   if (data.identity) {
@@ -74,6 +165,7 @@ const accountSchemaResponseTransformer = (data: any) => {
   if (data.updated_at) {
     data.updated_at = new Date(data.updated_at);
   }
+  data.wallets = data.wallets.map((item: any) => walletSchemaResponseTransformer(item));
   return data;
 };
 
@@ -133,14 +225,6 @@ export const getApiKeyResponseTransformer = async (data: any): Promise<GetApiKey
   return data;
 };
 
-const btcAddressSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
 export const listBtcAddressesResponseTransformer = async (
   data: any
 ): Promise<ListBtcAddressesResponse> => {
@@ -162,37 +246,6 @@ export const getBtcAddressResponseTransformer = async (
   return data;
 };
 
-const btcOutputSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
-const lnInvoiceSchemaResponseTransformer = (data: any) => {
-  data.expires_at = new Date(data.expires_at);
-  return data;
-};
-
-const invoiceSchemaResponseTransformer = (data: any) => {
-  if (data.bitcoin_output) {
-    data.bitcoin_output = btcOutputSchemaResponseTransformer(data.bitcoin_output);
-  }
-  data.created_at = new Date(data.created_at);
-  if (data.ln_invoice) {
-    data.ln_invoice = lnInvoiceSchemaResponseTransformer(data.ln_invoice);
-  }
-  if (data.payment_time) {
-    data.payment_time = new Date(data.payment_time);
-  }
-  data.timestamp = new Date(data.timestamp);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
 export const listInvoicesResponseTransformer = async (data: any): Promise<ListInvoicesResponse> => {
   data = data.map((item: any) => invoiceSchemaResponseTransformer(item));
   return data;
@@ -207,14 +260,6 @@ export const generateInvoiceResponseTransformer = async (
 
 export const getInvoiceResponseTransformer = async (data: any): Promise<GetInvoiceResponse> => {
   data = invoiceSchemaResponseTransformer(data);
-  return data;
-};
-
-const lnAddressSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
   return data;
 };
 
@@ -311,50 +356,6 @@ export const updateAccountPreferencesResponseTransformer = async (
   data: any
 ): Promise<UpdateAccountPreferencesResponse> => {
   data = accountPreferencesSchemaResponseTransformer(data);
-  return data;
-};
-
-const assetSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
-const contactSchemaResponseTransformer = (data: any) => {
-  data.contact_since = new Date(data.contact_since);
-  return data;
-};
-
-const paymentSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.payment_time) {
-    data.payment_time = new Date(data.payment_time);
-  }
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
-const walletSchemaResponseTransformer = (data: any) => {
-  if (data.asset) {
-    data.asset = assetSchemaResponseTransformer(data.asset);
-  }
-  data.btc_addresses = data.btc_addresses.map((item: any) =>
-    btcAddressSchemaResponseTransformer(item)
-  );
-  data.contacts = data.contacts.map((item: any) => contactSchemaResponseTransformer(item));
-  data.created_at = new Date(data.created_at);
-  data.invoices = data.invoices.map((item: any) => invoiceSchemaResponseTransformer(item));
-  if (data.ln_address) {
-    data.ln_address = lnAddressSchemaResponseTransformer(data.ln_address);
-  }
-  data.payments = data.payments.map((item: any) => paymentSchemaResponseTransformer(item));
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
   return data;
 };
 

--- a/dashboard/src/lib/swissknife/types.gen.ts
+++ b/dashboard/src/lib/swissknife/types.gen.ts
@@ -31,6 +31,14 @@ export type Account = {
    * Date of update in database.
    */
   updated_at?: Date | null;
+  /**
+   * Wallets owned by this account.
+   *
+   * These include asset metadata, balances, and the linked Lightning
+   * Address, but not payments, invoices, Bitcoin addresses, or contacts.
+   * Fetch a wallet by ID when those related resources are needed.
+   */
+  wallets: Array<Wallet>;
 };
 
 /**

--- a/dashboard/src/lib/swissknife/zod.gen.ts
+++ b/dashboard/src/lib/swissknife/zod.gen.ts
@@ -405,20 +405,6 @@ export const zPermission = z.enum([
 ]);
 
 /**
- * An account is the owner and authorization boundary for identities, wallets,
- * API keys, permissions, and account-scoped preferences.
- */
-export const zAccount = z.object({
-  created_at: z.iso.datetime(),
-  display_name: z.string().nullish(),
-  id: z.uuid(),
-  identity: zAuthIdentity.nullish(),
-  permissions: z.array(zPermission).nullish(),
-  preferences: zAccountPreferences.nullish(),
-  updated_at: z.iso.datetime().nullish(),
-});
-
-/**
  * API Key
  */
 export const zApiKey = z.object({
@@ -590,6 +576,21 @@ export const zWallet = z.object({
   ln_address: zLnAddress.nullish(),
   payments: z.array(zPayment),
   updated_at: z.iso.datetime().nullish(),
+});
+
+/**
+ * An account is the owner and authorization boundary for identities, wallets,
+ * API keys, permissions, and account-scoped preferences.
+ */
+export const zAccount = z.object({
+  created_at: z.iso.datetime(),
+  display_name: z.string().nullish(),
+  id: z.uuid(),
+  identity: zAuthIdentity.nullish(),
+  permissions: z.array(zPermission).nullish(),
+  preferences: zAccountPreferences.nullish(),
+  updated_at: z.iso.datetime().nullish(),
+  wallets: z.array(zWallet),
 });
 
 /**

--- a/src/domains/account/auth_service.rs
+++ b/src/domains/account/auth_service.rs
@@ -302,6 +302,7 @@ mod tests {
             }),
             permissions: Some(permissions),
             preferences: None,
+            wallets: Vec::new(),
             created_at: Utc::now(),
             updated_at: None,
         }

--- a/src/domains/wallet/account_wallet_handler.rs
+++ b/src/domains/wallet/account_wallet_handler.rs
@@ -1007,6 +1007,7 @@ mod tests {
                     identity: None,
                     permissions: None,
                     preferences: None,
+                    wallets: Vec::new(),
                     created_at: Utc::now(),
                     updated_at: None,
                 })

--- a/src/infra/database/sea_orm/repositories/sea_orm_account_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_account_repository.rs
@@ -11,10 +11,17 @@ use uuid::Uuid;
 
 use crate::{
     application::errors::DatabaseError,
-    domains::account::{Account, AccountFilter, AccountPreferences, AccountRepository, AuthProvider, Permission},
+    domains::{
+        account::{Account, AccountFilter, AccountPreferences, AccountRepository, AuthProvider, Permission},
+        wallet::Wallet as AccountWallet,
+    },
     infra::database::sea_orm::models::{
-        account, account_preference, auth_identity,
-        prelude::{Account as AccountEntity, AccountPreference, AuthIdentity},
+        account, account_preference, auth_identity, ln_address,
+        prelude::{
+            Account as AccountEntity, AccountPreference, Asset as AssetEntity, AuthIdentity,
+            LnAddress as LnAddressEntity, Wallet as WalletEntity,
+        },
+        wallet,
     },
     infra::database::sea_orm::sea_order,
 };
@@ -36,6 +43,38 @@ impl SeaOrmAccountRepository {
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
         Ok(preference.map(Into::into))
+    }
+
+    async fn find_wallets(&self, account_ids: &[Uuid]) -> Result<HashMap<Uuid, Vec<AccountWallet>>, DatabaseError> {
+        if account_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let models = WalletEntity::find()
+            .filter(wallet::Column::AccountId.is_in(account_ids.to_vec()))
+            .order_by_asc(wallet::Column::CreatedAt)
+            .find_also_related(AssetEntity)
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+        let mut ln_addresses = LnAddressEntity::find()
+            .filter(ln_address::Column::AccountId.is_in(account_ids.to_vec()))
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?
+            .into_iter()
+            .map(|address| (address.wallet_id, address))
+            .collect::<HashMap<_, _>>();
+
+        let mut wallets_by_account = HashMap::<Uuid, Vec<AccountWallet>>::new();
+        for (wallet_model, asset_model) in models {
+            let mut wallet: AccountWallet = wallet_model.into();
+            wallet.asset = asset_model.map(Into::into);
+            wallet.ln_address = ln_addresses.remove(&wallet.id).map(Into::into);
+            wallets_by_account.entry(wallet.account_id).or_default().push(wallet);
+        }
+
+        Ok(wallets_by_account)
     }
 }
 
@@ -63,6 +102,7 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = identity.map(Into::into);
         account.preferences = Some(preference_model.into());
+        account.wallets = self.find_wallets(&[id]).await?.remove(&id).unwrap_or_default();
 
         Ok(Some(account))
     }
@@ -89,6 +129,11 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = Some(identity.into());
         account.preferences = self.find_preferences(account.id).await?;
+        account.wallets = self
+            .find_wallets(&[account.id])
+            .await?
+            .remove(&account.id)
+            .unwrap_or_default();
 
         Ok(Some(account))
     }
@@ -115,10 +160,11 @@ impl AccountRepository for SeaOrmAccountRepository {
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
         let preferences = AccountPreference::find()
-            .filter(account_preference::Column::AccountId.is_in(account_ids))
+            .filter(account_preference::Column::AccountId.is_in(account_ids.clone()))
             .all(&self.db)
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
+        let mut wallets_by_account = self.find_wallets(&account_ids).await?;
 
         let mut identities_by_account = HashMap::new();
         for identity in identities {
@@ -138,6 +184,7 @@ impl AccountRepository for SeaOrmAccountRepository {
             let mut account: Account = model.into();
             account.identity = identities_by_account.remove(&account_id).map(Into::into);
             account.preferences = Some(preference.into());
+            account.wallets = wallets_by_account.remove(&account_id).unwrap_or_default();
             accounts.push(account);
         }
 
@@ -290,6 +337,7 @@ impl AccountRepository for SeaOrmAccountRepository {
         let permissions = serde_json::to_value(permissions).map_err(|e| DatabaseError::Update(e.to_string()))?;
         let identity = account.identity;
         let preferences = account.preferences;
+        let wallets = account.wallets;
 
         let account_model = account::ActiveModel {
             id: Set(account.id),
@@ -305,6 +353,7 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = identity;
         account.preferences = preferences;
+        account.wallets = wallets;
         Ok(account)
     }
 

--- a/src/infra/database/sea_orm/repositories/sea_orm_account_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_account_repository.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait,
-    Set, TransactionTrait,
+    sea_query::Expr, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, LoaderTrait, ModelTrait,
+    QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, TransactionTrait,
 };
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -13,13 +13,16 @@ use crate::{
     application::errors::DatabaseError,
     domains::{
         account::{Account, AccountFilter, AccountPreferences, AccountRepository, AuthProvider, Permission},
+        payment::PaymentStatus,
         wallet::Wallet as AccountWallet,
     },
     infra::database::sea_orm::models::{
-        account, account_preference, auth_identity, ln_address,
+        account, account_preference, auth_identity,
+        invoice::Column as InvoiceColumn,
+        payment::Column as PaymentColumn,
         prelude::{
-            Account as AccountEntity, AccountPreference, Asset as AssetEntity, AuthIdentity,
-            LnAddress as LnAddressEntity, Wallet as WalletEntity,
+            Account as AccountEntity, AccountPreference, Asset as AssetEntity, AuthIdentity, Invoice as InvoiceEntity,
+            LnAddress as LnAddressEntity, Payment as PaymentEntity, Wallet as WalletEntity,
         },
         wallet,
     },
@@ -36,45 +39,75 @@ impl SeaOrmAccountRepository {
         Self { db }
     }
 
-    async fn find_preferences(&self, id: Uuid) -> Result<Option<AccountPreferences>, DatabaseError> {
-        let preference = AccountPreference::find_by_id(id)
-            .one(&self.db)
-            .await
-            .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
-
-        Ok(preference.map(Into::into))
-    }
-
-    async fn find_wallets(&self, account_ids: &[Uuid]) -> Result<HashMap<Uuid, Vec<AccountWallet>>, DatabaseError> {
-        if account_ids.is_empty() {
-            return Ok(HashMap::new());
+    async fn hydrate_wallets(
+        &self,
+        wallet_groups: Vec<Vec<wallet::Model>>,
+    ) -> Result<Vec<Vec<AccountWallet>>, DatabaseError> {
+        let group_lengths = wallet_groups.iter().map(Vec::len).collect::<Vec<_>>();
+        let models = wallet_groups.into_iter().flatten().collect::<Vec<_>>();
+        if models.is_empty() {
+            return Ok(group_lengths.into_iter().map(|_| Vec::new()).collect());
         }
 
-        let models = WalletEntity::find()
-            .filter(wallet::Column::AccountId.is_in(account_ids.to_vec()))
-            .order_by_asc(wallet::Column::CreatedAt)
-            .find_also_related(AssetEntity)
-            .all(&self.db)
+        let assets = models
+            .load_one(AssetEntity, &self.db)
             .await
             .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
-        let mut ln_addresses = LnAddressEntity::find()
-            .filter(ln_address::Column::AccountId.is_in(account_ids.to_vec()))
+        let ln_addresses = models
+            .load_one(LnAddressEntity, &self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+
+        let wallet_ids = models.iter().map(|model| model.id).collect::<Vec<_>>();
+        let mut received_by_wallet = InvoiceEntity::find()
+            .filter(InvoiceColumn::WalletId.is_in(wallet_ids.clone()))
+            .select_only()
+            .column(InvoiceColumn::WalletId)
+            .column_as(
+                Expr::cust("CAST(SUM(invoice.amount_received_msat) AS BIGINT)"),
+                "received_msat",
+            )
+            .group_by(InvoiceColumn::WalletId)
+            .into_tuple::<(Uuid, Option<i64>)>()
             .all(&self.db)
             .await
             .map_err(|e| DatabaseError::FindRelated(e.to_string()))?
             .into_iter()
-            .map(|address| (address.wallet_id, address))
+            .collect::<HashMap<_, _>>();
+        let mut spent_by_wallet = PaymentEntity::find()
+            .filter(PaymentColumn::WalletId.is_in(wallet_ids))
+            .filter(PaymentColumn::Status.eq(PaymentStatus::Settled.to_string()))
+            .select_only()
+            .column(PaymentColumn::WalletId)
+            .column_as(Expr::cust("CAST(SUM(payment.amount_msat) AS BIGINT)"), "sent_msat")
+            .column_as(Expr::cust("CAST(SUM(payment.fee_msat) AS BIGINT)"), "fees_paid_msat")
+            .group_by(PaymentColumn::WalletId)
+            .into_tuple::<(Uuid, Option<i64>, Option<i64>)>()
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?
+            .into_iter()
+            .map(|(id, sent, fees)| (id, (sent, fees)))
             .collect::<HashMap<_, _>>();
 
-        let mut wallets_by_account = HashMap::<Uuid, Vec<AccountWallet>>::new();
-        for (wallet_model, asset_model) in models {
+        let mut wallets = Vec::with_capacity(models.len());
+        for ((wallet_model, asset_model), ln_address_model) in models.into_iter().zip(assets).zip(ln_addresses) {
             let mut wallet: AccountWallet = wallet_model.into();
+            let received_msat = received_by_wallet.remove(&wallet.id).flatten().unwrap_or(0);
+            let (sent_msat, fees_paid_msat) = spent_by_wallet.remove(&wallet.id).unwrap_or((None, None));
+            wallet.balance.received_msat = received_msat as u64;
+            wallet.balance.sent_msat = sent_msat.unwrap_or(0) as u64;
+            wallet.balance.fees_paid_msat = fees_paid_msat.unwrap_or(0) as u64;
             wallet.asset = asset_model.map(Into::into);
-            wallet.ln_address = ln_addresses.remove(&wallet.id).map(Into::into);
-            wallets_by_account.entry(wallet.account_id).or_default().push(wallet);
+            wallet.ln_address = ln_address_model.map(Into::into);
+            wallets.push(wallet);
         }
 
-        Ok(wallets_by_account)
+        let mut wallets = wallets.into_iter();
+        Ok(group_lengths
+            .into_iter()
+            .map(|length| wallets.by_ref().take(length).collect())
+            .collect())
     }
 }
 
@@ -90,11 +123,18 @@ impl AccountRepository for SeaOrmAccountRepository {
             return Ok(None);
         };
 
-        let identity = AuthIdentity::find()
-            .filter(auth_identity::Column::AccountId.eq(id))
+        let identity = account_model
+            .find_related(AuthIdentity)
+            .order_by_asc(auth_identity::Column::CreatedAt)
             .one(&self.db)
             .await
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
+        let wallet_models = account_model
+            .find_related(WalletEntity)
+            .order_by_asc(wallet::Column::CreatedAt)
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
 
         let preference_model = preference_model
             .ok_or_else(|| DatabaseError::FindRelated("account does not reference preferences".to_string()))?;
@@ -102,7 +142,11 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = identity.map(Into::into);
         account.preferences = Some(preference_model.into());
-        account.wallets = self.find_wallets(&[id]).await?.remove(&id).unwrap_or_default();
+        account.wallets = self
+            .hydrate_wallets(vec![wallet_models])
+            .await?
+            .pop()
+            .unwrap_or_default();
 
         Ok(Some(account))
     }
@@ -126,13 +170,25 @@ impl AccountRepository for SeaOrmAccountRepository {
             None => return Ok(None),
         };
 
+        let preference_model = account_model
+            .find_related(AccountPreference)
+            .one(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+        let wallet_models = account_model
+            .find_related(WalletEntity)
+            .order_by_asc(wallet::Column::CreatedAt)
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+
         let mut account: Account = account_model.into();
         account.identity = Some(identity.into());
-        account.preferences = self.find_preferences(account.id).await?;
+        account.preferences = preference_model.map(Into::into);
         account.wallets = self
-            .find_wallets(&[account.id])
+            .hydrate_wallets(vec![wallet_models])
             .await?
-            .remove(&account.id)
+            .pop()
             .unwrap_or_default();
 
         Ok(Some(account))
@@ -152,39 +208,33 @@ impl AccountRepository for SeaOrmAccountRepository {
             return Ok(Vec::new());
         }
 
-        let account_ids = models.iter().map(|model| model.id).collect::<Vec<_>>();
-        let identities = AuthIdentity::find()
-            .filter(auth_identity::Column::AccountId.is_in(account_ids.clone()))
-            .order_by_asc(auth_identity::Column::CreatedAt)
-            .all(&self.db)
+        let identities = models
+            .load_many(
+                AuthIdentity::find().order_by_asc(auth_identity::Column::CreatedAt),
+                &self.db,
+            )
             .await
-            .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
-        let preferences = AccountPreference::find()
-            .filter(account_preference::Column::AccountId.is_in(account_ids.clone()))
-            .all(&self.db)
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+        let preferences = models
+            .load_one(AccountPreference, &self.db)
             .await
-            .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
-        let mut wallets_by_account = self.find_wallets(&account_ids).await?;
-
-        let mut identities_by_account = HashMap::new();
-        for identity in identities {
-            identities_by_account.entry(identity.account_id).or_insert(identity);
-        }
-        let mut preferences_by_account = preferences
-            .into_iter()
-            .map(|preference| (preference.account_id, preference))
-            .collect::<HashMap<_, _>>();
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+        let wallet_models = models
+            .load_many(WalletEntity::find().order_by_asc(wallet::Column::CreatedAt), &self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+        let wallets = self.hydrate_wallets(wallet_models).await?;
 
         let mut accounts = Vec::with_capacity(models.len());
-        for model in models {
-            let account_id = model.id;
-            let preference = preferences_by_account
-                .remove(&account_id)
+        for (((model, identities), preference), wallets) in
+            models.into_iter().zip(identities).zip(preferences).zip(wallets)
+        {
+            let preference = preference
                 .ok_or_else(|| DatabaseError::FindRelated("account does not reference preferences".to_string()))?;
             let mut account: Account = model.into();
-            account.identity = identities_by_account.remove(&account_id).map(Into::into);
+            account.identity = identities.into_iter().next().map(Into::into);
             account.preferences = Some(preference.into());
-            account.wallets = wallets_by_account.remove(&account_id).unwrap_or_default();
+            account.wallets = wallets;
             accounts.push(account);
         }
 

--- a/src/infra/database/sea_orm/types.rs
+++ b/src/infra/database/sea_orm/types.rs
@@ -61,6 +61,7 @@ impl From<AccountModel> for Account {
             identity: None,
             permissions: serde_json::from_value(model.permissions).expect(ASSERTION_MSG),
             preferences: None,
+            wallets: Vec::new(),
             created_at: model.created_at.and_utc(),
             updated_at: model.updated_at.map(|t| t.and_utc()),
         }

--- a/src/infra/database/sea_orm/uow_tests.rs
+++ b/src/infra/database/sea_orm/uow_tests.rs
@@ -21,13 +21,14 @@ use crate::domains::account::{AccountFilter, AccountRepository, ApiKey, ApiKeyRe
 use crate::domains::event::EventProjectionUnitOfWork;
 use crate::domains::invoice::{Invoice, InvoiceRepository};
 use crate::domains::ln_address::LnAddressRepository;
-use crate::domains::payment::{LnPayment, Payment, PaymentStatus, PaymentUnitOfWork};
+use crate::domains::payment::{LnPayment, Payment, PaymentRepository, PaymentStatus, PaymentUnitOfWork};
 use crate::domains::{asset::AssetRepository, bitcoin::BtcNetwork, wallet::WalletRepository};
 
 use super::models::{prelude::Wallet, wallet};
 use super::{
     SeaOrmAccountRepository, SeaOrmApiKeyRepository, SeaOrmAssetRepository, SeaOrmEventProjectionUnitOfWork,
-    SeaOrmInvoiceRepository, SeaOrmLnAddressRepository, SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
+    SeaOrmInvoiceRepository, SeaOrmLnAddressRepository, SeaOrmPaymentRepository, SeaOrmPaymentUnitOfWork,
+    SeaOrmWalletRepository,
 };
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -386,6 +387,19 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
     let wallet_repo = SeaOrmWalletRepository::new(conn.clone());
     let wallet = wallet_repo.upsert(account.id, asset.id).await.unwrap();
     wallet_repo.credit(wallet.id, 42_000).await.unwrap();
+    let mut invoice = pending_invoice(wallet.id, 42_000);
+    invoice.payment_time = Some(Utc::now());
+    SeaOrmInvoiceRepository::new(conn.clone())
+        .insert(invoice)
+        .await
+        .unwrap();
+    let mut payment = pending_payment(wallet.id, 10_000, 250);
+    payment.status = PaymentStatus::Settled;
+    payment.payment_time = Some(Utc::now());
+    SeaOrmPaymentRepository::new(conn.clone())
+        .insert(payment)
+        .await
+        .unwrap();
     assert!(wallet_repo.exists_for_account(account.id, wallet.id).await.unwrap());
     assert!(!wallet_repo.exists_for_account(Uuid::new_v4(), wallet.id).await.unwrap());
     let ln_address = SeaOrmLnAddressRepository::new(conn.clone())
@@ -397,6 +411,9 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
     assert_eq!(aggregate.wallets.len(), 1);
     assert_eq!(aggregate.wallets[0].id, wallet.id);
     assert_eq!(aggregate.wallets[0].balance.available_msat, 42_000);
+    assert_eq!(aggregate.wallets[0].balance.received_msat, 42_000);
+    assert_eq!(aggregate.wallets[0].balance.sent_msat, 10_000);
+    assert_eq!(aggregate.wallets[0].balance.fees_paid_msat, 250);
     assert_eq!(
         aggregate.wallets[0].asset.as_ref().map(|asset| asset.id),
         Some(asset.id)
@@ -409,6 +426,16 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
     assert!(aggregate.wallets[0].invoices.is_empty());
     assert!(aggregate.wallets[0].btc_addresses.is_empty());
     assert!(aggregate.wallets[0].contacts.is_empty());
+    let listed = repo
+        .find_many(AccountFilter {
+            ids: Some(vec![account.id]),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(listed[0].wallets[0].balance.received_msat, 42_000);
+    assert_eq!(listed[0].wallets[0].balance.sent_msat, 10_000);
+    assert_eq!(listed[0].wallets[0].balance.fees_paid_msat, 250);
     SeaOrmApiKeyRepository::new(conn.clone())
         .insert(ApiKey {
             account_id: account.id,

--- a/src/infra/database/sea_orm/uow_tests.rs
+++ b/src/infra/database/sea_orm/uow_tests.rs
@@ -20,13 +20,14 @@ use crate::application::errors::{ApplicationError, DataError};
 use crate::domains::account::{AccountFilter, AccountRepository, ApiKey, ApiKeyRepository, AuthProvider, Permission};
 use crate::domains::event::EventProjectionUnitOfWork;
 use crate::domains::invoice::{Invoice, InvoiceRepository};
+use crate::domains::ln_address::LnAddressRepository;
 use crate::domains::payment::{LnPayment, Payment, PaymentStatus, PaymentUnitOfWork};
 use crate::domains::{asset::AssetRepository, bitcoin::BtcNetwork, wallet::WalletRepository};
 
 use super::models::{prelude::Wallet, wallet};
 use super::{
     SeaOrmAccountRepository, SeaOrmApiKeyRepository, SeaOrmAssetRepository, SeaOrmEventProjectionUnitOfWork,
-    SeaOrmInvoiceRepository, SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
+    SeaOrmInvoiceRepository, SeaOrmLnAddressRepository, SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
 };
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -384,8 +385,30 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
         .unwrap();
     let wallet_repo = SeaOrmWalletRepository::new(conn.clone());
     let wallet = wallet_repo.upsert(account.id, asset.id).await.unwrap();
+    wallet_repo.credit(wallet.id, 42_000).await.unwrap();
     assert!(wallet_repo.exists_for_account(account.id, wallet.id).await.unwrap());
     assert!(!wallet_repo.exists_for_account(Uuid::new_v4(), wallet.id).await.unwrap());
+    let ln_address = SeaOrmLnAddressRepository::new(conn.clone())
+        .insert(account.id, wallet.id, "operator", false, None)
+        .await
+        .unwrap();
+    let aggregate = repo.find(account.id).await.unwrap().unwrap();
+    assert!(aggregate.identity.is_none());
+    assert_eq!(aggregate.wallets.len(), 1);
+    assert_eq!(aggregate.wallets[0].id, wallet.id);
+    assert_eq!(aggregate.wallets[0].balance.available_msat, 42_000);
+    assert_eq!(
+        aggregate.wallets[0].asset.as_ref().map(|asset| asset.id),
+        Some(asset.id)
+    );
+    assert_eq!(
+        aggregate.wallets[0].ln_address.as_ref().map(|address| address.id),
+        Some(ln_address.id)
+    );
+    assert!(aggregate.wallets[0].payments.is_empty());
+    assert!(aggregate.wallets[0].invoices.is_empty());
+    assert!(aggregate.wallets[0].btc_addresses.is_empty());
+    assert!(aggregate.wallets[0].contacts.is_empty());
     SeaOrmApiKeyRepository::new(conn.clone())
         .insert(ApiKey {
             account_id: account.id,

--- a/tests/suites/accounts.rs
+++ b/tests/suites/accounts.rs
@@ -104,6 +104,27 @@ mod lifecycle {
             .await;
         assert_status(&lightning_address, StatusCode::OK);
         let lightning_address = lightning_address.parse::<swissknife_types::LnAddress>();
+        let aggregate = app
+            .api()
+            .get(&format!("/v1/accounts/{}", created.id), Auth::Bearer(admin))
+            .await;
+        assert_status(&aggregate, StatusCode::OK);
+        let aggregate = aggregate.parse::<Account>();
+        assert!(aggregate.identity.is_none());
+        assert_eq!(aggregate.wallets.len(), 1);
+        assert_eq!(aggregate.wallets[0].id, wallet.id);
+        assert_eq!(
+            aggregate.wallets[0].asset.as_ref().map(|asset| asset.id),
+            Some(regtest_btc_asset_id())
+        );
+        assert_eq!(
+            aggregate.wallets[0].ln_address.as_ref().map(|address| address.id),
+            Some(lightning_address.id)
+        );
+        assert!(aggregate.wallets[0].payments.is_empty());
+        assert!(aggregate.wallets[0].invoices.is_empty());
+        assert!(aggregate.wallets[0].btc_addresses.is_empty());
+        assert!(aggregate.wallets[0].contacts.is_empty());
         let account_key = app
             .account_api_key(admin, created.id, Permission::all_permissions())
             .await;


### PR DESCRIPTION
## Summary

- expose lightweight owned wallets on the `Account` aggregate
- include wallet asset metadata, complete balance totals, and linked Lightning Address
- intentionally leave payments, invoices, Bitcoin addresses, and contacts for wallet-detail reads
- use SeaORM relations directly for single-account reads and `LoaderTrait` for batched account lists
- hydrate received, sent, and fee totals with two grouped queries across the complete wallet batch
- regenerate the OpenAPI schema and dashboard client from the backend type
- cover identity-less account aggregates and their wallet relationships in persistence and HTTP lifecycle tests

This PR is now backend/API-contract only. The account and wallet administration UI is consolidated in #342.

## Stack

- Base: `main` (through #334)
- Next: #340, then #341, then #342
- Cross-repo docs: bitcoin-numeraire/doc#11

## Verification

- `make fmt`
- `make lint`
- `make test` (244 passed, 1 ignored)
- `make test-persistence ITEST_DATABASE=sqlite` (18 passed)
- `yarn lint`
- `yarn typecheck`
- `yarn test` (17 passed)

Related: #297, #335