### PR TITLE
docs: allow multi-network wallet catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ release notes when a tag is published.
   aggregate deletion of wallets and API keys ([#327]).
 - Added black-box account lifecycle, concurrent provisioning, explicit wallet
   routing, and cross-network balance isolation coverage ([#329]).
+- Added lightweight wallets with asset, balance, and Lightning Address metadata
+  to account responses ([#335]).
 
 ### Changed
 

--- a/crates/swissknife-types/src/account.rs
+++ b/crates/swissknife-types/src/account.rs
@@ -5,11 +5,11 @@ use serde_with::{serde_as, DisplayFromStr};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
-use crate::{AuthProvider, OrderDirection, Permission};
+use crate::{AuthProvider, OrderDirection, Permission, Wallet};
 
 /// An account is the owner and authorization boundary for identities, wallets,
 /// API keys, permissions, and account-scoped preferences.
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
 pub struct Account {
     /// Stable internal account ID.
     pub id: Uuid,
@@ -30,6 +30,13 @@ pub struct Account {
     /// Account-scoped dashboard and UI preferences.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferences: Option<AccountPreferences>,
+
+    /// Wallets owned by this account.
+    ///
+    /// These include asset metadata, balances, and the linked Lightning
+    /// Address, but not payments, invoices, Bitcoin addresses, or contacts.
+    /// Fetch a wallet by ID when those related resources are needed.
+    pub wallets: Vec<Wallet>,
 
     /// Date of creation in database.
     pub created_at: DateTime<Utc>,

--- a/dashboard/src/lib/openapi.json
+++ b/dashboard/src/lib/openapi.json
@@ -7496,6 +7496,7 @@
         "description": "An account is the owner and authorization boundary for identities, wallets,\nAPI keys, permissions, and account-scoped preferences.",
         "required": [
           "id",
+          "wallets",
           "created_at"
         ],
         "properties": {
@@ -7556,6 +7557,13 @@
             ],
             "format": "date-time",
             "description": "Date of update in database."
+          },
+          "wallets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Wallet"
+            },
+            "description": "Wallets owned by this account.\n\nThese include asset metadata, balances, and the linked Lightning\nAddress, but not payments, invoices, Bitcoin addresses, or contacts.\nFetch a wallet by ID when those related resources are needed."
           }
         }
       },

--- a/dashboard/src/lib/swissknife/transformers.gen.ts
+++ b/dashboard/src/lib/swissknife/transformers.gen.ts
@@ -63,6 +63,97 @@ const accountPreferencesSchemaResponseTransformer = (data: any) => {
   return data;
 };
 
+const assetSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const btcAddressSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const contactSchemaResponseTransformer = (data: any) => {
+  data.contact_since = new Date(data.contact_since);
+  return data;
+};
+
+const btcOutputSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const lnInvoiceSchemaResponseTransformer = (data: any) => {
+  data.expires_at = new Date(data.expires_at);
+  return data;
+};
+
+const invoiceSchemaResponseTransformer = (data: any) => {
+  if (data.bitcoin_output) {
+    data.bitcoin_output = btcOutputSchemaResponseTransformer(data.bitcoin_output);
+  }
+  data.created_at = new Date(data.created_at);
+  if (data.ln_invoice) {
+    data.ln_invoice = lnInvoiceSchemaResponseTransformer(data.ln_invoice);
+  }
+  if (data.payment_time) {
+    data.payment_time = new Date(data.payment_time);
+  }
+  data.timestamp = new Date(data.timestamp);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const lnAddressSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const paymentSchemaResponseTransformer = (data: any) => {
+  data.created_at = new Date(data.created_at);
+  if (data.payment_time) {
+    data.payment_time = new Date(data.payment_time);
+  }
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
+const walletSchemaResponseTransformer = (data: any) => {
+  if (data.asset) {
+    data.asset = assetSchemaResponseTransformer(data.asset);
+  }
+  data.btc_addresses = data.btc_addresses.map((item: any) =>
+    btcAddressSchemaResponseTransformer(item)
+  );
+  data.contacts = data.contacts.map((item: any) => contactSchemaResponseTransformer(item));
+  data.created_at = new Date(data.created_at);
+  data.invoices = data.invoices.map((item: any) => invoiceSchemaResponseTransformer(item));
+  if (data.ln_address) {
+    data.ln_address = lnAddressSchemaResponseTransformer(data.ln_address);
+  }
+  data.payments = data.payments.map((item: any) => paymentSchemaResponseTransformer(item));
+  if (data.updated_at) {
+    data.updated_at = new Date(data.updated_at);
+  }
+  return data;
+};
+
 const accountSchemaResponseTransformer = (data: any) => {
   data.created_at = new Date(data.created_at);
   if (data.identity) {
@@ -74,6 +165,7 @@ const accountSchemaResponseTransformer = (data: any) => {
   if (data.updated_at) {
     data.updated_at = new Date(data.updated_at);
   }
+  data.wallets = data.wallets.map((item: any) => walletSchemaResponseTransformer(item));
   return data;
 };
 
@@ -133,14 +225,6 @@ export const getApiKeyResponseTransformer = async (data: any): Promise<GetApiKey
   return data;
 };
 
-const btcAddressSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
 export const listBtcAddressesResponseTransformer = async (
   data: any
 ): Promise<ListBtcAddressesResponse> => {
@@ -162,37 +246,6 @@ export const getBtcAddressResponseTransformer = async (
   return data;
 };
 
-const btcOutputSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
-const lnInvoiceSchemaResponseTransformer = (data: any) => {
-  data.expires_at = new Date(data.expires_at);
-  return data;
-};
-
-const invoiceSchemaResponseTransformer = (data: any) => {
-  if (data.bitcoin_output) {
-    data.bitcoin_output = btcOutputSchemaResponseTransformer(data.bitcoin_output);
-  }
-  data.created_at = new Date(data.created_at);
-  if (data.ln_invoice) {
-    data.ln_invoice = lnInvoiceSchemaResponseTransformer(data.ln_invoice);
-  }
-  if (data.payment_time) {
-    data.payment_time = new Date(data.payment_time);
-  }
-  data.timestamp = new Date(data.timestamp);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
 export const listInvoicesResponseTransformer = async (data: any): Promise<ListInvoicesResponse> => {
   data = data.map((item: any) => invoiceSchemaResponseTransformer(item));
   return data;
@@ -207,14 +260,6 @@ export const generateInvoiceResponseTransformer = async (
 
 export const getInvoiceResponseTransformer = async (data: any): Promise<GetInvoiceResponse> => {
   data = invoiceSchemaResponseTransformer(data);
-  return data;
-};
-
-const lnAddressSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
   return data;
 };
 
@@ -311,50 +356,6 @@ export const updateAccountPreferencesResponseTransformer = async (
   data: any
 ): Promise<UpdateAccountPreferencesResponse> => {
   data = accountPreferencesSchemaResponseTransformer(data);
-  return data;
-};
-
-const assetSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
-const contactSchemaResponseTransformer = (data: any) => {
-  data.contact_since = new Date(data.contact_since);
-  return data;
-};
-
-const paymentSchemaResponseTransformer = (data: any) => {
-  data.created_at = new Date(data.created_at);
-  if (data.payment_time) {
-    data.payment_time = new Date(data.payment_time);
-  }
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
-  return data;
-};
-
-const walletSchemaResponseTransformer = (data: any) => {
-  if (data.asset) {
-    data.asset = assetSchemaResponseTransformer(data.asset);
-  }
-  data.btc_addresses = data.btc_addresses.map((item: any) =>
-    btcAddressSchemaResponseTransformer(item)
-  );
-  data.contacts = data.contacts.map((item: any) => contactSchemaResponseTransformer(item));
-  data.created_at = new Date(data.created_at);
-  data.invoices = data.invoices.map((item: any) => invoiceSchemaResponseTransformer(item));
-  if (data.ln_address) {
-    data.ln_address = lnAddressSchemaResponseTransformer(data.ln_address);
-  }
-  data.payments = data.payments.map((item: any) => paymentSchemaResponseTransformer(item));
-  if (data.updated_at) {
-    data.updated_at = new Date(data.updated_at);
-  }
   return data;
 };
 

--- a/dashboard/src/lib/swissknife/types.gen.ts
+++ b/dashboard/src/lib/swissknife/types.gen.ts
@@ -31,6 +31,14 @@ export type Account = {
    * Date of update in database.
    */
   updated_at?: Date | null;
+  /**
+   * Wallets owned by this account.
+   *
+   * These include asset metadata, balances, and the linked Lightning
+   * Address, but not payments, invoices, Bitcoin addresses, or contacts.
+   * Fetch a wallet by ID when those related resources are needed.
+   */
+  wallets: Array<Wallet>;
 };
 
 /**

--- a/dashboard/src/lib/swissknife/zod.gen.ts
+++ b/dashboard/src/lib/swissknife/zod.gen.ts
@@ -405,20 +405,6 @@ export const zPermission = z.enum([
 ]);
 
 /**
- * An account is the owner and authorization boundary for identities, wallets,
- * API keys, permissions, and account-scoped preferences.
- */
-export const zAccount = z.object({
-  created_at: z.iso.datetime(),
-  display_name: z.string().nullish(),
-  id: z.uuid(),
-  identity: zAuthIdentity.nullish(),
-  permissions: z.array(zPermission).nullish(),
-  preferences: zAccountPreferences.nullish(),
-  updated_at: z.iso.datetime().nullish(),
-});
-
-/**
  * API Key
  */
 export const zApiKey = z.object({
@@ -590,6 +576,21 @@ export const zWallet = z.object({
   ln_address: zLnAddress.nullish(),
   payments: z.array(zPayment),
   updated_at: z.iso.datetime().nullish(),
+});
+
+/**
+ * An account is the owner and authorization boundary for identities, wallets,
+ * API keys, permissions, and account-scoped preferences.
+ */
+export const zAccount = z.object({
+  created_at: z.iso.datetime(),
+  display_name: z.string().nullish(),
+  id: z.uuid(),
+  identity: zAuthIdentity.nullish(),
+  permissions: z.array(zPermission).nullish(),
+  preferences: zAccountPreferences.nullish(),
+  updated_at: z.iso.datetime().nullish(),
+  wallets: z.array(zWallet),
 });
 
 /**

--- a/docs/adr/0002-identity-assets-wallet-model.md
+++ b/docs/adr/0002-identity-assets-wallet-model.md
@@ -336,37 +336,52 @@ Both display as USDT, but they are different assets and therefore different wall
 
 ## Migration strategy
 
-The migration must support SQLite and Postgres and must preserve existing wallets, invoices, payments, balances, addresses, API keys, and Lightning addresses.
+The migration supports SQLite and Postgres and preserves the production wallets, invoices,
+payments, balances, Bitcoin addresses, and Lightning addresses. After this ADR was accepted, the
+production data audit narrowed the executable backfill to the data that actually exists:
+
+- every legacy identity is an OAuth2/Auth0 subject;
+- every legacy wallet is native BTC on Bitcoin mainnet;
+- there is no testnet data or mixed-currency wallet data;
+- the legacy API-key table is empty, so the schema changes but no API keys are backfilled; and
+- no migration-only provider or network configuration is required.
+
+These are migration preconditions, not limitations of the target account/asset/wallet model. The
+operator must verify them before deployment; the migrations intentionally contain no synthetic
+identity, provider-selection, API-key, or network-inference branches outside this audited shape.
 
 ### Phase 1: Add identity and asset tables
 
 1. Create `account`, `auth_identity`, `account_preference`, and `asset`.
-2. Seed assets for all existing `Currency` enum values.
-3. Backfill one `account` per distinct `wallet.user_id`.
-4. Backfill one `auth_identity` per old wallet user ID using the configured auth provider when known; otherwise require an operator-supplied provider mapping before migration.
-5. Add `account_id` to `api_key` and backfill through `wallet.user_id`.
-6. Grant the full permission set in `account.permissions` to the bootstrap admin's account when the deployment uses local JWT. OAuth2 deployments backfill nothing, because token claims stay authoritative. `api_key.permissions` rows are unchanged.
+2. Seed the supported native-BTC network assets.
+3. Backfill one `account` and preference row per distinct `wallet.user_id`.
+4. Backfill one `auth_identity(provider = oauth2, subject = wallet.user_id)` per account.
+5. Add `account_id` to `api_key`; require the legacy table to be empty instead of manufacturing
+   account ownership for unused keys.
+6. Leave account permissions empty because OAuth2 token claims are authoritative.
 
 ### Phase 2: Convert wallet rows into asset wallets
 
-1. Add `wallet.account_id`, `wallet.asset_id`, `wallet.available_amount`, `wallet.reserved_amount`, and `wallet.label`.
-2. Build a temporary mapping table:
-
-   ```text
-   wallet_asset_migration(old_wallet_id, old_currency, new_wallet_id)
-   ```
-
-3. For each `(old_wallet_id, currency)` present in `wallet_balance`, `payment`, or `invoice`, create exactly one asset-scoped wallet.
-4. Backfill wallet balances from `wallet_balance.available_amount` and `wallet_balance.reserved_amount`. If no `wallet_balance` row exists, derive the same values from settled invoices, settled payments, and pending reservations using the ADR 0001 formula.
-5. Fail loudly if historical reserved balances are negative or historical available balances require operator reconciliation before cutover.
+1. Add nullable `wallet.account_id`, `wallet.asset_id`, `wallet.available_amount`,
+   `wallet.reserved_amount`, and `wallet.label` columns in a schema migration.
+2. Reuse each legacy wallet row as the account's native-BTC mainnet asset wallet. Resolve
+   `account_id` through its OAuth2 identity and resolve `asset_id` through
+   `(bitcoin, bitcoin/mainnet, native)`.
+3. Backfill available and reserved amounts from the legacy `Bitcoin` wallet-balance row, defaulting
+   missing rows to zero.
+4. Fail if any wallet remains without an account or asset after the data migration.
+5. Make account/asset ownership authoritative and drop the legacy columns only after the backfill
+   succeeds.
 
 ### Phase 3: Repoint resource FKs
 
-1. Update `payment.wallet_id` by joining `(old wallet_id, payment.currency)` through the migration mapping.
-2. Update `invoice.wallet_id` by joining `(old wallet_id, invoice.currency)` through the migration mapping.
-3. Move `btc_address.wallet_id` to the account's native BTC wallet for the active Bitcoin network. Existing `btc_address` rows do not carry their own currency, so this must use deployment/network configuration or a documented manual fallback.
-4. Add `ln_address.account_id` and keep the old `wallet_id` column as the invoice-receiving wallet route.
-5. Resolve the receiving wallet from `(account_id, active native BTC asset)` in service code and cover it with integration tests. This avoids accepting mismatched wallets or networks at the API boundary.
+1. Keep payment, invoice, and Bitcoin-address foreign keys on their reused wallet row; no synthetic
+   wallet mapping or FK rewrite is needed for the audited BTC-mainnet data.
+2. Add `ln_address.account_id`, deriving it from the receiving wallet, and keep `wallet_id` as the
+   concrete invoice-receiving route.
+3. Drop payment/invoice currency columns only after wallet asset ownership is populated.
+4. Resolve new Lightning Address receiving wallets from `(account_id, active native BTC asset)` in
+   service code and cover the network behavior with integration tests.
 
 ### Phase 4: Cut over services
 
@@ -408,16 +423,14 @@ The migration must support SQLite and Postgres and must preserve existing wallet
 
 ### Migration/backfill tests
 
-Cover existing databases containing:
+Cover the audited production shape on SQLite and Postgres:
 
-- one user with no activity;
-- one user with settled invoices and settled payments;
-- pending outgoing payments with `reserved_amount`;
-- multiple old `wallet_balance` currencies under one old wallet;
-- API keys referencing old `wallet.user_id`;
-- Lightning addresses and generated invoices;
-- Bitcoin addresses;
-- an imported `BitcoinTestnet` database where network choice must come from configuration.
+- OAuth2/Auth0 subjects become accounts with identities and preferences;
+- legacy native-BTC mainnet wallets retain available and reserved balances;
+- existing payment, invoice, Bitcoin-address, and Lightning-address relationships remain attached to
+  the reused wallet;
+- the migration requires an empty legacy API-key table; and
+- no testnet/provider inference or migration-only environment variables are introduced.
 
 ### Authorization tests
 

--- a/docs/adr/0002-identity-assets-wallet-model.md
+++ b/docs/adr/0002-identity-assets-wallet-model.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Status | Accepted |
 | Date | 2026-07-02 |
-| Related issues | #297, #252, #254, #291, #292, #115, #237, #239, #240, #241 |
+| Related issues | #297, #252, #254, #291, #292, #337, #115, #237, #239, #240, #241 |
 | Scope | Identity, accounts, wallets, currencies/assets, network scoping, migration strategy |
 
 ## Summary
@@ -158,7 +158,9 @@ Initial seed assets map the existing enum values into explicit assets:
 
 `BitcoinTestnet` currently cannot distinguish testnet3 from testnet4 by itself because `BtcNetwork::Testnet` and `BtcNetwork::Testnet4` both convert to `Currency::BitcoinTestnet`. During migration, use the configured node network when available; if a database has historical mixed testnet3/testnet4 activity, require explicit operator reconciliation rather than silently merging networks.
 
-Network is a database concern, not only a rendering concern. It is persisted exactly once, on `asset`; wallets, payments, invoices, and addresses derive it through their FKs and never duplicate it. It must live in the database for three reasons: payment validation compares the network encoded in the instrument (BOLT11 HRPs `lnbc`/`lntb`/`lntbs`/`lnbcrt`, on-chain address prefixes) against the wallet asset's network; rows must stay attributed to the network they were created on even if the deployment configuration later changes; and the testnet3/testnet4 reconciliation above is only expressible if network is data. What is genuinely frontend-only is pricing and formatting: testnet assets have no market value, so fiat conversion and ticker styling (`tBTC`) are display-layer decisions on top of the persisted network. As an operational guard, startup should verify that the configured node network matches the network of every asset with active wallets and refuse to run on mismatch, instead of discovering the mismatch one rejected payment at a time.
+Network is a database concern, not only a rendering concern. It is persisted exactly once, on `asset`; wallets, payments, invoices, and addresses derive it through their FKs and never duplicate it. It must live in the database for three reasons: payment validation compares the network encoded in the instrument (BOLT11 HRPs `lnbc`/`lntb`/`lntbs`/`lnbcrt`, on-chain address prefixes) against the wallet asset's network; rows must stay attributed to the network they were created on even if the deployment configuration later changes; and the testnet3/testnet4 reconciliation above is only expressible if network is data. What is genuinely frontend-only is pricing and formatting: testnet assets have no market value, so fiat conversion and ticker styling (`tBTC`) are display-layer decisions on top of the persisted network.
+
+A SwissKnife database may contain wallets for several networks at the same time. The configured Lightning or chain provider describes the settlement capability available to a running instance; it does not constrain which network-scoped wallets may exist in the catalog. Every money-moving or address-producing operation must validate the selected wallet asset against both the instrument network and the provider network, and reject an incompatible request before reserving funds or creating provider state. Startup must not reject a database merely because it contains wallets that the current provider cannot service. This keeps historical attribution intact and allows a future runtime to attach additional liquidity providers without another wallet-schema change.
 
 ### 3. Make wallets asset-scoped spendable balances
 

--- a/src/domains/account/auth_service.rs
+++ b/src/domains/account/auth_service.rs
@@ -302,6 +302,7 @@ mod tests {
             }),
             permissions: Some(permissions),
             preferences: None,
+            wallets: Vec::new(),
             created_at: Utc::now(),
             updated_at: None,
         }

--- a/src/domains/wallet/account_wallet_handler.rs
+++ b/src/domains/wallet/account_wallet_handler.rs
@@ -1007,6 +1007,7 @@ mod tests {
                     identity: None,
                     permissions: None,
                     preferences: None,
+                    wallets: Vec::new(),
                     created_at: Utc::now(),
                     updated_at: None,
                 })

--- a/src/infra/database/sea_orm/repositories/sea_orm_account_repository.rs
+++ b/src/infra/database/sea_orm/repositories/sea_orm_account_repository.rs
@@ -11,10 +11,17 @@ use uuid::Uuid;
 
 use crate::{
     application::errors::DatabaseError,
-    domains::account::{Account, AccountFilter, AccountPreferences, AccountRepository, AuthProvider, Permission},
+    domains::{
+        account::{Account, AccountFilter, AccountPreferences, AccountRepository, AuthProvider, Permission},
+        wallet::Wallet as AccountWallet,
+    },
     infra::database::sea_orm::models::{
-        account, account_preference, auth_identity,
-        prelude::{Account as AccountEntity, AccountPreference, AuthIdentity},
+        account, account_preference, auth_identity, ln_address,
+        prelude::{
+            Account as AccountEntity, AccountPreference, Asset as AssetEntity, AuthIdentity,
+            LnAddress as LnAddressEntity, Wallet as WalletEntity,
+        },
+        wallet,
     },
     infra::database::sea_orm::sea_order,
 };
@@ -36,6 +43,38 @@ impl SeaOrmAccountRepository {
             .map_err(|e| DatabaseError::FindOne(e.to_string()))?;
 
         Ok(preference.map(Into::into))
+    }
+
+    async fn find_wallets(&self, account_ids: &[Uuid]) -> Result<HashMap<Uuid, Vec<AccountWallet>>, DatabaseError> {
+        if account_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let models = WalletEntity::find()
+            .filter(wallet::Column::AccountId.is_in(account_ids.to_vec()))
+            .order_by_asc(wallet::Column::CreatedAt)
+            .find_also_related(AssetEntity)
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?;
+        let mut ln_addresses = LnAddressEntity::find()
+            .filter(ln_address::Column::AccountId.is_in(account_ids.to_vec()))
+            .all(&self.db)
+            .await
+            .map_err(|e| DatabaseError::FindRelated(e.to_string()))?
+            .into_iter()
+            .map(|address| (address.wallet_id, address))
+            .collect::<HashMap<_, _>>();
+
+        let mut wallets_by_account = HashMap::<Uuid, Vec<AccountWallet>>::new();
+        for (wallet_model, asset_model) in models {
+            let mut wallet: AccountWallet = wallet_model.into();
+            wallet.asset = asset_model.map(Into::into);
+            wallet.ln_address = ln_addresses.remove(&wallet.id).map(Into::into);
+            wallets_by_account.entry(wallet.account_id).or_default().push(wallet);
+        }
+
+        Ok(wallets_by_account)
     }
 }
 
@@ -63,6 +102,7 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = identity.map(Into::into);
         account.preferences = Some(preference_model.into());
+        account.wallets = self.find_wallets(&[id]).await?.remove(&id).unwrap_or_default();
 
         Ok(Some(account))
     }
@@ -89,6 +129,11 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = Some(identity.into());
         account.preferences = self.find_preferences(account.id).await?;
+        account.wallets = self
+            .find_wallets(&[account.id])
+            .await?
+            .remove(&account.id)
+            .unwrap_or_default();
 
         Ok(Some(account))
     }
@@ -115,10 +160,11 @@ impl AccountRepository for SeaOrmAccountRepository {
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
         let preferences = AccountPreference::find()
-            .filter(account_preference::Column::AccountId.is_in(account_ids))
+            .filter(account_preference::Column::AccountId.is_in(account_ids.clone()))
             .all(&self.db)
             .await
             .map_err(|e| DatabaseError::FindMany(e.to_string()))?;
+        let mut wallets_by_account = self.find_wallets(&account_ids).await?;
 
         let mut identities_by_account = HashMap::new();
         for identity in identities {
@@ -138,6 +184,7 @@ impl AccountRepository for SeaOrmAccountRepository {
             let mut account: Account = model.into();
             account.identity = identities_by_account.remove(&account_id).map(Into::into);
             account.preferences = Some(preference.into());
+            account.wallets = wallets_by_account.remove(&account_id).unwrap_or_default();
             accounts.push(account);
         }
 
@@ -290,6 +337,7 @@ impl AccountRepository for SeaOrmAccountRepository {
         let permissions = serde_json::to_value(permissions).map_err(|e| DatabaseError::Update(e.to_string()))?;
         let identity = account.identity;
         let preferences = account.preferences;
+        let wallets = account.wallets;
 
         let account_model = account::ActiveModel {
             id: Set(account.id),
@@ -305,6 +353,7 @@ impl AccountRepository for SeaOrmAccountRepository {
         let mut account: Account = account_model.into();
         account.identity = identity;
         account.preferences = preferences;
+        account.wallets = wallets;
         Ok(account)
     }
 

--- a/src/infra/database/sea_orm/types.rs
+++ b/src/infra/database/sea_orm/types.rs
@@ -61,6 +61,7 @@ impl From<AccountModel> for Account {
             identity: None,
             permissions: serde_json::from_value(model.permissions).expect(ASSERTION_MSG),
             preferences: None,
+            wallets: Vec::new(),
             created_at: model.created_at.and_utc(),
             updated_at: model.updated_at.map(|t| t.and_utc()),
         }

--- a/src/infra/database/sea_orm/uow_tests.rs
+++ b/src/infra/database/sea_orm/uow_tests.rs
@@ -20,13 +20,14 @@ use crate::application::errors::{ApplicationError, DataError};
 use crate::domains::account::{AccountFilter, AccountRepository, ApiKey, ApiKeyRepository, AuthProvider, Permission};
 use crate::domains::event::EventProjectionUnitOfWork;
 use crate::domains::invoice::{Invoice, InvoiceRepository};
+use crate::domains::ln_address::LnAddressRepository;
 use crate::domains::payment::{LnPayment, Payment, PaymentStatus, PaymentUnitOfWork};
 use crate::domains::{asset::AssetRepository, bitcoin::BtcNetwork, wallet::WalletRepository};
 
 use super::models::{prelude::Wallet, wallet};
 use super::{
     SeaOrmAccountRepository, SeaOrmApiKeyRepository, SeaOrmAssetRepository, SeaOrmEventProjectionUnitOfWork,
-    SeaOrmInvoiceRepository, SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
+    SeaOrmInvoiceRepository, SeaOrmLnAddressRepository, SeaOrmPaymentUnitOfWork, SeaOrmWalletRepository,
 };
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -384,8 +385,30 @@ async fn account_repository_crud_keeps_the_aggregate_consistent() {
         .unwrap();
     let wallet_repo = SeaOrmWalletRepository::new(conn.clone());
     let wallet = wallet_repo.upsert(account.id, asset.id).await.unwrap();
+    wallet_repo.credit(wallet.id, 42_000).await.unwrap();
     assert!(wallet_repo.exists_for_account(account.id, wallet.id).await.unwrap());
     assert!(!wallet_repo.exists_for_account(Uuid::new_v4(), wallet.id).await.unwrap());
+    let ln_address = SeaOrmLnAddressRepository::new(conn.clone())
+        .insert(account.id, wallet.id, "operator", false, None)
+        .await
+        .unwrap();
+    let aggregate = repo.find(account.id).await.unwrap().unwrap();
+    assert!(aggregate.identity.is_none());
+    assert_eq!(aggregate.wallets.len(), 1);
+    assert_eq!(aggregate.wallets[0].id, wallet.id);
+    assert_eq!(aggregate.wallets[0].balance.available_msat, 42_000);
+    assert_eq!(
+        aggregate.wallets[0].asset.as_ref().map(|asset| asset.id),
+        Some(asset.id)
+    );
+    assert_eq!(
+        aggregate.wallets[0].ln_address.as_ref().map(|address| address.id),
+        Some(ln_address.id)
+    );
+    assert!(aggregate.wallets[0].payments.is_empty());
+    assert!(aggregate.wallets[0].invoices.is_empty());
+    assert!(aggregate.wallets[0].btc_addresses.is_empty());
+    assert!(aggregate.wallets[0].contacts.is_empty());
     SeaOrmApiKeyRepository::new(conn.clone())
         .insert(ApiKey {
             account_id: account.id,

--- a/tests/suites/accounts.rs
+++ b/tests/suites/accounts.rs
@@ -104,6 +104,27 @@ mod lifecycle {
             .await;
         assert_status(&lightning_address, StatusCode::OK);
         let lightning_address = lightning_address.parse::<swissknife_types::LnAddress>();
+        let aggregate = app
+            .api()
+            .get(&format!("/v1/accounts/{}", created.id), Auth::Bearer(admin))
+            .await;
+        assert_status(&aggregate, StatusCode::OK);
+        let aggregate = aggregate.parse::<Account>();
+        assert!(aggregate.identity.is_none());
+        assert_eq!(aggregate.wallets.len(), 1);
+        assert_eq!(aggregate.wallets[0].id, wallet.id);
+        assert_eq!(
+            aggregate.wallets[0].asset.as_ref().map(|asset| asset.id),
+            Some(regtest_btc_asset_id())
+        );
+        assert_eq!(
+            aggregate.wallets[0].ln_address.as_ref().map(|address| address.id),
+            Some(lightning_address.id)
+        );
+        assert!(aggregate.wallets[0].payments.is_empty());
+        assert!(aggregate.wallets[0].invoices.is_empty());
+        assert!(aggregate.wallets[0].btc_addresses.is_empty());
+        assert!(aggregate.wallets[0].contacts.is_empty());
         let account_key = app
             .account_api_key(admin, created.id, Permission::all_permissions())
             .await;


### PR DESCRIPTION
## Summary

- resolve the ADR 0002 startup-network ambiguity in favor of a multi-network wallet catalog
- define the configured provider as a runtime settlement capability, not a database-wide network binding
- keep network validation at money-moving and address-producing operation boundaries
- leave room for multiple liquidity providers without adding wallet lifecycle state now

## Why

The implemented model and integration coverage intentionally allow one account to own mainnet, signet, and regtest wallets. Refusing startup whenever another-network wallet exists would make that valid catalog impossible to restart and would require an otherwise unused active/enabled state.

## Stack

- Base: `docs/identity-adr-implementation-notes` (#340)
- Next: #342 separates Account and Wallet administration views
- Cross-repo docs: bitcoin-numeraire/doc#11

## Validation

- `make fmt`
- `git diff --check`

Closes #337. Related: #297.