### PR TITLE
fix(lnd): support pinned Polar gRPC certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4711,6 +4711,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust_socketio",
+ "rustls",
  "sea-orm",
  "serde",
  "serde_bolt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tower-http = { version = "0.7.0", features = [
     "cors",
 ] }
 regex = "1"
+rustls = { version = "0.23.41", default-features = false, features = ["ring", "std", "tls12"] }
 sea-orm = { version = "1.1.20", features = [
     "sqlx-postgres",
     "sqlx-sqlite",

--- a/config/default.toml
+++ b/config/default.toml
@@ -51,6 +51,9 @@ reorg_buffer_blocks = 2
 [lnd_grpc_config]
 endpoint = "https://localhost:10009"
 cert_path = "certs/lnd/tls.cert"
+# Dev-only workaround for LND certificates that are incorrectly marked as CAs.
+# The server must present this exact certificate and prove possession of its private key.
+pin_server_certificate = false
 macaroon_path = "certs/lnd/admin.macaroon"
 payment_timeout = "60s"
 fee_limit_msat = 25000

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,6 +17,23 @@ cargo run
 
 > If not using a Lightning provider, running dependencies locally can be done easily with [Polar](https://lightningpolar.com/).
 
+Polar's LND certificate is marked as a certificate authority and is therefore
+rejected as a server certificate by rustls. When using LND over gRPC with
+Polar, point `lnd_grpc_config.cert_path` at the node's `tls.cert` and enable
+exact certificate pinning:
+
+```toml
+[lnd_grpc_config]
+endpoint = "https://127.0.0.1:10001"
+cert_path = "/path/to/polar/node/tls.cert"
+pin_server_certificate = true
+```
+
+Pinning is intended for local development only. It accepts only the configured
+certificate and still verifies that the server owns its private key. Leave it
+disabled when `cert_path` contains a proper CA certificate, including the
+integration-test LND network.
+
 Before submitting backend changes, run:
 
 ```bash

--- a/src/infra/lightning/lnd/lnd_grpc_client.rs
+++ b/src/infra/lightning/lnd/lnd_grpc_client.rs
@@ -1,9 +1,15 @@
-use std::{collections::HashMap, error::Error as StdError, path::PathBuf, str::FromStr, time::Duration};
+use std::{collections::HashMap, error::Error as StdError, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{TimeZone, Utc};
 use lightning_invoice::Bolt11Invoice;
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::{ring, verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms},
+    pki_types::{pem::PemObject, CertificateDer, ServerName, UnixTime},
+    CertificateError, DigitallySignedStruct, Error as TlsError, SignatureScheme,
+};
 use serde::Deserialize;
 use serde_bolt::bitcoin::hashes::{sha256, Hash};
 use tokio::{fs, time::timeout};
@@ -97,11 +103,69 @@ pub(crate) type LndChannel = InterceptedService<Channel, MacaroonInterceptor>;
 pub struct LndGrpcClientConfig {
     pub endpoint: String,
     pub cert_path: String,
+    #[serde(default)]
+    pub pin_server_certificate: bool,
     pub macaroon_path: String,
     pub fee_limit_msat: u64,
     #[serde(deserialize_with = "deserialize_duration")]
     pub payment_timeout: Duration,
     pub reorg_buffer_blocks: u32,
+}
+
+#[derive(Debug)]
+struct PinnedServerCertificateVerifier {
+    certificate: CertificateDer<'static>,
+    supported_algorithms: WebPkiSupportedAlgorithms,
+}
+
+impl PinnedServerCertificateVerifier {
+    fn new(certificate: CertificateDer<'static>) -> Self {
+        Self {
+            certificate,
+            supported_algorithms: ring::default_provider().signature_verification_algorithms,
+        }
+    }
+}
+
+impl ServerCertVerifier for PinnedServerCertificateVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        if end_entity.as_ref() != self.certificate.as_ref() {
+            return Err(TlsError::InvalidCertificate(
+                CertificateError::ApplicationVerificationFailure,
+            ));
+        }
+
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        certificate: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        verify_tls12_signature(message, certificate, signature, &self.supported_algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        certificate: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        verify_tls13_signature(message, certificate, signature, &self.supported_algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.supported_algorithms.supported_schemes()
+    }
 }
 
 pub struct LndGrpcClient {
@@ -148,16 +212,28 @@ impl LndGrpcClient {
         let tls_cert = fs::read(PathBuf::from(&config.cert_path))
             .await
             .map_err(|e| LightningError::ReadCertificates(e.to_string()))?;
-        let ca_certificate = Certificate::from_pem(tls_cert);
+        let endpoint =
+            Channel::from_shared(config.endpoint.clone()).map_err(|e| LightningError::ParseConfig(e.to_string()))?;
+        let endpoint = if config.pin_server_certificate {
+            let pinned_certificate = CertificateDer::from_pem_slice(&tls_cert)
+                .map_err(|e| LightningError::ReadCertificates(e.to_string()))?;
+            endpoint
+                .tls_config_with_verifier(
+                    ClientTlsConfig::new().domain_name(tls_domain),
+                    Arc::new(PinnedServerCertificateVerifier::new(pinned_certificate)),
+                )
+                .map_err(|e| LightningError::ParseConfig(e.to_string()))?
+        } else {
+            endpoint
+                .tls_config(
+                    ClientTlsConfig::new()
+                        .ca_certificate(Certificate::from_pem(tls_cert))
+                        .domain_name(tls_domain),
+                )
+                .map_err(|e| LightningError::ParseConfig(e.to_string()))?
+        };
 
-        let tls_config = ClientTlsConfig::new()
-            .ca_certificate(ca_certificate)
-            .domain_name(tls_domain);
-
-        let channel = Channel::from_shared(config.endpoint.clone())
-            .map_err(|e| LightningError::ParseConfig(e.to_string()))?
-            .tls_config(tls_config)
-            .map_err(|e| LightningError::ParseConfig(e.to_string()))?
+        let channel = endpoint
             .connect()
             .await
             .map_err(|e| LightningError::Connect(Self::format_transport_error(&e)))?;
@@ -696,5 +772,30 @@ impl BitcoinWallet for LndGrpcClient {
 
     fn network(&self) -> BtcNetwork {
         self.network
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pinned_server_certificate_accepts_only_exact_certificate() {
+        let pinned_certificate = CertificateDer::from(vec![1, 2, 3]);
+        let verifier = PinnedServerCertificateVerifier::new(pinned_certificate.clone());
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let now = UnixTime::since_unix_epoch(Duration::ZERO);
+
+        assert!(verifier
+            .verify_server_cert(&pinned_certificate, &[], &server_name, &[], now)
+            .is_ok());
+
+        let other_certificate = CertificateDer::from(vec![4, 5, 6]);
+        assert!(matches!(
+            verifier.verify_server_cert(&other_certificate, &[], &server_name, &[], now),
+            Err(TlsError::InvalidCertificate(
+                CertificateError::ApplicationVerificationFailure
+            ))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add opt-in exact server-certificate pinning for LND gRPC
- preserve strict CA and hostname validation as the default
- document the Polar configuration and its local-development scope

The pinned mode works around Polar/LND certificates marked `CA:TRUE` without accepting arbitrary certificates. The TLS handshake signature is still verified, proving possession of the pinned certificate private key.

## Verification
- `cargo check --locked`
- `cargo test --locked pinned_server_certificate_accepts_only_exact_certificate`
- `make lint`
- live startup against Polar LND gRPC on `127.0.0.1:10001`: `GetInfo`, event replay, on-chain sync, and server startup succeeded